### PR TITLE
Update build-image.yaml, build docker image on release publish

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - main
+  release:
+    types: [published]
 
 # This job uses RafikFarhad's GitHub action to build and
 # push a docker image to a specified GCP repository


### PR DESCRIPTION
Does this look right for also building a docker image when we publish a release?  (now that the version number isn't changed as a commit)