### PR TITLE
Vite fixes

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -1,14 +1,15 @@
 name: Docker Build and Push to GCR
-on: 
+on:
   push:
-    branches: [ main ]
+    branches:
+      - main
 
-# This job uses RafikFarhad's GitHub action to build and 
+# This job uses RafikFarhad's GitHub action to build and
 # push a docker image to a specified GCP repository
 jobs:
   build-and-push-to-gcr:
     runs-on: ubuntu-latest
-    steps:      
+    steps:
       - name: Checkout
         uses: actions/checkout@v3
 
@@ -28,9 +29,8 @@ jobs:
           image_name: monarch-api/monarch-api
           image_tag: latest, ${{ steps.get-tag.outputs.IMAGE_TAG }}
           dockerfile: ./backend/Dockerfile
-
-# This version uses Google's authentication Action directly, 
-# and makes use of this repository's Makefile. 
+# This version uses Google's authentication Action directly,
+# and makes use of this repository's Makefile.
 # It currently fails at the push step.
 #
 # jobs:

--- a/.github/workflows/deploy-documentation.yaml
+++ b/.github/workflows/deploy-documentation.yaml
@@ -1,7 +1,8 @@
 name: Build and Deploy Docs to GitHub Pages
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -10,23 +11,23 @@ jobs:
   build-docs:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@main
-      with:
-        fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
+      - name: Checkout
+        uses: actions/checkout@main
+        with:
+          fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
 
-    - name: Set up Python 3
-      uses: actions/setup-python@main
-      with:
-        python-version: '3.11'
+      - name: Set up Python 3
+        uses: actions/setup-python@main
+        with:
+          python-version: "3.11"
 
-    - name: Install Poetry
-      uses: snok/install-poetry@main
+      - name: Install Poetry
+        uses: snok/install-poetry@main
 
-    - name: Install Dependencies
-      run: poetry -C backend install
+      - name: Install Dependencies
+        run: poetry -C backend install
 
-    - name: Build and Deploy Documentation.
-      run: |
-        make docs
-        poetry -C backend run mkdocs gh-deploy --site-dir /docs --force
+      - name: Build and Deploy Documentation.
+        run: |
+          make docs
+          poetry -C backend run mkdocs gh-deploy --site-dir docs --force

--- a/.github/workflows/deploy-frontend.yaml
+++ b/.github/workflows/deploy-frontend.yaml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+defaults:
+  run:
+    working-directory: ./frontend
+
 permissions:
   contents: write
 

--- a/.github/workflows/test-backend.yaml
+++ b/.github/workflows/test-backend.yaml
@@ -1,11 +1,7 @@
 name: Test Backend
 
 on:
-  # Triggers the workflow on push or pull request events but only for the main branch
-  push:
-    branches: [ main ]
   pull_request:
-    types: [opened, synchronize, reopened]
   workflow_dispatch:
 
 defaults:
@@ -18,38 +14,36 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11"]
-        os: [ ubuntu-latest ]
+        os: [ubuntu-latest]
         #os: [ ubuntu-latest, windows-latest ]
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    #----------------------------------------------
-    #          install & configure poetry
-    #----------------------------------------------
-    - name: Install Poetry
-      uses: snok/install-poetry@v1
-    
+      #----------------------------------------------
+      #          install & configure poetry
+      #----------------------------------------------
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
 
-    #----------------------------------------------
-    #    install your root project, if required 
-    #----------------------------------------------      
-    - name: Install library
-      run: poetry install --no-interaction
+      #----------------------------------------------
+      #    install your root project, if required
+      #----------------------------------------------
+      - name: Install library
+        run: poetry install --no-interaction
 
-    #----------------------------------------------
-    #              run tox
-    #----------------------------------------------
-    #- name: Lint with flake8
-    #  run: poetry run tox -e flake8
-
-    #----------------------------------------------
-    #              run pytest
-    #----------------------------------------------
-    - name: Test with unittest
-      run: poetry run pytest tests/
-      # run: poetry run python -u -m unittest discover
+      #----------------------------------------------
+      #              run tox
+      #----------------------------------------------
+      #- name: Lint with flake8
+      #  run: poetry run tox -e flake8
+      #----------------------------------------------
+      #              run pytest
+      #----------------------------------------------
+      - name: Test with unittest
+        run: poetry run pytest tests/
+        # run: poetry run python -u -m unittest discover

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 
 This repo contains the source code for the website (frontend) and API (backend) for the Monarch Initiative.
 
-[The Website](https://monarch-initiative.github.io/monarch-app/)
-[Documentation](https://monarch-initiative.github.io/monarch-app/docs)
+[The Website](https://monarch-app.monarchinitiative.org)
+[Documentation](https://monarch-app.monarchinitiative.org/docs)
 
 ### For developers
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -2,7 +2,7 @@
 
 This is a FastAPI for browsing the knowledge graph produced by the Monarch Initiative.
 
-[Documentation](https://monarch-initiative.github.io/monarch-app)
+[Documentation](https://monarch-initiative.github.io/monarch-app/docs)
 
 ### Running the API:
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -2,7 +2,7 @@
 
 This is a FastAPI for browsing the knowledge graph produced by the Monarch Initiative.
 
-[Documentation](https://monarch-initiative.github.io/monarch-app/docs)
+[Documentation](https://monarch-app.monarchinitiative.org/docs)
 
 ### Running the API:
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -9,10 +9,10 @@ This project was scaffolded using Vite (`yarn create vite` → `Vue` → `create
 - ESLint (code quality)
 - Prettier (code formatting)
 
-## Approaches
+Techniques/approaches used:
 
 - Vue 3
-- Composition API (not Options API)
+- Composition API
 - `<script setup>` syntax
 - `<style lang="scss" scoped>` styles
 

--- a/frontend/env.d.ts
+++ b/frontend/env.d.ts
@@ -1,7 +1,1 @@
 /// <reference types="vite/client" />
-
-declare module "phenogrid" {
-  import type { PhenogridDefinition } from "./api/phenogrid";
-  const phenogrid: PhenogridDefinition;
-  export default phenogrid;
-}

--- a/frontend/fixtures/index.ts
+++ b/frontend/fixtures/index.ts
@@ -185,6 +185,7 @@ export const handlers = [
     /** for certain exceptions, passthrough (let browser make a real request) */
     const exceptions = [
       ".vue",
+      ".js" /** vite seems to turn dynamic import of images into .js */,
       ".mp4",
       ".svg",
       ".png",
@@ -208,6 +209,6 @@ export const handlers = [
      * otherwise, throw error to make sure we never hit any api when mocking is
      * enabled
      */
-    return res(ctx.status(500, "Non-mocked request"));
+    return res(ctx.status(500, "Non-mocked request " + req.url.pathname));
   }),
 ];

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -52,11 +52,6 @@
       href="https://fonts.googleapis.com/css2?family=Courier+Prime&display=swap"
       rel="stylesheet"
     />
-
-    <script>
-      /** phenogrid fix */
-      window.global = window;
-    </script>
   </head>
 
   <body>

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -49,7 +49,9 @@ const config: PlaywrightTestConfig = {
 
   /* run local dev server before starting tests */
   webServer: {
-    command: "vite dev --mode test",
+    command: process.env.CI
+      ? "vite build && vite preview --port 5173 --mode test"
+      : "vite dev --mode test",
     port: 5173,
     reuseExistingServer: !process.env.CI,
   },

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -49,12 +49,9 @@ const config: PlaywrightTestConfig = {
 
   /* run local dev server before starting tests */
   webServer: {
-    /** on CI, build app to more closely match production */
-    command: process.env.CI
-      ? "vite build && vite preview --port 5173 --mode test"
-      : "vite dev --mode test",
+    /** build instead of dev to more closely match production */
+    command: "vite build --mode test && vite preview --port 5173",
     port: 5173,
-    reuseExistingServer: !process.env.CI,
   },
 };
 

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -49,8 +49,15 @@ const config: PlaywrightTestConfig = {
 
   /* run local dev server before starting tests */
   webServer: {
-    /** build instead of dev to more closely match production */
-    command: "vite build --mode test && vite preview --port 5173",
+    /**
+     * vite uses esbuild for dev but parcel for build. results should be the
+     * same except for very rare cases (like the very old phenogrid). cover both
+     * situations w/ local and CI. of the two, build should be more reflective
+     * of actual production app.
+     */
+    command: process.env.CI
+      ? "vite build --mode test && vite preview --port 5173"
+      : "vite dev --mode test",
     port: 5173,
   },
 };

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -49,6 +49,7 @@ const config: PlaywrightTestConfig = {
 
   /* run local dev server before starting tests */
   webServer: {
+    /** on CI, build app to more closely match production */
     command: process.env.CI
       ? "vite build && vite preview --port 5173 --mode test"
       : "vite dev --mode test",

--- a/frontend/public/mockServiceWorker.js
+++ b/frontend/public/mockServiceWorker.js
@@ -2,7 +2,7 @@
 /* tslint:disable */
 
 /**
- * mock Service Worker (1.2.1).
+ * Mock Service Worker (1.2.1).
  * @see https://github.com/mswjs/msw
  * - Please do NOT modify this file.
  * - Please do NOT serve this file on production.

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -37,7 +37,6 @@ watch(
 
     /** update document title from route */
     appTitle.value = [route.name || ""];
-    console.log(route.name);
 
     /** update description */
     appDescription.value = route.meta.description as string;

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -28,7 +28,7 @@ const route = useRoute();
 
 /** when route changes, update document meta data. see https://metatags.io/ */
 watch(
-  () => route.fullPath,
+  () => route,
   async () => {
     /**
      * meta vars set in components should override this, since this component is
@@ -36,7 +36,8 @@ watch(
      */
 
     /** update document title from route */
-    appTitle.value = [String(route.name)];
+    appTitle.value = [route.name || ""];
+    console.log(route.name);
 
     /** update description */
     appDescription.value = route.meta.description as string;
@@ -44,6 +45,6 @@ watch(
     /** update canonical url */
     appUrl.value = window.location.href;
   },
-  { immediate: true }
+  { immediate: true, deep: true }
 );
 </script>

--- a/frontend/src/api/phenogrid.ts
+++ b/frontend/src/api/phenogrid.ts
@@ -1,6 +1,5 @@
-import Phenogrid from "phenogrid";
+import "phenogrid/dist/phenogrid-bundle.js";
 import { waitFor } from "@/util/dom";
-/** import "phenogrid/dist/phenogrid-bundle.css"; */
 import "./phenogrid.css";
 import { biolink } from "./";
 
@@ -40,10 +39,30 @@ export const mountPhenogrid = async (
   await waitFor("#phenogrid_svg", patchSvg);
 };
 
-/** sHIMS FOR PHENOGRID */
+/** fix incorrect svg sizing */
+const patchSvg = (svg: Element, padding = 20) => {
+  const { x, y, width, height } = (svg as SVGSVGElement).getBBox();
+  /** set view box to bbox, essentially fitting view to content */
+  const viewBox = [
+    x - padding,
+    y - padding,
+    width + padding * 2,
+    height + padding * 2,
+  ]
+    .map((v) => Math.round(v))
+    .join(" ");
 
-/** typescript definition */
-export type PhenogridDefinition = {
+  svg.setAttribute("viewBox", viewBox);
+  svg.removeAttribute("width");
+  svg.removeAttribute("height");
+};
+
+declare global {
+  const Phenogrid: PhenogridType;
+}
+
+/** typescript definition for phenogrid */
+type PhenogridType = {
   createPhenogridForElement: (
     element: HTMLElement | null,
     options: {
@@ -61,22 +80,4 @@ export type PhenogridDefinition = {
       owlSimFunction: string;
     }
   ) => void;
-};
-
-/** fix incorrect svg sizing */
-const patchSvg = (svg: Element, padding = 20) => {
-  const { x, y, width, height } = (svg as SVGSVGElement).getBBox();
-  /** set view box to bbox, essentially fitting view to content */
-  const viewBox = [
-    x - padding,
-    y - padding,
-    width + padding * 2,
-    height + padding * 2,
-  ]
-    .map((v) => Math.round(v))
-    .join(" ");
-
-  svg.setAttribute("viewBox", viewBox);
-  svg.removeAttribute("width");
-  svg.removeAttribute("height");
 };

--- a/frontend/src/components/AppGroup.vue
+++ b/frontend/src/components/AppGroup.vue
@@ -35,7 +35,7 @@ watch(
     try {
       src.value = (await import(`../assets/team/groups/${image}.png`)).default;
     } catch (error) {
-      //
+      console.error("failed to load team group image", error);
     }
   },
   { immediate: true }

--- a/frontend/src/components/AppIcon.vue
+++ b/frontend/src/components/AppIcon.vue
@@ -3,37 +3,39 @@
 -->
 
 <template>
-  <InlineSvg
-    v-if="custom"
-    :src="custom"
-    class="icon"
-    aria-hidden="true"
-    :data-icon="icon"
-  />
   <FontAwesomeIcon
-    v-else-if="fa"
-    :icon="fa"
+    v-if="_icon?.type === 'fa'"
+    :icon="_icon?.definition"
+    :data-icon="icon"
+    aria-hidden="true"
+  />
+  <InlineSvg
+    v-else-if="_icon?.type === 'custom'"
+    :src="_icon?.src"
+    class="icon"
     :data-icon="icon"
     aria-hidden="true"
   />
   <svg
-    v-else-if="initials"
+    v-else-if="_icon?.type === 'initials'"
     viewBox="-10 -10 120 120"
     class="initials"
-    :data-debug1="fa"
-    :data-debug2="custom"
   >
     <circle cx="50" cy="50" r="55" />
     <text x="50" y="54">
-      {{ initials }}
+      {{ _icon?.letters }}
     </text>
   </svg>
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch } from "vue";
+import { ref, watch } from "vue";
 import InlineSvg from "vue-inline-svg";
-import type { IconName, IconPrefix } from "@fortawesome/fontawesome-svg-core";
+import type {
+  IconDefinition,
+  IconName,
+  IconPrefix,
+} from "@fortawesome/fontawesome-svg-core";
 import { findIconDefinition } from "@fortawesome/fontawesome-svg-core";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 
@@ -47,42 +49,50 @@ type Props = {
 
 const props = defineProps<Props>();
 
-/** find custom icon with matching name, if there is one */
-const custom = ref("");
+type _Icon =
+  | { type: "fa"; definition: IconDefinition }
+  | { type: "custom"; src: string }
+  | { type: "initials"; letters: string };
+
+/** computed icon */
+const _icon = ref<_Icon>();
+
 watch(
   () => props.icon,
   async () => {
-    try {
-      custom.value = (
-        await import(`../assets/icons/${props.icon}.svg`)
-      ).default;
-    } catch (error) {
-      /** don't log error, many failures expected */
+    /** first look for font awesome icon with matching name */
+    for (const prefix of ["fas", "far", "fab"]) {
+      const match = findIconDefinition({
+        prefix: prefix as IconPrefix,
+        iconName: props.icon as IconName,
+      });
+      if (match) {
+        _icon.value = { type: "fa", definition: match };
+        return;
+      }
     }
+
+    /** otherwise, look for custom icon with matching name */
+    try {
+      const src = (await import(`../assets/icons/${props.icon}.svg`)).default;
+      _icon.value = { type: "custom", src };
+      return;
+    } catch (error) {
+      console.error("couldn't load custom icon", error);
+    }
+
+    /** last resort, use initials */
+    _icon.value = {
+      type: "initials",
+      letters:
+        props.icon
+          ?.replace(/^category-/, "")
+          .split("-")
+          .map((word) => (word[0] || "").toUpperCase())
+          .join("") || "",
+    };
   },
   { immediate: true }
-);
-
-/** find font awesome icon with matching name, if there is one */
-const fa = computed(() => {
-  for (const prefix of ["fas", "far", "fab"]) {
-    const match = findIconDefinition({
-      prefix: prefix as IconPrefix,
-      iconName: props.icon as IconName,
-    });
-    if (match) return match;
-  }
-
-  return undefined;
-});
-
-/** initials as fallback */
-const initials = computed(() =>
-  props.icon
-    ?.replace(/^category-/, "")
-    .split("-")
-    .map((word) => (word[0] || "").toUpperCase())
-    .join("")
 );
 </script>
 

--- a/frontend/src/components/AppIcon.vue
+++ b/frontend/src/components/AppIcon.vue
@@ -57,7 +57,7 @@ watch(
         await import(`../assets/icons/${props.icon}.svg`)
       ).default;
     } catch (error) {
-      //
+      /** don't log error, many failures expected */
     }
   },
   { immediate: true }

--- a/frontend/src/views/about/PageSources.vue
+++ b/frontend/src/views/about/PageSources.vue
@@ -189,7 +189,7 @@ const {
         await import(`../../assets/sources/${source.image}.png`)
       ).default;
     } catch (error) {
-      //
+      console.error("couldn't load source image", error);
     }
   }
 

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -1,20 +1,21 @@
-site_name: 'Monarch API Documentation'
-repo_name: 'monarch-api'
-repo_url: 'https://github.com/monarch-initiative/monarch-app/'
-site_url: 'https://monarch-app.monarchinitiative.org/docs/'
+site_name: "Monarch API Documentation"
+repo_name: "monarch-api"
+repo_url: "https://github.com/monarch-initiative/monarch-app/"
+site_url: "https://monarch-app.monarchinitiative.org/docs/"
+site_dir: "docs"
 
 theme:
-    name: 'material'
-    docs_dir: docs/
-    logo: 'images/monarch-initiative.png'
-    favicon: 'images/favicon.ico'
-    features:
-        - navigation.expand
-        - navigation.instant
-        - navigation.tracking
-        - navigation.tabs
-        - navigation.tabs.sticky
-    palette:
+  name: "material"
+  docs_dir: docs/
+  logo: "images/monarch-initiative.png"
+  favicon: "images/favicon.ico"
+  features:
+    - navigation.expand
+    - navigation.instant
+    - navigation.tracking
+    - navigation.tabs
+    - navigation.tabs.sticky
+  palette:
     - scheme: default
       primary: indigo
       accent: indigo
@@ -27,21 +28,20 @@ theme:
       toggle:
         icon: material/brightness-7
         name: Switch to light mode
-    font:
-        text: 'Source Sans Pro'
-        code: 'Source Sans Pro Mono'
-
+  font:
+    text: "Source Sans Pro"
+    code: "Source Sans Pro Mono"
 
 plugins:
   - search
   - mkdocstrings:
       handlers:
         python:
-          paths: [ ./backend ]
+          paths: [./backend]
           import:
-          - https://docs.python.org/3/objects.inv
-          - https://mkdocstrings.github.io/objects.inv
-          - https://mkdocstrings.github.io/griffe/objects.inv
+            - https://docs.python.org/3/objects.inv
+            - https://mkdocstrings.github.io/objects.inv
+            - https://mkdocstrings.github.io/griffe/objects.inv
           options:
             docstring_style: google
             docstring_options:
@@ -55,7 +55,6 @@ plugins:
             filters:
               - "!^_[^_]"
               - "^_[^_]"
-
 
 markdown_extensions:
   - admonition
@@ -73,14 +72,11 @@ markdown_extensions:
   - pymdownx.tabbed:
       alternate_style: true
 
-
 extra:
   social:
-    - icon: 'fontawesome/solid/house'
-      link: 'https://monarchinitiative.org'
-    - icon: 'fontawesome/brands/github-alt'
-      link: 'https://github.com/monarch-initiative/'
-
-
+    - icon: "fontawesome/solid/house"
+      link: "https://monarchinitiative.org"
+    - icon: "fontawesome/brands/github-alt"
+      link: "https://github.com/monarch-initiative/"
 # copyright: 'Copyright &copy; 2020 - 2022 [Glass](glass-ships.com)'
 


### PR DESCRIPTION
- format workflow yaml files with prettier
- fix deploy-frontend workflow (needed /frontend working dir)
- fix phenogrid imports and types. this is likely what was preventing playwright (initially) and netlify deploy preview from working in the last pr.
- revert playwright server command to build prod app on CI. this would've caught phenogrid issue, which only happened when building and previewing prod app.
- fix minor tab title bug
- rework icon component to be a little cleaner
- format mkdocs config yaml with prettier