### PR TITLE
Link to all association table subjects/objects if not a self-link

### DIFF
--- a/frontend/src/pages/node/AssociationsSummary.vue
+++ b/frontend/src/pages/node/AssociationsSummary.vue
@@ -28,7 +28,7 @@
             name: item.subject_label,
             category: item.subject_category,
           }"
-          :link="node.id === item.object"
+          :link="node.id !== item.subject"
         />
         <AppPredicateBadge :association="item" :vertical="true" />
         <AppNodeBadge
@@ -37,7 +37,7 @@
             name: item.object_label,
             category: item.object_category,
           }"
-          :link="node.id === item.subject"
+          :link="node.id !== item.object"
         />
       </AppFlex>
 

--- a/frontend/src/pages/node/AssociationsTable.vue
+++ b/frontend/src/pages/node/AssociationsTable.vue
@@ -31,7 +31,7 @@
           name: row.subject_label,
           category: row.subject_category,
         }"
-        :link="node.id === row.object"
+        :link="node.id !== row.subject"
       />
     </template>
 
@@ -48,7 +48,7 @@
           name: row.object_label,
           category: row.object_category,
         }"
-        :link="node.id === row.subject"
+        :link="node.id !== row.object"
       />
     </template>
 


### PR DESCRIPTION
Fixes #267

Adds association links for either side of an association as long as it wouldn't be a self-link
