### PR TITLE
Fix multi-category/multi-predicate association queries 

### DIFF
--- a/backend/src/monarch_py/implementations/solr/solr_query_utils.py
+++ b/backend/src/monarch_py/implementations/solr/solr_query_utils.py
@@ -24,9 +24,9 @@ def build_association_query(
     """Populate a SolrQuery object with association filters"""
     query = SolrQuery(start=offset, rows=limit)
     if category:
-        query.add_field_filter_query("category", " OR ".join(category))
+        query.add_filter_query(" OR ".join([f'category:{escape(cat)}' for cat in category]))
     if predicate:
-        query.add_field_filter_query("predicate", " OR ".join(predicate))
+        query.add_filter_query(" OR ".join([f'predicate:{escape(pred)}' for pred in predicate]))
     if subject:
         if direct:
             query.add_field_filter_query("subject", " OR ".join(subject))

--- a/backend/src/monarch_py/implementations/solr/solr_query_utils.py
+++ b/backend/src/monarch_py/implementations/solr/solr_query_utils.py
@@ -24,9 +24,9 @@ def build_association_query(
     """Populate a SolrQuery object with association filters"""
     query = SolrQuery(start=offset, rows=limit)
     if category:
-        query.add_filter_query(" OR ".join([f'category:{escape(cat)}' for cat in category]))
+        query.add_filter_query(" OR ".join([f"category:{escape(cat)}" for cat in category]))
     if predicate:
-        query.add_filter_query(" OR ".join([f'predicate:{escape(pred)}' for pred in predicate]))
+        query.add_filter_query(" OR ".join([f"predicate:{escape(pred)}" for pred in predicate]))
     if subject:
         if direct:
             query.add_field_filter_query("subject", " OR ".join(subject))

--- a/backend/tests/fixtures/association_query_direct.py
+++ b/backend/tests/fixtures/association_query_direct.py
@@ -12,7 +12,7 @@ def association_query_direct():
         "facet_queries": [],
         "filter_queries": [
             "category:biolink\\:TestCase",
-            "predicate:biolink\\:is_a_test_case OR biolink\\:is_an_example",
+            "predicate:biolink\\:is_a_test_case OR predicate:biolink\\:is_an_example",
             "subject:TEST\\:0000001",
             "subject_closure:TEST\\:0000003",
             "object:TEST\\:0000002",

--- a/backend/tests/fixtures/association_query_indirect.py
+++ b/backend/tests/fixtures/association_query_indirect.py
@@ -12,7 +12,7 @@ def association_query_indirect():
         "facet_queries": [],
         "filter_queries": [
             "category:biolink\\:TestCase",
-            "predicate:biolink\\:is_a_test_case OR biolink\\:is_an_example",
+            "predicate:biolink\\:is_a_test_case OR predicate:biolink\\:is_an_example",
             'subject:"TEST:0000001" OR subject_closure:"TEST:0000001"',
             "subject_closure:TEST\\:0000003",
             'object:"TEST:0000002" OR object_closure:"TEST:0000002"',

--- a/backend/tests/unit/test_solr_queries.py
+++ b/backend/tests/unit/test_solr_queries.py
@@ -45,31 +45,49 @@ def test_build_association_multiple_categories():
     query = build_association_query(category=["biolink:Disease", "biolink:PhenotypicFeature"])
     assert len(query.filter_queries) > 0, "filter_queries is empty"
     category_filter = [fq for fq in query.filter_queries if fq.startswith("category:")][0]
-    assert category_filter == "category:biolink\\:Disease OR category:biolink\\:PhenotypicFeature", "multiple category filter is not as expected"
+    assert (
+        category_filter == "category:biolink\\:Disease OR category:biolink\\:PhenotypicFeature"
+    ), "multiple category filter is not as expected"
+
 
 def test_build_association_multiple_predicates():
     query = build_association_query(predicate=["biolink:has_phenotype", "biolink:expressed_in"])
     assert len(query.filter_queries) > 0, "filter_queries is empty"
     predicate_filter = [fq for fq in query.filter_queries if fq.startswith("predicate:")][0]
-    assert predicate_filter == "predicate:biolink\\:has_phenotype OR predicate:biolink\\:expressed_in", "multiple predicate filter is not as expected"
+    assert (
+        predicate_filter == "predicate:biolink\\:has_phenotype OR predicate:biolink\\:expressed_in"
+    ), "multiple predicate filter is not as expected"
+
 
 def test_build_association_multiple_entites():
     query = build_association_query(entity=["MONDO:0020121", "HP:0000006"])
     assert len(query.filter_queries) > 0, "filter_queries is empty"
     entity_filter = [fq for fq in query.filter_queries if fq.startswith("subject:")][0]
-    assert entity_filter == 'subject:"MONDO\\:0020121" OR subject_closure:"MONDO\\:0020121" OR object:"MONDO\\:0020121" OR object_closure:"MONDO\\:0020121" OR subject:"HP\\:0000006" OR subject_closure:"HP\\:0000006" OR object:"HP\\:0000006" OR object_closure:"HP\\:0000006"'
+    assert (
+        entity_filter
+        == 'subject:"MONDO\\:0020121" OR subject_closure:"MONDO\\:0020121" OR object:"MONDO\\:0020121" OR object_closure:"MONDO\\:0020121" OR subject:"HP\\:0000006" OR subject_closure:"HP\\:0000006" OR object:"HP\\:0000006" OR object_closure:"HP\\:0000006"'
+    )
+
 
 def test_build_association_multiple_subjects():
     query = build_association_query(subject=["MONDO:0020121", "MONDO:0007915"])
     assert len(query.filter_queries) > 0, "filter_queries is empty"
     subject_filter = [fq for fq in query.filter_queries if fq.startswith("subject:")][0]
-    assert subject_filter == 'subject:"MONDO:0020121" OR subject_closure:"MONDO:0020121" OR subject:"MONDO:0007915" OR subject_closure:"MONDO:0007915"', "multiple subject filter is not as expected"
+    assert (
+        subject_filter
+        == 'subject:"MONDO:0020121" OR subject_closure:"MONDO:0020121" OR subject:"MONDO:0007915" OR subject_closure:"MONDO:0007915"'
+    ), "multiple subject filter is not as expected"
+
 
 def test_build_association_multiple_objects():
     query = build_association_query(object=["HP:0000006", "HP:0000007"])
     assert len(query.filter_queries) > 0, "filter_queries is empty"
     object_filter = [fq for fq in query.filter_queries if fq.startswith("object:")][0]
-    assert object_filter == 'object:"HP:0000006" OR object_closure:"HP:0000006" OR object:"HP:0000007" OR object_closure:"HP:0000007"', "multiple object filter is not as expected"
+    assert (
+        object_filter
+        == 'object:"HP:0000006" OR object_closure:"HP:0000006" OR object:"HP:0000007" OR object_closure:"HP:0000007"'
+    ), "multiple object filter is not as expected"
+
 
 def test_build_association_counts_query(association_counts_query, node):
     query = build_association_counts_query(entity=Node(**node).id).dict()

--- a/backend/tests/unit/test_solr_queries.py
+++ b/backend/tests/unit/test_solr_queries.py
@@ -41,6 +41,36 @@ def test_build_association_query(
     assert compare_dicts(query, expected), f"Query is not as expected. Difference: {dict_diff(query, expected)}"
 
 
+def test_build_association_multiple_categories():
+    query = build_association_query(category=["biolink:Disease", "biolink:PhenotypicFeature"])
+    assert len(query.filter_queries) > 0, "filter_queries is empty"
+    category_filter = [fq for fq in query.filter_queries if fq.startswith("category:")][0]
+    assert category_filter == "category:biolink\\:Disease OR category:biolink\\:PhenotypicFeature", "multiple category filter is not as expected"
+
+def test_build_association_multiple_predicates():
+    query = build_association_query(predicate=["biolink:has_phenotype", "biolink:expressed_in"])
+    assert len(query.filter_queries) > 0, "filter_queries is empty"
+    predicate_filter = [fq for fq in query.filter_queries if fq.startswith("predicate:")][0]
+    assert predicate_filter == "predicate:biolink\\:has_phenotype OR predicate:biolink\\:expressed_in", "multiple predicate filter is not as expected"
+
+def test_build_association_multiple_entites():
+    query = build_association_query(entity=["MONDO:0020121", "HP:0000006"])
+    assert len(query.filter_queries) > 0, "filter_queries is empty"
+    entity_filter = [fq for fq in query.filter_queries if fq.startswith("subject:")][0]
+    assert entity_filter == 'subject:"MONDO\\:0020121" OR subject_closure:"MONDO\\:0020121" OR object:"MONDO\\:0020121" OR object_closure:"MONDO\\:0020121" OR subject:"HP\\:0000006" OR subject_closure:"HP\\:0000006" OR object:"HP\\:0000006" OR object_closure:"HP\\:0000006"'
+
+def test_build_association_multiple_subjects():
+    query = build_association_query(subject=["MONDO:0020121", "MONDO:0007915"])
+    assert len(query.filter_queries) > 0, "filter_queries is empty"
+    subject_filter = [fq for fq in query.filter_queries if fq.startswith("subject:")][0]
+    assert subject_filter == 'subject:"MONDO:0020121" OR subject_closure:"MONDO:0020121" OR subject:"MONDO:0007915" OR subject_closure:"MONDO:0007915"', "multiple subject filter is not as expected"
+
+def test_build_association_multiple_objects():
+    query = build_association_query(object=["HP:0000006", "HP:0000007"])
+    assert len(query.filter_queries) > 0, "filter_queries is empty"
+    object_filter = [fq for fq in query.filter_queries if fq.startswith("object:")][0]
+    assert object_filter == 'object:"HP:0000006" OR object_closure:"HP:0000006" OR object:"HP:0000007" OR object_closure:"HP:0000007"', "multiple object filter is not as expected"
+
 def test_build_association_counts_query(association_counts_query, node):
     query = build_association_counts_query(entity=Node(**node).id).dict()
     expected = association_counts_query


### PR DESCRIPTION
Fixes filter query syntax when supplying multiple categories or multiple predicates, also adds some testing for those along with queries for multiple subjects, objects and entities.
