### PR TITLE
Mock solr

### DIFF
--- a/backend/src/monarch_py/api/config.py
+++ b/backend/src/monarch_py/api/config.py
@@ -7,11 +7,7 @@ class Settings(BaseSettings):
     solr_host = os.getenv("SOLR_HOST") if os.getenv("SOLR_HOST") else "127.0.0.1"
     solr_port = os.getenv("SOLR_PORT") if os.getenv("SOLR_PORT") else 8983
 
-    solr_url = (
-        os.getenv("SOLR_URL")
-        if os.getenv("SOLR_URL")
-        else f"http://{solr_host}:{solr_port}/solr"
-    )
+    solr_url = os.getenv("SOLR_URL") if os.getenv("SOLR_URL") else f"http://{solr_host}:{solr_port}/solr"
 
 
 settings = Settings()

--- a/backend/src/monarch_py/api/entity.py
+++ b/backend/src/monarch_py/api/entity.py
@@ -48,9 +48,7 @@ def _association_table(
         example="biolink:DiseaseToPhenotypicFeatureAssociation",
         title="Type of association to retrieve association table data for",
     ),
-    query: str = Query(
-        None, example="thumb", title="Query string to limit results to a subset"
-    ),
+    query: str = Query(None, example="thumb", title="Query string to limit results to a subset"),
 ) -> AssociationTableResults:
     """
     Retrieves association table data for a given entity and association type

--- a/backend/src/monarch_py/api/main.py
+++ b/backend/src/monarch_py/api/main.py
@@ -34,5 +34,6 @@ async def _api():
 def run():
     uvicorn.run("monarch_py:api.main.app", host="127.0.0.1", port=8000, reload=True)
 
+
 if __name__ == "__main__":
     run()

--- a/backend/src/monarch_py/api/model.py
+++ b/backend/src/monarch_py/api/model.py
@@ -50,19 +50,13 @@ class Association(ConfiguredBaseModel):
     id: str = Field(...)
     subject: str = Field(...)
     original_subject: Optional[str] = Field(None)
-    subject_namespace: Optional[str] = Field(
-        None, description="""The namespace/prefix of the subject entity"""
-    )
-    subject_category: Optional[str] = Field(
-        None, description="""The category of the subject entity"""
-    )
+    subject_namespace: Optional[str] = Field(None, description="""The namespace/prefix of the subject entity""")
+    subject_category: Optional[str] = Field(None, description="""The category of the subject entity""")
     subject_closure: Optional[List[str]] = Field(
         default_factory=list,
         description="""Field containing subject id and the ids of all of it's ancestors""",
     )
-    subject_label: Optional[str] = Field(
-        None, description="""The name of the subject entity"""
-    )
+    subject_label: Optional[str] = Field(None, description="""The name of the subject entity""")
     subject_closure_label: Optional[List[str]] = Field(
         default_factory=list,
         description="""Field containing subject name and the names of all of it's ancestors""",
@@ -70,19 +64,13 @@ class Association(ConfiguredBaseModel):
     predicate: str = Field(...)
     object: str = Field(...)
     original_object: Optional[str] = Field(None)
-    object_namespace: Optional[str] = Field(
-        None, description="""The namespace/prefix of the object entity"""
-    )
-    object_category: Optional[str] = Field(
-        None, description="""The category of the object entity"""
-    )
+    object_namespace: Optional[str] = Field(None, description="""The namespace/prefix of the object entity""")
+    object_category: Optional[str] = Field(None, description="""The category of the object entity""")
     object_closure: Optional[List[str]] = Field(
         default_factory=list,
         description="""Field containing object id and the ids of all of it's ancestors""",
     )
-    object_label: Optional[str] = Field(
-        None, description="""The name of the object entity"""
-    )
+    object_label: Optional[str] = Field(None, description="""The name of the object entity""")
     object_closure_label: Optional[List[str]] = Field(
         default_factory=list,
         description="""Field containing object name and the names of all of it's ancestors""",
@@ -100,9 +88,7 @@ class Association(ConfiguredBaseModel):
     stage_qualifier: Optional[str] = Field(None)
     pathway: Optional[str] = Field(None)
     relation: Optional[str] = Field(None)
-    frequency_qualifier_label: Optional[str] = Field(
-        None, description="""The name of the frequency_qualifier entity"""
-    )
+    frequency_qualifier_label: Optional[str] = Field(None, description="""The name of the frequency_qualifier entity""")
     frequency_qualifier_namespace: Optional[str] = Field(
         None, description="""The namespace/prefix of the frequency_qualifier entity"""
     )
@@ -117,15 +103,11 @@ class Association(ConfiguredBaseModel):
         default_factory=list,
         description="""Field containing frequency_qualifier name and the names of all of it's ancestors""",
     )
-    onset_qualifier_label: Optional[str] = Field(
-        None, description="""The name of the onset_qualifier entity"""
-    )
+    onset_qualifier_label: Optional[str] = Field(None, description="""The name of the onset_qualifier entity""")
     onset_qualifier_namespace: Optional[str] = Field(
         None, description="""The namespace/prefix of the onset_qualifier entity"""
     )
-    onset_qualifier_category: Optional[str] = Field(
-        None, description="""The category of the onset_qualifier entity"""
-    )
+    onset_qualifier_category: Optional[str] = Field(None, description="""The category of the onset_qualifier entity""")
     onset_qualifier_closure: Optional[List[str]] = Field(
         default_factory=list,
         description="""Field containing onset_qualifier id and the ids of all of it's ancestors""",
@@ -134,15 +116,11 @@ class Association(ConfiguredBaseModel):
         default_factory=list,
         description="""Field containing onset_qualifier name and the names of all of it's ancestors""",
     )
-    sex_qualifier_label: Optional[str] = Field(
-        None, description="""The name of the sex_qualifier entity"""
-    )
+    sex_qualifier_label: Optional[str] = Field(None, description="""The name of the sex_qualifier entity""")
     sex_qualifier_namespace: Optional[str] = Field(
         None, description="""The namespace/prefix of the sex_qualifier entity"""
     )
-    sex_qualifier_category: Optional[str] = Field(
-        None, description="""The category of the sex_qualifier entity"""
-    )
+    sex_qualifier_category: Optional[str] = Field(None, description="""The category of the sex_qualifier entity""")
     sex_qualifier_closure: Optional[List[str]] = Field(
         default_factory=list,
         description="""Field containing sex_qualifier id and the ids of all of it's ancestors""",
@@ -151,15 +129,11 @@ class Association(ConfiguredBaseModel):
         default_factory=list,
         description="""Field containing sex_qualifier name and the names of all of it's ancestors""",
     )
-    stage_qualifier_label: Optional[str] = Field(
-        None, description="""The name of the stage_qualifier entity"""
-    )
+    stage_qualifier_label: Optional[str] = Field(None, description="""The name of the stage_qualifier entity""")
     stage_qualifier_namespace: Optional[str] = Field(
         None, description="""The namespace/prefix of the stage_qualifier entity"""
     )
-    stage_qualifier_category: Optional[str] = Field(
-        None, description="""The category of the stage_qualifier entity"""
-    )
+    stage_qualifier_category: Optional[str] = Field(None, description="""The category of the stage_qualifier entity""")
     stage_qualifier_closure: Optional[List[str]] = Field(
         default_factory=list,
         description="""Field containing stage_qualifier id and the ids of all of it's ancestors""",
@@ -217,19 +191,13 @@ class DirectionalAssociation(Association):
     id: str = Field(...)
     subject: str = Field(...)
     original_subject: Optional[str] = Field(None)
-    subject_namespace: Optional[str] = Field(
-        None, description="""The namespace/prefix of the subject entity"""
-    )
-    subject_category: Optional[str] = Field(
-        None, description="""The category of the subject entity"""
-    )
+    subject_namespace: Optional[str] = Field(None, description="""The namespace/prefix of the subject entity""")
+    subject_category: Optional[str] = Field(None, description="""The category of the subject entity""")
     subject_closure: Optional[List[str]] = Field(
         default_factory=list,
         description="""Field containing subject id and the ids of all of it's ancestors""",
     )
-    subject_label: Optional[str] = Field(
-        None, description="""The name of the subject entity"""
-    )
+    subject_label: Optional[str] = Field(None, description="""The name of the subject entity""")
     subject_closure_label: Optional[List[str]] = Field(
         default_factory=list,
         description="""Field containing subject name and the names of all of it's ancestors""",
@@ -237,19 +205,13 @@ class DirectionalAssociation(Association):
     predicate: str = Field(...)
     object: str = Field(...)
     original_object: Optional[str] = Field(None)
-    object_namespace: Optional[str] = Field(
-        None, description="""The namespace/prefix of the object entity"""
-    )
-    object_category: Optional[str] = Field(
-        None, description="""The category of the object entity"""
-    )
+    object_namespace: Optional[str] = Field(None, description="""The namespace/prefix of the object entity""")
+    object_category: Optional[str] = Field(None, description="""The category of the object entity""")
     object_closure: Optional[List[str]] = Field(
         default_factory=list,
         description="""Field containing object id and the ids of all of it's ancestors""",
     )
-    object_label: Optional[str] = Field(
-        None, description="""The name of the object entity"""
-    )
+    object_label: Optional[str] = Field(None, description="""The name of the object entity""")
     object_closure_label: Optional[List[str]] = Field(
         default_factory=list,
         description="""Field containing object name and the names of all of it's ancestors""",
@@ -267,9 +229,7 @@ class DirectionalAssociation(Association):
     stage_qualifier: Optional[str] = Field(None)
     pathway: Optional[str] = Field(None)
     relation: Optional[str] = Field(None)
-    frequency_qualifier_label: Optional[str] = Field(
-        None, description="""The name of the frequency_qualifier entity"""
-    )
+    frequency_qualifier_label: Optional[str] = Field(None, description="""The name of the frequency_qualifier entity""")
     frequency_qualifier_namespace: Optional[str] = Field(
         None, description="""The namespace/prefix of the frequency_qualifier entity"""
     )
@@ -284,15 +244,11 @@ class DirectionalAssociation(Association):
         default_factory=list,
         description="""Field containing frequency_qualifier name and the names of all of it's ancestors""",
     )
-    onset_qualifier_label: Optional[str] = Field(
-        None, description="""The name of the onset_qualifier entity"""
-    )
+    onset_qualifier_label: Optional[str] = Field(None, description="""The name of the onset_qualifier entity""")
     onset_qualifier_namespace: Optional[str] = Field(
         None, description="""The namespace/prefix of the onset_qualifier entity"""
     )
-    onset_qualifier_category: Optional[str] = Field(
-        None, description="""The category of the onset_qualifier entity"""
-    )
+    onset_qualifier_category: Optional[str] = Field(None, description="""The category of the onset_qualifier entity""")
     onset_qualifier_closure: Optional[List[str]] = Field(
         default_factory=list,
         description="""Field containing onset_qualifier id and the ids of all of it's ancestors""",
@@ -301,15 +257,11 @@ class DirectionalAssociation(Association):
         default_factory=list,
         description="""Field containing onset_qualifier name and the names of all of it's ancestors""",
     )
-    sex_qualifier_label: Optional[str] = Field(
-        None, description="""The name of the sex_qualifier entity"""
-    )
+    sex_qualifier_label: Optional[str] = Field(None, description="""The name of the sex_qualifier entity""")
     sex_qualifier_namespace: Optional[str] = Field(
         None, description="""The namespace/prefix of the sex_qualifier entity"""
     )
-    sex_qualifier_category: Optional[str] = Field(
-        None, description="""The category of the sex_qualifier entity"""
-    )
+    sex_qualifier_category: Optional[str] = Field(None, description="""The category of the sex_qualifier entity""")
     sex_qualifier_closure: Optional[List[str]] = Field(
         default_factory=list,
         description="""Field containing sex_qualifier id and the ids of all of it's ancestors""",
@@ -318,15 +270,11 @@ class DirectionalAssociation(Association):
         default_factory=list,
         description="""Field containing sex_qualifier name and the names of all of it's ancestors""",
     )
-    stage_qualifier_label: Optional[str] = Field(
-        None, description="""The name of the stage_qualifier entity"""
-    )
+    stage_qualifier_label: Optional[str] = Field(None, description="""The name of the stage_qualifier entity""")
     stage_qualifier_namespace: Optional[str] = Field(
         None, description="""The namespace/prefix of the stage_qualifier entity"""
     )
-    stage_qualifier_category: Optional[str] = Field(
-        None, description="""The category of the stage_qualifier entity"""
-    )
+    stage_qualifier_category: Optional[str] = Field(None, description="""The category of the stage_qualifier entity""")
     stage_qualifier_closure: Optional[List[str]] = Field(
         default_factory=list,
         description="""Field containing stage_qualifier id and the ids of all of it's ancestors""",
@@ -348,9 +296,7 @@ class Entity(ConfiguredBaseModel):
     description: Optional[str] = Field(None)
     xref: Optional[List[str]] = Field(default_factory=list)
     provided_by: Optional[str] = Field(None)
-    in_taxon: Optional[str] = Field(
-        None, description="""The biolink taxon that the entity is in the closure of."""
-    )
+    in_taxon: Optional[str] = Field(None, description="""The biolink taxon that the entity is in the closure of.""")
     in_taxon_label: Optional[str] = Field(
         None,
         description="""The label of the biolink taxon that the entity is in the closure of.""",
@@ -402,9 +348,7 @@ class Node(Entity):
     UI conatiner class extending Entity with additional information
     """
 
-    in_taxon: Optional[str] = Field(
-        None, description="""The biolink taxon that the entity is in the closure of."""
-    )
+    in_taxon: Optional[str] = Field(None, description="""The biolink taxon that the entity is in the closure of.""")
     in_taxon_label: Optional[str] = Field(
         None,
         description="""The label of the biolink taxon that the entity is in the closure of.""",
@@ -471,9 +415,7 @@ class EntityResults(Results):
 
 class SearchResult(Entity):
 
-    highlight: Optional[str] = Field(
-        None, description="""matching text snippet containing html tags"""
-    )
+    highlight: Optional[str] = Field(None, description="""matching text snippet containing html tags""")
     score: Optional[float] = Field(None)
     id: str = Field(...)
     category: str = Field(...)
@@ -481,9 +423,7 @@ class SearchResult(Entity):
     description: Optional[str] = Field(None)
     xref: Optional[List[str]] = Field(default_factory=list)
     provided_by: Optional[str] = Field(None)
-    in_taxon: Optional[str] = Field(
-        None, description="""The biolink taxon that the entity is in the closure of."""
-    )
+    in_taxon: Optional[str] = Field(None, description="""The biolink taxon that the entity is in the closure of.""")
     in_taxon_label: Optional[str] = Field(
         None,
         description="""The label of the biolink taxon that the entity is in the closure of.""",

--- a/backend/src/monarch_py/api/semsim.py
+++ b/backend/src/monarch_py/api/semsim.py
@@ -3,9 +3,7 @@ from monarch_py.api.additional_models import PaginationParams
 from monarch_py.api.utils.get_similarity import *
 from oaklib.cli import _shorthand_to_pred_curie
 
-router = APIRouter(
-    prefix="/api/semsim", tags=["semsim"], responses={404: {"description": "Not Found"}}
-)
+router = APIRouter(prefix="/api/semsim", tags=["semsim"], responses={404: {"description": "Not Found"}})
 
 
 @router.get("/semsim/{subjlist}/{objlist}")

--- a/backend/src/monarch_py/cli.py
+++ b/backend/src/monarch_py/cli.py
@@ -3,10 +3,9 @@ from pathlib import Path
 from typing import List, Optional
 
 import typer
-from typing_extensions import Annotated
-
 from monarch_py import solr_cli, sql_cli
 from monarch_py.utils.utils import set_log_level
+from typing_extensions import Annotated
 
 app = typer.Typer()
 app.add_typer(solr_cli.solr_app, name="solr")
@@ -17,17 +16,11 @@ app.add_typer(sql_cli.sql_app, name="sql")
 def callback(
     ctx: typer.Context,
     version: Annotated[
-        Optional[bool], 
-        typer.Option("--version", "-v", help="Show the currently installed version", is_eager=True)
+        Optional[bool], typer.Option("--version", "-v", help="Show the currently installed version", is_eager=True)
     ] = None,
     # verbose: Annotated[int, typer.Option("--verbose", "-v", count=True)] = 0,
-    quiet: Annotated[
-        bool, 
-        typer.Option("--quiet", "-q", help="Set log level to warning")
-    ] = False,
-    debug: Annotated[
-        bool, typer.Option("--debug", "-d", help="Set log level to debug")
-    ] = False,
+    quiet: Annotated[bool, typer.Option("--quiet", "-q", help="Set log level to warning")] = False,
+    debug: Annotated[bool, typer.Option("--debug", "-d", help="Set log level to debug")] = False,
 ):
     if version and ctx.invoked_subcommand is None:
         from monarch_py import __version__
@@ -56,9 +49,7 @@ def schema():
     Print the linkml schema for the data model
     """
     schema_name = "model"
-    schema_dir = Path(
-        importlib.util.find_spec(f"monarch_py.datamodels.{schema_name}").origin
-    ).parent
+    schema_dir = Path(importlib.util.find_spec(f"monarch_py.datamodels.{schema_name}").origin).parent
     schema_path = schema_dir / Path(schema_name + ".yaml")
     with open(schema_path, "r") as schema_file:
         print(schema_file.read())
@@ -66,6 +57,7 @@ def schema():
 
 
 ### "Aliases" for Solr CLI ###
+
 
 @app.command("entity")
 def entity(
@@ -82,9 +74,7 @@ def entity(
         "-f",
         help="The format of the output (json, yaml, tsv, table)",
     ),
-    output: str = typer.Option(
-        None, "--output", "-o", help="The path to the output file"
-    ),
+    output: str = typer.Option(None, "--output", "-o", help="The path to the output file"),
 ):
     """
     Retrieve an entity by ID
@@ -100,42 +90,26 @@ def entity(
 
 @app.command("associations")
 def associations(
-    category: List[str] = typer.Option(
-        None, "--category", "-c", help="Comma-separated list of categories"
-    ),
-    subject: List[str] = typer.Option(
-        None, "--subject", "-s", help="Comma-separated list of subjects"
-    ),
-    predicate: List[str] = typer.Option(
-        None, "--predicate", "-p", help="Comma-separated list of predicates"
-    ),
-    object: List[str] = typer.Option(
-        None, "--object", "-o", help="Comma-separated list of objects"
-    ),
-    entity: List[str] = typer.Option(
-        None, "--entity", "-e", help="Comma-separated list of entities"
-    ),
+    category: List[str] = typer.Option(None, "--category", "-c", help="Comma-separated list of categories"),
+    subject: List[str] = typer.Option(None, "--subject", "-s", help="Comma-separated list of subjects"),
+    predicate: List[str] = typer.Option(None, "--predicate", "-p", help="Comma-separated list of predicates"),
+    object: List[str] = typer.Option(None, "--object", "-o", help="Comma-separated list of objects"),
+    entity: List[str] = typer.Option(None, "--entity", "-e", help="Comma-separated list of entities"),
     direct: bool = typer.Option(
         False,
         "--direct",
         "-d",
         help="Whether to exclude associations with subject/object as ancestors",
     ),
-    limit: int = typer.Option(
-        20, "--limit", "-l", help="The number of associations to return"
-    ),
-    offset: int = typer.Option(
-        0, "--offset", help="The offset of the first association to be retrieved"
-    ),
+    limit: int = typer.Option(20, "--limit", "-l", help="The number of associations to return"),
+    offset: int = typer.Option(0, "--offset", help="The offset of the first association to be retrieved"),
     fmt: str = typer.Option(
         "json",
         "--format",
         "-f",
         help="The format of the output (json, yaml, tsv, table)",
     ),
-    output: str = typer.Option(
-        None, "--output", "-o", help="The path to the output file"
-    ),
+    output: str = typer.Option(None, "--output", "-o", help="The path to the output file"),
 ):
     """
     Paginate through associations
@@ -170,9 +144,7 @@ def search(
         "-f",
         help="The format of the output (json, yaml, tsv, table)",
     ),
-    output: str = typer.Option(
-        None, "--output", "-o", help="The path to the output file"
-    ),
+    output: str = typer.Option(None, "--output", "-o", help="The path to the output file"),
     # sort: str = typer.Option(None, "--sort", "-s"),
 ):
     """
@@ -199,9 +171,7 @@ def autocomplete(
         "-f",
         help="The format of the output (json, yaml, tsv, table)",
     ),
-    output: str = typer.Option(
-        None, "--output", "-o", help="The path to the output file"
-    ),
+    output: str = typer.Option(None, "--output", "-o", help="The path to the output file"),
 ):
     """
     Return entity autcomplete matches for a query string
@@ -224,9 +194,7 @@ def histopheno(
         "-f",
         help="The format of the output (json, yaml, tsv, table)",
     ),
-    output: str = typer.Option(
-        None, "--output", "-o", help="The path to the output file"
-    ),
+    output: str = typer.Option(None, "--output", "-o", help="The path to the output file"),
 ):
     """
     Retrieve the histopheno data for an entity by ID
@@ -250,9 +218,7 @@ def association_counts(
         "-f",
         help="The format of the output (json, yaml, tsv, table)",
     ),
-    output: str = typer.Option(
-        None, "--output", "-o", help="The path to the output file"
-    ),
+    output: str = typer.Option(None, "--output", "-o", help="The path to the output file"),
 ):
     """
     Retrieve association counts for an entity by ID
@@ -284,9 +250,7 @@ def association_table(
         "-f",
         help="The format of the output (json, yaml, tsv, table)",
     ),
-    output: str = typer.Option(
-        None, "--output", "-o", help="The path to the output file"
-    ),
+    output: str = typer.Option(None, "--output", "-o", help="The path to the output file"),
 ):
     solr_cli.association_table(**locals())
 

--- a/backend/src/monarch_py/datamodels/model.py
+++ b/backend/src/monarch_py/datamodels/model.py
@@ -1,15 +1,16 @@
 from __future__ import annotations
-from datetime import datetime, date
-from enum import Enum
-from typing import List, Dict, Optional, Any, Union
-from pydantic import BaseModel as BaseModel, Field
-from linkml_runtime.linkml_model import Decimal
+
 import sys
+from enum import Enum
+from typing import List, Optional
+
+from pydantic import BaseModel as BaseModel
+from pydantic import Field
 
 if sys.version_info >= (3, 8):
-    from typing import Literal
+    pass
 else:
-    from typing_extensions import Literal
+    pass
 
 
 metamodel_version = "None"
@@ -49,19 +50,13 @@ class Association(ConfiguredBaseModel):
     id: str = Field(...)
     subject: str = Field(...)
     original_subject: Optional[str] = Field(None)
-    subject_namespace: Optional[str] = Field(
-        None, description="""The namespace/prefix of the subject entity"""
-    )
-    subject_category: Optional[str] = Field(
-        None, description="""The category of the subject entity"""
-    )
+    subject_namespace: Optional[str] = Field(None, description="""The namespace/prefix of the subject entity""")
+    subject_category: Optional[str] = Field(None, description="""The category of the subject entity""")
     subject_closure: Optional[List[str]] = Field(
         default_factory=list,
         description="""Field containing subject id and the ids of all of it's ancestors""",
     )
-    subject_label: Optional[str] = Field(
-        None, description="""The name of the subject entity"""
-    )
+    subject_label: Optional[str] = Field(None, description="""The name of the subject entity""")
     subject_closure_label: Optional[List[str]] = Field(
         default_factory=list,
         description="""Field containing subject name and the names of all of it's ancestors""",
@@ -69,19 +64,13 @@ class Association(ConfiguredBaseModel):
     predicate: str = Field(...)
     object: str = Field(...)
     original_object: Optional[str] = Field(None)
-    object_namespace: Optional[str] = Field(
-        None, description="""The namespace/prefix of the object entity"""
-    )
-    object_category: Optional[str] = Field(
-        None, description="""The category of the object entity"""
-    )
+    object_namespace: Optional[str] = Field(None, description="""The namespace/prefix of the object entity""")
+    object_category: Optional[str] = Field(None, description="""The category of the object entity""")
     object_closure: Optional[List[str]] = Field(
         default_factory=list,
         description="""Field containing object id and the ids of all of it's ancestors""",
     )
-    object_label: Optional[str] = Field(
-        None, description="""The name of the object entity"""
-    )
+    object_label: Optional[str] = Field(None, description="""The name of the object entity""")
     object_closure_label: Optional[List[str]] = Field(
         default_factory=list,
         description="""Field containing object name and the names of all of it's ancestors""",
@@ -99,9 +88,7 @@ class Association(ConfiguredBaseModel):
     stage_qualifier: Optional[str] = Field(None)
     pathway: Optional[str] = Field(None)
     relation: Optional[str] = Field(None)
-    frequency_qualifier_label: Optional[str] = Field(
-        None, description="""The name of the frequency_qualifier entity"""
-    )
+    frequency_qualifier_label: Optional[str] = Field(None, description="""The name of the frequency_qualifier entity""")
     frequency_qualifier_namespace: Optional[str] = Field(
         None, description="""The namespace/prefix of the frequency_qualifier entity"""
     )
@@ -116,15 +103,11 @@ class Association(ConfiguredBaseModel):
         default_factory=list,
         description="""Field containing frequency_qualifier name and the names of all of it's ancestors""",
     )
-    onset_qualifier_label: Optional[str] = Field(
-        None, description="""The name of the onset_qualifier entity"""
-    )
+    onset_qualifier_label: Optional[str] = Field(None, description="""The name of the onset_qualifier entity""")
     onset_qualifier_namespace: Optional[str] = Field(
         None, description="""The namespace/prefix of the onset_qualifier entity"""
     )
-    onset_qualifier_category: Optional[str] = Field(
-        None, description="""The category of the onset_qualifier entity"""
-    )
+    onset_qualifier_category: Optional[str] = Field(None, description="""The category of the onset_qualifier entity""")
     onset_qualifier_closure: Optional[List[str]] = Field(
         default_factory=list,
         description="""Field containing onset_qualifier id and the ids of all of it's ancestors""",
@@ -133,15 +116,11 @@ class Association(ConfiguredBaseModel):
         default_factory=list,
         description="""Field containing onset_qualifier name and the names of all of it's ancestors""",
     )
-    sex_qualifier_label: Optional[str] = Field(
-        None, description="""The name of the sex_qualifier entity"""
-    )
+    sex_qualifier_label: Optional[str] = Field(None, description="""The name of the sex_qualifier entity""")
     sex_qualifier_namespace: Optional[str] = Field(
         None, description="""The namespace/prefix of the sex_qualifier entity"""
     )
-    sex_qualifier_category: Optional[str] = Field(
-        None, description="""The category of the sex_qualifier entity"""
-    )
+    sex_qualifier_category: Optional[str] = Field(None, description="""The category of the sex_qualifier entity""")
     sex_qualifier_closure: Optional[List[str]] = Field(
         default_factory=list,
         description="""Field containing sex_qualifier id and the ids of all of it's ancestors""",
@@ -150,15 +129,11 @@ class Association(ConfiguredBaseModel):
         default_factory=list,
         description="""Field containing sex_qualifier name and the names of all of it's ancestors""",
     )
-    stage_qualifier_label: Optional[str] = Field(
-        None, description="""The name of the stage_qualifier entity"""
-    )
+    stage_qualifier_label: Optional[str] = Field(None, description="""The name of the stage_qualifier entity""")
     stage_qualifier_namespace: Optional[str] = Field(
         None, description="""The namespace/prefix of the stage_qualifier entity"""
     )
-    stage_qualifier_category: Optional[str] = Field(
-        None, description="""The category of the stage_qualifier entity"""
-    )
+    stage_qualifier_category: Optional[str] = Field(None, description="""The category of the stage_qualifier entity""")
     stage_qualifier_closure: Optional[List[str]] = Field(
         default_factory=list,
         description="""Field containing stage_qualifier id and the ids of all of it's ancestors""",
@@ -216,19 +191,13 @@ class DirectionalAssociation(Association):
     id: str = Field(...)
     subject: str = Field(...)
     original_subject: Optional[str] = Field(None)
-    subject_namespace: Optional[str] = Field(
-        None, description="""The namespace/prefix of the subject entity"""
-    )
-    subject_category: Optional[str] = Field(
-        None, description="""The category of the subject entity"""
-    )
+    subject_namespace: Optional[str] = Field(None, description="""The namespace/prefix of the subject entity""")
+    subject_category: Optional[str] = Field(None, description="""The category of the subject entity""")
     subject_closure: Optional[List[str]] = Field(
         default_factory=list,
         description="""Field containing subject id and the ids of all of it's ancestors""",
     )
-    subject_label: Optional[str] = Field(
-        None, description="""The name of the subject entity"""
-    )
+    subject_label: Optional[str] = Field(None, description="""The name of the subject entity""")
     subject_closure_label: Optional[List[str]] = Field(
         default_factory=list,
         description="""Field containing subject name and the names of all of it's ancestors""",
@@ -236,19 +205,13 @@ class DirectionalAssociation(Association):
     predicate: str = Field(...)
     object: str = Field(...)
     original_object: Optional[str] = Field(None)
-    object_namespace: Optional[str] = Field(
-        None, description="""The namespace/prefix of the object entity"""
-    )
-    object_category: Optional[str] = Field(
-        None, description="""The category of the object entity"""
-    )
+    object_namespace: Optional[str] = Field(None, description="""The namespace/prefix of the object entity""")
+    object_category: Optional[str] = Field(None, description="""The category of the object entity""")
     object_closure: Optional[List[str]] = Field(
         default_factory=list,
         description="""Field containing object id and the ids of all of it's ancestors""",
     )
-    object_label: Optional[str] = Field(
-        None, description="""The name of the object entity"""
-    )
+    object_label: Optional[str] = Field(None, description="""The name of the object entity""")
     object_closure_label: Optional[List[str]] = Field(
         default_factory=list,
         description="""Field containing object name and the names of all of it's ancestors""",
@@ -266,9 +229,7 @@ class DirectionalAssociation(Association):
     stage_qualifier: Optional[str] = Field(None)
     pathway: Optional[str] = Field(None)
     relation: Optional[str] = Field(None)
-    frequency_qualifier_label: Optional[str] = Field(
-        None, description="""The name of the frequency_qualifier entity"""
-    )
+    frequency_qualifier_label: Optional[str] = Field(None, description="""The name of the frequency_qualifier entity""")
     frequency_qualifier_namespace: Optional[str] = Field(
         None, description="""The namespace/prefix of the frequency_qualifier entity"""
     )
@@ -283,15 +244,11 @@ class DirectionalAssociation(Association):
         default_factory=list,
         description="""Field containing frequency_qualifier name and the names of all of it's ancestors""",
     )
-    onset_qualifier_label: Optional[str] = Field(
-        None, description="""The name of the onset_qualifier entity"""
-    )
+    onset_qualifier_label: Optional[str] = Field(None, description="""The name of the onset_qualifier entity""")
     onset_qualifier_namespace: Optional[str] = Field(
         None, description="""The namespace/prefix of the onset_qualifier entity"""
     )
-    onset_qualifier_category: Optional[str] = Field(
-        None, description="""The category of the onset_qualifier entity"""
-    )
+    onset_qualifier_category: Optional[str] = Field(None, description="""The category of the onset_qualifier entity""")
     onset_qualifier_closure: Optional[List[str]] = Field(
         default_factory=list,
         description="""Field containing onset_qualifier id and the ids of all of it's ancestors""",
@@ -300,15 +257,11 @@ class DirectionalAssociation(Association):
         default_factory=list,
         description="""Field containing onset_qualifier name and the names of all of it's ancestors""",
     )
-    sex_qualifier_label: Optional[str] = Field(
-        None, description="""The name of the sex_qualifier entity"""
-    )
+    sex_qualifier_label: Optional[str] = Field(None, description="""The name of the sex_qualifier entity""")
     sex_qualifier_namespace: Optional[str] = Field(
         None, description="""The namespace/prefix of the sex_qualifier entity"""
     )
-    sex_qualifier_category: Optional[str] = Field(
-        None, description="""The category of the sex_qualifier entity"""
-    )
+    sex_qualifier_category: Optional[str] = Field(None, description="""The category of the sex_qualifier entity""")
     sex_qualifier_closure: Optional[List[str]] = Field(
         default_factory=list,
         description="""Field containing sex_qualifier id and the ids of all of it's ancestors""",
@@ -317,15 +270,11 @@ class DirectionalAssociation(Association):
         default_factory=list,
         description="""Field containing sex_qualifier name and the names of all of it's ancestors""",
     )
-    stage_qualifier_label: Optional[str] = Field(
-        None, description="""The name of the stage_qualifier entity"""
-    )
+    stage_qualifier_label: Optional[str] = Field(None, description="""The name of the stage_qualifier entity""")
     stage_qualifier_namespace: Optional[str] = Field(
         None, description="""The namespace/prefix of the stage_qualifier entity"""
     )
-    stage_qualifier_category: Optional[str] = Field(
-        None, description="""The category of the stage_qualifier entity"""
-    )
+    stage_qualifier_category: Optional[str] = Field(None, description="""The category of the stage_qualifier entity""")
     stage_qualifier_closure: Optional[List[str]] = Field(
         default_factory=list,
         description="""Field containing stage_qualifier id and the ids of all of it's ancestors""",
@@ -347,9 +296,7 @@ class Entity(ConfiguredBaseModel):
     description: Optional[str] = Field(None)
     xref: Optional[List[str]] = Field(default_factory=list)
     provided_by: Optional[str] = Field(None)
-    in_taxon: Optional[str] = Field(
-        None, description="""The biolink taxon that the entity is in the closure of."""
-    )
+    in_taxon: Optional[str] = Field(None, description="""The biolink taxon that the entity is in the closure of.""")
     in_taxon_label: Optional[str] = Field(
         None,
         description="""The label of the biolink taxon that the entity is in the closure of.""",
@@ -401,9 +348,7 @@ class Node(Entity):
     UI conatiner class extending Entity with additional information
     """
 
-    in_taxon: Optional[str] = Field(
-        None, description="""The biolink taxon that the entity is in the closure of."""
-    )
+    in_taxon: Optional[str] = Field(None, description="""The biolink taxon that the entity is in the closure of.""")
     in_taxon_label: Optional[str] = Field(
         None,
         description="""The label of the biolink taxon that the entity is in the closure of.""",
@@ -470,9 +415,7 @@ class EntityResults(Results):
 
 class SearchResult(Entity):
 
-    highlight: Optional[str] = Field(
-        None, description="""matching text snippet containing html tags"""
-    )
+    highlight: Optional[str] = Field(None, description="""matching text snippet containing html tags""")
     score: Optional[float] = Field(None)
     id: str = Field(...)
     category: str = Field(...)
@@ -480,9 +423,7 @@ class SearchResult(Entity):
     description: Optional[str] = Field(None)
     xref: Optional[List[str]] = Field(default_factory=list)
     provided_by: Optional[str] = Field(None)
-    in_taxon: Optional[str] = Field(
-        None, description="""The biolink taxon that the entity is in the closure of."""
-    )
+    in_taxon: Optional[str] = Field(None, description="""The biolink taxon that the entity is in the closure of.""")
     in_taxon_label: Optional[str] = Field(
         None,
         description="""The label of the biolink taxon that the entity is in the closure of.""",

--- a/backend/src/monarch_py/datamodels/solr.py
+++ b/backend/src/monarch_py/datamodels/solr.py
@@ -2,9 +2,8 @@ import urllib
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, Field
-
 from monarch_py.utils.utils import escape
+from pydantic import BaseModel, Field
 
 
 class core(Enum):
@@ -66,11 +65,7 @@ class SolrQuery(BaseModel):
 
     def query_string(self):
         return urllib.parse.urlencode(
-            {
-                self._solrize(k): self._solrize(v)
-                for k, v in self.dict().items()
-                if v is not None
-            },
+            {self._solrize(k): self._solrize(v) for k, v in self.dict().items() if v is not None},
             doseq=True,
         )
 

--- a/backend/src/monarch_py/interfaces/entity_interface.py
+++ b/backend/src/monarch_py/interfaces/entity_interface.py
@@ -7,9 +7,7 @@ class EntityInterface(ABC):
     """Abstract interface for entities in the Monarch KG"""
 
     @abstractmethod
-    def get_entity(
-        self, id: str, get_association_counts: bool = False, get_hierarchy: bool = False
-    ) -> Entity:
+    def get_entity(self, id: str, get_association_counts: bool = False, get_hierarchy: bool = False) -> Entity:
         """Retrieve a specific entity by exact ID match, with optional extras
 
         Args:

--- a/backend/src/monarch_py/interfaces/search_interface.py
+++ b/backend/src/monarch_py/interfaces/search_interface.py
@@ -1,11 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import List
 
-from monarch_py.datamodels.model import (
-    AssociationTableResults,
-    FacetValue,
-    SearchResults,
-)
+from monarch_py.datamodels.model import AssociationTableResults, FacetValue, SearchResults
 
 
 class SearchInterface(ABC):

--- a/backend/src/monarch_py/service/solr_service.py
+++ b/backend/src/monarch_py/service/solr_service.py
@@ -3,10 +3,9 @@ from typing import Dict, List
 
 import requests
 from loguru import logger
-from pydantic import BaseModel
-
 from monarch_py.datamodels.solr import SolrQuery, SolrQueryResult, core
 from monarch_py.utils.utils import escape
+from pydantic import BaseModel
 
 
 class SolrService(BaseModel):
@@ -19,10 +18,10 @@ class SolrService(BaseModel):
         response = requests.get(url)
         response.raise_for_status()
         entity = response.json()["doc"]
-        try: 
+        try:
             self._strip_json(entity, "_version_")
         except TypeError:
-                pass # what if entity is None?
+            pass  # what if entity is None?
         return entity
 
     def query(self, q: SolrQuery) -> SolrQueryResult:

--- a/backend/src/monarch_py/solr_cli.py
+++ b/backend/src/monarch_py/solr_cli.py
@@ -2,17 +2,10 @@ from typing import List
 
 import pystow
 import typer
-from typing_extensions import Annotated
-
 from monarch_py.datamodels.model import AssociationCountList
-from monarch_py.utils.solr_cli_utils import (
-    ensure_solr,
-    get_solr,
-    solr_status,
-    start_solr,
-    stop_solr,
-)
+from monarch_py.utils.solr_cli_utils import ensure_solr, get_solr, solr_status, start_solr, stop_solr
 from monarch_py.utils.utils import console, format_output, set_log_level
+from typing_extensions import Annotated
 
 solr_app = typer.Typer()
 monarchstow = pystow.module("monarch")
@@ -21,12 +14,8 @@ monarchstow = pystow.module("monarch")
 @solr_app.callback(invoke_without_command=True)
 def callback(
     ctx: typer.Context,
-    quiet: Annotated[
-        bool, typer.Option("--quiet", "-q", help="Set log level to warning")
-    ] = False,
-    debug: Annotated[
-        bool, typer.Option("--debug", "-d", help="Set log level to debug")
-    ] = False,
+    quiet: Annotated[bool, typer.Option("--quiet", "-q", help="Set log level to warning")] = False,
+    debug: Annotated[bool, typer.Option("--debug", "-d", help="Set log level to debug")] = False,
 ):
     if ctx.invoked_subcommand is None:
         typer.secho(
@@ -66,17 +55,23 @@ def status():
 
 @solr_app.command("download")
 def download(
-    version: Annotated[str, typer.Option(
+    version: Annotated[
+        str,
+        typer.Option(
             "latest",
             "--version",
             help="The version of the Solr KG to download (latest, dev, or a specific version)",
-        )] = "latest",
-    overwrite: Annotated[bool, typer.Option(
+        ),
+    ] = "latest",
+    overwrite: Annotated[
+        bool,
+        typer.Option(
             False,
             "--overwrite",
             help="Overwrite the existing Solr KG if it exists",
-        )] = False,
-    ):
+        ),
+    ] = False,
+):
     """Download the Monarch Solr KG."""
     ensure_solr(version, overwrite)
     raise typer.Exit()
@@ -102,9 +97,7 @@ def entity(
         "-f",
         help="The format of the output (json, yaml, tsv, table)",
     ),
-    output: str = typer.Option(
-        None, "--output", "-o", help="The path to the output file"
-    ),
+    output: str = typer.Option(None, "--output", "-o", help="The path to the output file"),
 ):
     """
     Retrieve an entity by ID
@@ -127,42 +120,26 @@ def entity(
 
 @solr_app.command("associations")
 def associations(
-    category: List[str] = typer.Option(
-        None, "--category", "-c", help="Comma-separated list of categories"
-    ),
-    subject: List[str] = typer.Option(
-        None, "--subject", "-s", help="Comma-separated list of subjects"
-    ),
-    predicate: List[str] = typer.Option(
-        None, "--predicate", "-p", help="Comma-separated list of predicates"
-    ),
-    object: List[str] = typer.Option(
-        None, "--object", "-o", help="Comma-separated list of objects"
-    ),
-    entity: List[str] = typer.Option(
-        None, "--entity", "-e", help="Comma-separated list of entities"
-    ),
+    category: List[str] = typer.Option(None, "--category", "-c", help="Comma-separated list of categories"),
+    subject: List[str] = typer.Option(None, "--subject", "-s", help="Comma-separated list of subjects"),
+    predicate: List[str] = typer.Option(None, "--predicate", "-p", help="Comma-separated list of predicates"),
+    object: List[str] = typer.Option(None, "--object", "-o", help="Comma-separated list of objects"),
+    entity: List[str] = typer.Option(None, "--entity", "-e", help="Comma-separated list of entities"),
     direct: bool = typer.Option(
         False,
         "--direct",
         "-d",
         help="Whether to exclude associations with subject/object as ancestors",
     ),
-    limit: int = typer.Option(
-        20, "--limit", "-l", help="The number of associations to return"
-    ),
-    offset: int = typer.Option(
-        0, "--offset", help="The offset of the first association to be retrieved"
-    ),
+    limit: int = typer.Option(20, "--limit", "-l", help="The number of associations to return"),
+    offset: int = typer.Option(0, "--offset", help="The offset of the first association to be retrieved"),
     fmt: str = typer.Option(
         "json",
         "--format",
         "-f",
         help="The format of the output (json, yaml, tsv, table)",
     ),
-    output: str = typer.Option(
-        None, "--output", "-o", help="The path to the output file"
-    ),
+    output: str = typer.Option(None, "--output", "-o", help="The path to the output file"),
 ):
     """
     Paginate through associations
@@ -204,9 +181,7 @@ def search(
         "-f",
         help="The format of the output (json, yaml, tsv, table)",
     ),
-    output: str = typer.Option(
-        None, "--output", "-o", help="The path to the output file"
-    ),
+    output: str = typer.Option(None, "--output", "-o", help="The path to the output file"),
     # sort: str = typer.Option(None, "--sort", "-s"),
 ):
     """
@@ -241,9 +216,7 @@ def autocomplete(
         "-f",
         help="The format of the output (json, yaml, tsv, table)",
     ),
-    output: str = typer.Option(
-        None, "--output", "-o", help="The path to the output file"
-    ),
+    output: str = typer.Option(None, "--output", "-o", help="The path to the output file"),
 ):
     """
     Return entity autcomplete matches for a query string
@@ -268,9 +241,7 @@ def histopheno(
         "-f",
         help="The format of the output (json, yaml, tsv, table)",
     ),
-    output: str = typer.Option(
-        None, "--output", "-o", help="The path to the output file"
-    ),
+    output: str = typer.Option(None, "--output", "-o", help="The path to the output file"),
 ):
     """
     Retrieve the histopheno associations for a given subject
@@ -302,9 +273,7 @@ def association_counts(
         "-f",
         help="The format of the output (json, yaml, tsv, table)",
     ),
-    output: str = typer.Option(
-        None, "--output", "-o", help="The path to the output file"
-    ),
+    output: str = typer.Option(None, "--output", "-o", help="The path to the output file"),
 ):
     """
     Retrieve the association counts for a given entity
@@ -342,12 +311,8 @@ def association_table(
         "-f",
         help="The format of the output (json, yaml, tsv, table)",
     ),
-    output: str = typer.Option(
-        None, "--output", "-o", help="The path to the output file"
-    ),
+    output: str = typer.Option(None, "--output", "-o", help="The path to the output file"),
 ):
     data = get_solr(update=False)
-    response = data.get_association_table(
-        entity=entity, category=category, q=q, limit=limit, offset=offset
-    )
+    response = data.get_association_table(entity=entity, category=category, q=q, limit=limit, offset=offset)
     format_output(fmt, response, output)

--- a/backend/src/monarch_py/sql_cli.py
+++ b/backend/src/monarch_py/sql_cli.py
@@ -1,10 +1,9 @@
 from typing import List
 
 import typer
-from typing_extensions import Annotated
-
 from monarch_py.implementations.sql.sql_implementation import SQLImplementation
 from monarch_py.utils.utils import console, format_output, set_log_level
+from typing_extensions import Annotated
 
 sql_app = typer.Typer()
 app_state = {"log_level": "WARNING"}
@@ -13,12 +12,8 @@ app_state = {"log_level": "WARNING"}
 @sql_app.callback(invoke_without_command=True)
 def callback(
     ctx: typer.Context,
-    quiet: Annotated[
-        bool, typer.Option("--quiet", "-q", help="Set log level to warning")
-    ] = False,
-    debug: Annotated[
-        bool, typer.Option("--debug", "-d", help="Set log level to debug")
-    ] = False,
+    quiet: Annotated[bool, typer.Option("--quiet", "-q", help="Set log level to warning")] = False,
+    debug: Annotated[bool, typer.Option("--debug", "-d", help="Set log level to debug")] = False,
 ):
     if ctx.invoked_subcommand is None:
         typer.secho(
@@ -39,18 +34,14 @@ def entity(
         "-e",
         help="Include extra fields in the output (association_counts and node_hierarchy)",
     ),
-    update: bool = typer.Option(
-        False, "--update", "-u", help="Whether to re-download the Monarch KG"
-    ),
+    update: bool = typer.Option(False, "--update", "-u", help="Whether to re-download the Monarch KG"),
     fmt: str = typer.Option(
         "json",
         "--format",
         "-f",
         help="The format of the output (json, yaml, tsv, table)",
     ),
-    output: str = typer.Option(
-        None, "--output", "-o", help="The path to the output file"
-    ),
+    output: str = typer.Option(None, "--output", "-o", help="The path to the output file"),
 ):
     """Retrieve an entity by ID
 
@@ -75,42 +66,26 @@ def entity(
 
 @sql_app.command()
 def associations(
-    category: List[str] = typer.Option(
-        None, "--category", "-c", help="Comma-separated list of categories"
-    ),
-    subject: List[str] = typer.Option(
-        None, "--subject", "-s", help="Comma-separated list of subjects"
-    ),
-    predicate: List[str] = typer.Option(
-        None, "--predicate", "-p", help="Comma-separated list of predicates"
-    ),
-    object: List[str] = typer.Option(
-        None, "--object", "-o", help="Comma-separated list of objects"
-    ),
-    entity: List[str] = typer.Option(
-        None, "--entity", "-e", help="Comma-separated list of entities"
-    ),
+    category: List[str] = typer.Option(None, "--category", "-c", help="Comma-separated list of categories"),
+    subject: List[str] = typer.Option(None, "--subject", "-s", help="Comma-separated list of subjects"),
+    predicate: List[str] = typer.Option(None, "--predicate", "-p", help="Comma-separated list of predicates"),
+    object: List[str] = typer.Option(None, "--object", "-o", help="Comma-separated list of objects"),
+    entity: List[str] = typer.Option(None, "--entity", "-e", help="Comma-separated list of entities"),
     direct: bool = typer.Option(
         False,
         "--direct",
         "-d",
         help="Whether to exclude associations with subject/object as ancestors",
     ),
-    limit: int = typer.Option(
-        20, "--limit", "-l", help="The number of associations to return"
-    ),
-    offset: int = typer.Option(
-        0, "--offset", help="The offset of the first association to be retrieved"
-    ),
+    limit: int = typer.Option(20, "--limit", "-l", help="The number of associations to return"),
+    offset: int = typer.Option(0, "--offset", help="The offset of the first association to be retrieved"),
     fmt: str = typer.Option(
         "json",
         "--format",
         "-f",
         help="The format of the output (json, yaml, tsv, table)",
     ),
-    output: str = typer.Option(
-        None, "--output", "-o", help="The path to the output file"
-    ),
+    output: str = typer.Option(None, "--output", "-o", help="The path to the output file"),
 ):
     """Paginate through associations
 

--- a/backend/src/monarch_py/utils/association_type_utils.py
+++ b/backend/src/monarch_py/utils/association_type_utils.py
@@ -3,9 +3,8 @@ import re
 from typing import List
 
 import yaml
-from pydantic import parse_obj_as
-
 from monarch_py.datamodels.model import AssociationTypeMapping
+from pydantic import parse_obj_as
 
 
 class AssociationTypeMappings:
@@ -13,9 +12,7 @@ class AssociationTypeMappings:
 
     def __init__(self):
         if AssociationTypeMappings.__instance is not None:
-            raise Exception(
-                "AssociationTypeMappings is a singleton class, use getInstance() to get the instance."
-            )
+            raise Exception("AssociationTypeMappings is a singleton class, use getInstance() to get the instance.")
         else:
             AssociationTypeMappings.__instance = self
             self.mappings = None
@@ -35,9 +32,7 @@ class AssociationTypeMappings:
                 return mapping
 
     def load_mappings(self):
-        mapping_data = pkgutil.get_data(
-            __package__, "../association_type_mappings.yaml"
-        )
+        mapping_data = pkgutil.get_data(__package__, "../association_type_mappings.yaml")
         mapping_data = yaml.load(mapping_data, Loader=yaml.FullLoader)
         self.mappings = parse_obj_as(List[AssociationTypeMapping], mapping_data)
 
@@ -57,19 +52,13 @@ def get_association_type_mapping_by_query_string(
     categories = parse_query_string_for_category(query_string)
 
     matching_types = [
-        a_type
-        for a_type in AssociationTypeMappings.get_mappings()
-        if set(a_type.category) == set(categories)
+        a_type for a_type in AssociationTypeMappings.get_mappings() if set(a_type.category) == set(categories)
     ]
 
     if len(matching_types) == 0:
-        raise ValueError(
-            f"No matching association type found for query string: [{query_string}]"
-        )
+        raise ValueError(f"No matching association type found for query string: [{query_string}]")
     elif len(matching_types) > 1:
-        raise ValueError(
-            f"Too many association types found for query string: [{query_string}]"
-        )
+        raise ValueError(f"Too many association types found for query string: [{query_string}]")
     else:
         return matching_types[0]
 

--- a/backend/src/monarch_py/utils/solr_cli_utils.py
+++ b/backend/src/monarch_py/utils/solr_cli_utils.py
@@ -5,17 +5,13 @@ import time
 
 import docker
 import pystow
-
 from monarch_py.implementations.solr.solr_implementation import SolrImplementation
 from monarch_py.utils.utils import MONARCH_DATA_URL, console
 
 monarchstow = pystow.module("monarch")
 
 
-def ensure_solr(
-        version: str = "latest",
-        overwrite: bool = False
-    ) -> None:
+def ensure_solr(version: str = "latest", overwrite: bool = False) -> None:
     """Download and unpack the monarch solr kg, and check permissions."""
     data_path = monarchstow.base / "solr" / "data"
     # When untarred solr won't necessarily use the same file names for index segments etc
@@ -51,9 +47,7 @@ def get_solr(update: bool = False):
     if check_for_solr(dc=docker.from_env(), quiet=True):
         return SolrImplementation()
     else:
-        console.print(
-            "\nNo Solr container found!\nStart a Solr container with [bold]monarch solr start[/]."
-        )
+        console.print("\nNo Solr container found!\nStart a Solr container with [bold]monarch solr start[/].")
         sys.exit(1)
 
 
@@ -82,9 +76,7 @@ def start_solr():
         try:
             c.start()
         except Exception as e:
-            console.print(
-                f"Error running existing container {c.name} ({c.status}) - {e}"
-            )
+            console.print(f"Error running existing container {c.name} ({c.status}) - {e}")
             raise e
 
 

--- a/backend/src/monarch_py/utils/utils.py
+++ b/backend/src/monarch_py/utils/utils.py
@@ -3,17 +3,10 @@ import sys
 
 import typer
 import yaml
+from monarch_py.datamodels.model import AssociationCountList, ConfiguredBaseModel, Entity, HistoPheno, Results
 from rich import print_json
 from rich.console import Console
 from rich.table import Table
-
-from monarch_py.datamodels.model import (
-    AssociationCountList,
-    ConfiguredBaseModel,
-    Entity,
-    HistoPheno,
-    Results,
-)
 
 MONARCH_DATA_URL = "https://data.monarchinitiative.org/monarch-kg-dev"
 SOLR_DATA_URL = f"{MONARCH_DATA_URL}/latest/solr.tar.gz"
@@ -56,7 +49,9 @@ def set_log_level(log_level: str):
 
 ### Output conversion methods ###
 
-FMT_INPUT_ERROR_MSG = "Text conversion method only accepts Entity, HistoPheno, AssociationCountList, or Results objects."
+FMT_INPUT_ERROR_MSG = (
+    "Text conversion method only accepts Entity, HistoPheno, AssociationCountList, or Results objects."
+)
 
 
 def get_headers_from_obj(obj: ConfiguredBaseModel) -> list:
@@ -129,11 +124,7 @@ def to_table(obj: ConfiguredBaseModel):
                 row[i] = ", ".join(value)
             elif not isinstance(value, str):
                 row[i] = str(value)
-    title = (
-        f"{obj.__class__.__name__}: {obj.id}"
-        if hasattr(obj, "id")
-        else obj.__class__.__name__
-    )
+    title = f"{obj.__class__.__name__}: {obj.id}" if hasattr(obj, "id") else obj.__class__.__name__
     table = Table(
         title=console.rule(title),
         show_header=True,
@@ -154,11 +145,7 @@ def to_yaml(obj: ConfiguredBaseModel, file: str):
 
     if isinstance(obj, Entity):
         yaml.dump(obj.dict(), fh, indent=4)
-    elif (
-        isinstance(obj, Results)
-        or isinstance(obj, HistoPheno)
-        or isinstance(obj, AssociationCountList)
-    ):
+    elif isinstance(obj, Results) or isinstance(obj, HistoPheno) or isinstance(obj, AssociationCountList):
         yaml.dump([item.dict() for item in obj.items], fh, indent=4)
     else:
         raise TypeError(FMT_INPUT_ERROR_MSG)

--- a/backend/tests/api/test_association_flatter.py
+++ b/backend/tests/api/test_association_flatter.py
@@ -1,5 +1,4 @@
 import pytest
-
 from monarch_py.datamodels.model import Association, Entity
 from monarch_py.implementations.solr.solr_implementation import SolrImplementation
 
@@ -7,6 +6,7 @@ pytestmark = pytest.mark.skipif(
     condition=not SolrImplementation().solr_is_available(),
     reason="Solr is not available",
 )
+
 
 @pytest.fixture()
 def example_association():

--- a/backend/tests/api/test_node_hierarchy.py
+++ b/backend/tests/api/test_node_hierarchy.py
@@ -1,9 +1,10 @@
 # write a test that uses mocking to test the get_node_hierarchy function
-import pytest
 from unittest.mock import Mock
 
+import pytest
 from monarch_py.datamodels.model import AssociationResults, Entity
 from monarch_py.implementations.solr.solr_implementation import SolrImplementation
+
 
 @pytest.mark.skip(reason="We really need a mock solr implementation")
 def test_get_node_hierarchy():
@@ -14,9 +15,7 @@ def test_get_node_hierarchy():
     # create a mock solr implementation
     si = Mock(
         spec=SolrImplementation,
-        get_associations=Mock(
-            return_value=AssociationResults(limit=20, offset=0, total=100)
-        ),
+        get_associations=Mock(return_value=AssociationResults(limit=20, offset=0, total=100)),
     )
 
     # call get_node_hierarchy and assert that it calls get_associations

--- a/backend/tests/api/test_search.py
+++ b/backend/tests/api/test_search.py
@@ -13,7 +13,5 @@ def test_search(q, category, taxon, offset, limit):
     Test that search calls search from monarch_py
     """
     si = Mock(spec=SolrImplementation)
-    response = si.search(
-        q=q, category=category, taxon=taxon, offset=offset, limit=limit
-    )
+    response = si.search(q=q, category=category, taxon=taxon, offset=offset, limit=limit)
     assert response

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,8 +1,16 @@
 import os
 from glob import glob
 
+import pytest
+# from unittest import TestCase
+from unittest.mock import Mock, MagicMock, patch
+
+from monarch_py.implementations.solr.solr_implementation import SolrImplementation
+from monarch_py.datamodels.model import AssociationResults, HistoPheno, Node, SearchResults
+
 
 def _as_module(fixture_path: str) -> str:
+    """Convert a file path to a module path."""
     return fixture_path.replace("/", ".").replace("\\", ".").replace(".py", "")
 
 
@@ -13,7 +21,18 @@ elif os.getcwd().endswith("backend"):
 else:
     raise Exception("Could not find fixtures directory")
 
-
 fixtures = glob(f"{fixtures_dir}/[!_]*.py")
-
 pytest_plugins = [_as_module(f) for f in fixtures]
+
+
+### Mock SolrImplementation
+
+@pytest.fixture
+def mock_solr(node, associations, autocomplete, search, histopheno):
+    """Mock SolrImplementation class."""
+    with patch("monarch_py.implementations.solr.solr_implementation.SolrImplementation") as mock:
+        mock.get_entity.return_value = Node(**node)
+        mock.get_associations.return_value = AssociationResults(**associations)
+        mock.autocomplete.return_value = SearchResults(**autocomplete)
+        mock.search.return_value = SearchResults(**search)
+        yield mock

--- a/backend/tests/integration/test_solr_association.py
+++ b/backend/tests/integration/test_solr_association.py
@@ -1,5 +1,4 @@
 import pytest
-
 from monarch_py.implementations.solr.solr_implementation import SolrImplementation
 
 pytestmark = pytest.mark.skipif(
@@ -24,9 +23,7 @@ def test_association_page_limit():
 
 def test_association_category():
     si = SolrImplementation()
-    response = si.get_associations(
-        category="biolink:CorrelatedGeneToDiseaseAssociation"
-    )
+    response = si.get_associations(category="biolink:CorrelatedGeneToDiseaseAssociation")
     assert response
     assert response.total > 6000
     assert "biolink:CorrelatedGeneToDiseaseAssociation" in response.items[0].category
@@ -69,9 +66,4 @@ def test_entity():
     assert response
     assert response.total > 50
     for association in response.items:
-        assert (
-            "MONDO:0007947" in association.subject_closure
-            or "MONDO:0007947" in association.object_closure
-        )
-
-
+        assert "MONDO:0007947" in association.subject_closure or "MONDO:0007947" in association.object_closure

--- a/backend/tests/integration/test_solr_autocomplete.py
+++ b/backend/tests/integration/test_solr_autocomplete.py
@@ -1,5 +1,4 @@
 import pytest
-
 from monarch_py.implementations.solr.solr_implementation import SolrImplementation
 
 pytestmark = pytest.mark.skipif(

--- a/backend/tests/integration/test_solr_entity.py
+++ b/backend/tests/integration/test_solr_entity.py
@@ -1,5 +1,4 @@
 import pytest
-
 from monarch_py.implementations.solr.solr_implementation import SolrImplementation
 
 pytestmark = pytest.mark.skipif(

--- a/backend/tests/integration/test_solr_histopheno.py
+++ b/backend/tests/integration/test_solr_histopheno.py
@@ -1,5 +1,4 @@
 import pytest
-
 from monarch_py.implementations.solr.solr_implementation import SolrImplementation
 
 pytestmark = pytest.mark.skipif(

--- a/backend/tests/integration/test_solr_search.py
+++ b/backend/tests/integration/test_solr_search.py
@@ -1,5 +1,4 @@
 import pytest
-
 from monarch_py.datamodels.model import AssociationDirectionEnum
 from monarch_py.implementations.solr.solr_implementation import SolrImplementation
 
@@ -56,9 +55,7 @@ def test_single_filter_queries():
 
 def test_multiple_filter_queries():
     si = SolrImplementation()
-    response = si.search(
-        "eye", category=["biolink:Disease", "biolink:PhenotypicFeature"]
-    )
+    response = si.search("eye", category=["biolink:Disease", "biolink:PhenotypicFeature"])
     assert response
     assert response.total > 0
     for (i, item) in enumerate(response.items):
@@ -72,11 +69,7 @@ def test_association_facets():
     assert response.facet_fields
     category = [ff for ff in response.facet_fields if ff.label == "category"][0]
     assert category
-    d2p = [
-        fv
-        for fv in category.facet_values
-        if fv.label == "biolink:DiseaseToPhenotypicFeatureAssociation"
-    ][0]
+    d2p = [fv for fv in category.facet_values if fv.label == "biolink:DiseaseToPhenotypicFeatureAssociation"][0]
     assert d2p
     assert d2p.count > 100000
 
@@ -96,19 +89,13 @@ def test_association_facet_query():
     )
     assert response
     assert response.facet_queries
-    hp924 = [
-        fq for fq in response.facet_queries if fq.label == 'object_closure:"HP:0000924"'
-    ][0]
+    hp924 = [fq for fq in response.facet_queries if fq.label == 'object_closure:"HP:0000924"'][0]
     assert hp924.count > 20
 
-    hp707 = [
-        fq for fq in response.facet_queries if fq.label == 'object_closure:"HP:0000707"'
-    ][0]
+    hp707 = [fq for fq in response.facet_queries if fq.label == 'object_closure:"HP:0000707"'][0]
     assert hp707.count > 5
 
-    hp152 = [
-        fq for fq in response.facet_queries if fq.label == 'object_closure:"HP:0000152"'
-    ][0]
+    hp152 = [fq for fq in response.facet_queries if fq.label == 'object_closure:"HP:0000152"'][0]
     assert hp152.count > 20
 
 
@@ -118,17 +105,11 @@ def test_association_counts_for_disease():
     assert association_counts
     assert len(association_counts) > 0
 
-    causal_genes = [
-        ac
-        for ac in association_counts
-        if ac.category == "biolink:CausalGeneToDiseaseAssociation"
-    ][0]
+    causal_genes = [ac for ac in association_counts if ac.category == "biolink:CausalGeneToDiseaseAssociation"][0]
     assert causal_genes.label == "Causal Genes"
 
     disease_phenotype = [
-        ac
-        for ac in association_counts
-        if ac.category == "biolink:DiseaseToPhenotypicFeatureAssociation"
+        ac for ac in association_counts if ac.category == "biolink:DiseaseToPhenotypicFeatureAssociation"
     ][0]
     assert disease_phenotype.label == "Phenotypes"
 
@@ -147,25 +128,17 @@ def test_association_counts_for_phenotype():
     assert len(association_counts) > 0
 
     disease_phenotype = [
-        ac
-        for ac in association_counts
-        if ac.category == "biolink:DiseaseToPhenotypicFeatureAssociation"
+        ac for ac in association_counts if ac.category == "biolink:DiseaseToPhenotypicFeatureAssociation"
     ][0]
     assert disease_phenotype.label == "Diseases"
 
-    gene_phenotype = [
-        ac
-        for ac in association_counts
-        if ac.category == "biolink:GeneToPhenotypicFeatureAssociation"
-    ][0]
+    gene_phenotype = [ac for ac in association_counts if ac.category == "biolink:GeneToPhenotypicFeatureAssociation"][0]
     assert gene_phenotype.label == "Genes"
 
 
 def test_association_table():
     si = SolrImplementation()
-    association_results = si.get_association_table(
-        "MONDO:0007947", "biolink:DiseaseToPhenotypicFeatureAssociation"
-    )
+    association_results = si.get_association_table("MONDO:0007947", "biolink:DiseaseToPhenotypicFeatureAssociation")
     assert association_results
     assert association_results.total > 5
     assert association_results.items[0].direction == AssociationDirectionEnum.outgoing

--- a/backend/tests/integration/test_sql_association.py
+++ b/backend/tests/integration/test_sql_association.py
@@ -1,5 +1,4 @@
 import pytest
-
 from monarch_py.implementations.sql.sql_implementation import SQLImplementation
 
 pytestmark = pytest.mark.skip("Need to rewrite SQL tests")
@@ -57,10 +56,7 @@ def test_entity():
     assert response
     assert response.total > 50
     for association in response.items:
-        assert (
-            association.subject == "MONDO:0007947"
-            or association.object == "MONDO:0007947"
-        )
+        assert association.subject == "MONDO:0007947" or association.object == "MONDO:0007947"
 
 
 def test_between():
@@ -69,10 +65,7 @@ def test_between():
     assert response
     assert response.total > 0
     for association in response.items:
-        assert (
-            association.subject == "MONDO:0007947"
-            and association.object == "HP:0000098"
-        )
+        assert association.subject == "MONDO:0007947" and association.object == "HP:0000098"
 
 
 def test_between_reversed():
@@ -81,17 +74,12 @@ def test_between_reversed():
     assert response
     assert response.total > 0
     for association in response.items:
-        assert (
-            association.subject == "MONDO:0007947"
-            and association.object == "HP:0000098"
-        )
+        assert association.subject == "MONDO:0007947" and association.object == "HP:0000098"
 
 
 def test_associations_by_type():
     data = SQLImplementation()
-    response = data.get_associations(
-        entity="MONDO:0007947", category="biolink:DiseaseToPhenotypicFeatureAssociation"
-    )
+    response = data.get_associations(entity="MONDO:0007947", category="biolink:DiseaseToPhenotypicFeatureAssociation")
 
     assert response
     assert response.total > 60

--- a/backend/tests/integration/test_sql_entity.py
+++ b/backend/tests/integration/test_sql_entity.py
@@ -1,5 +1,4 @@
 import pytest
-
 from monarch_py.implementations.sql.sql_implementation import SQLImplementation
 
 pytestmark = pytest.mark.skip("all tests still WIP")

--- a/backend/tests/unit/test_association_type_mapping.py
+++ b/backend/tests/unit/test_association_type_mapping.py
@@ -1,5 +1,4 @@
 import pytest
-
 from monarch_py.datamodels.model import AssociationTypeMapping
 from monarch_py.utils.association_type_utils import (
     get_solr_query_fragment,

--- a/backend/tests/unit/test_datamodels_solr.py
+++ b/backend/tests/unit/test_datamodels_solr.py
@@ -2,7 +2,6 @@ import urllib
 from typing import List
 
 import pytest
-
 from monarch_py.datamodels.solr import SolrQuery
 
 

--- a/backend/tests/unit/test_mock_solr.py
+++ b/backend/tests/unit/test_mock_solr.py
@@ -1,0 +1,24 @@
+
+def test_entity(mock_solr, node):
+    si = mock_solr
+    assert si.get_entity("MONDO:0020121").name == "muscular dystrophy"
+
+
+def test_associations(mock_solr, associations):
+    si = mock_solr
+    assert si.get_associations("MONDO:0020121").total != 0
+
+
+def test_autocomplete(mock_solr, autocomplete):
+    si = mock_solr
+    assert si.autocomplete("fanc").total != 0
+
+
+def test_search(mock_solr, search):
+    si = mock_solr
+    assert si.search("fanc").total != 0
+
+
+def test_histopheno(mock_solr, histopheno):
+    si = mock_solr
+    assert si.get_histopheno("MONDO:0020121").total != 0


### PR DESCRIPTION
Mock `SolrImplementation` using pytest/unittest to allow tests to run tests without a local running Solr instance. 

- Very basic at this point, does not mock `SolrService`, but probably should so we can actually test some of the logic of `SolrImplementation` and not purely getting pre-made fixtures