### PR TITLE
Allow semsim compare of gene/disease by expanding to phenotype term sets

### DIFF
--- a/backend/src/monarch_py/api/entity.py
+++ b/backend/src/monarch_py/api/entity.py
@@ -1,8 +1,10 @@
+import logging
 from typing import List
 from fastapi import APIRouter, Depends, HTTPException, Query
 from monarch_py.api.additional_models import PaginationParams
 from monarch_py.api.config import solr
-from monarch_py.datamodels.model import AssociationTableResults, Node
+from monarch_py.datamodels.model import AssociationTableResults, Node, TermSetPairwiseSimilarity
+
 
 router = APIRouter(tags=["entity"], responses={404: {"description": "Not Found"}})
 
@@ -68,3 +70,50 @@ def _association_table(
         entity=id, category=category, q=query, sort=sort, offset=pagination.offset, limit=pagination.limit
     )
     return response
+
+@router.get("/{subject}/compare/{object}")
+def _entity_compare(
+        subject: str = Query(
+        ...,
+        description="ID for the entity to retrieve, ex: MONDO:0019391",
+        example="MONDO:0019391",
+    ),
+    object: str = Query(
+        ...,
+        description="ID for the entity to compare against, ex: MONDO:0007915",
+        example="MONDO:0007915",
+    ),
+) -> TermSetPairwiseSimilarity:
+    """Retrieves the entity with the specified id
+
+    Args:
+        subject (str): ID for the entity to retrieve, ex: MONDO:0019391
+        object (str): ID for the entity to compare against, ex: MONDO:0007915
+
+    Raises:
+        HTTPException: 404 if the entities are not found or if no phenotypes are found
+
+    Returns:
+        TermPairwiseSimilarity: Pairwise similarity between the phenotypes of subject and subject entities
+    """
+    categories = ["biolink:DiseaseToPhenotypicFeatureAssociation", "biolink:GeneToPhenotypicFeatureAssociation"]
+    subject = solr().get_entity(id=object, extra=False)
+    if subject is None:
+        raise HTTPException(status_code=404, detail=f"{subject} not found")
+    subject_associations = solr().get_associations(subject=subject, category=categories, limit=10000).items
+    if subject_associations is None:
+        raise HTTPException(status_code=404, detail=f"No phenotypes found for ${subject}")
+    subject_phenotypes = [association.object for association in subject_associations]
+
+    object = solr().get_entity(id=object, extra=False)
+    if object is None:
+        raise HTTPException(status_code=404, detail=f"{object} not found")
+    object_associations = solr().get_associations(subject=object, category=categories, limit=10000).items
+    if object_associations is None:
+        raise HTTPException(status_code=404, detail=f"No phenotypes found for ${object}")
+    object_phenotypes = [association.object for association in object_associations]
+
+    logging.debug(f"Comparing {subject} ({len(subject_phenotypes)} phenotypes) to {object} ({len(object_phenotypes)} phenotypes)")
+
+    return oak().compare(subjects=subject_phenotypes, objects=object_phenotypes)
+


### PR DESCRIPTION
Initially, this PR is adding /entity/<ID>/compare/<other ID>, which is a nice explicit compare that anchors itself to an an entity, but we likely also need to support expanding gene and disease IDs in the regular compare endpoints
