### PR TITLE
Add sorting for association table endpoint

### DIFF
--- a/backend/src/monarch_py/api/entity.py
+++ b/backend/src/monarch_py/api/entity.py
@@ -1,3 +1,4 @@
+from typing import List
 from fastapi import APIRouter, Depends, HTTPException, Query
 from monarch_py.api.additional_models import PaginationParams
 from monarch_py.api.config import settings
@@ -50,6 +51,7 @@ def _association_table(
         title="Type of association to retrieve association table data for",
     ),
     query: str = Query(None, example="thumb", title="Query string to limit results to a subset"),
+        sort: List[str] = Query(None, example=["subject_label asc", "predicate asc", "object_label asc"], title="Sort results by a list of field + direction statements"),
     pagination: PaginationParams = Depends(),
 ) -> AssociationTableResults:
     """
@@ -64,7 +66,7 @@ def _association_table(
     """
     solr = SolrImplementation(base_url=settings.solr_url)
     response = solr.get_association_table(
-        entity=id, category=category, q=query, offset=pagination.offset, limit=pagination.limit
+        entity=id, category=category, q=query, sort=sort, offset=pagination.offset, limit=pagination.limit
     )
 
     return response

--- a/backend/src/monarch_py/implementations/solr/solr_implementation.py
+++ b/backend/src/monarch_py/implementations/solr/solr_implementation.py
@@ -322,10 +322,10 @@ class SolrImplementation(EntityInterface, AssociationInterface, SearchInterface)
         self,
         entity: str,
         category: str,
-        q=None,
-        sort=None,
-        offset=0,
-        limit=5,
+        q: str =None,
+        sort: List[str]=None,
+        offset: int=0,
+        limit: int =5,
     ) -> AssociationTableResults:
 
         query = build_association_table_query(


### PR DESCRIPTION
Adds sorting to the association table endpoint in the way that the UI is already expecting. It was implemented in the low level method already, but wasn't yet connected to the api method.

Fixes #246
