### PR TITLE
Add breadcrumb tracking for associations

### DIFF
--- a/frontend/src/components/AppDetail.vue
+++ b/frontend/src/components/AppDetail.vue
@@ -8,7 +8,7 @@
     align-h="left"
     direction="col"
     gap="small"
-    :class="['detail', { big }]"
+    :class="['detail', { full }]"
   >
     <AppFlex gap="small" align-h="left">
       <AppIcon v-if="icon" :icon="icon" class="icon" />
@@ -45,14 +45,14 @@ type Props = {
    */
   blank?: boolean;
   /** whether info block is full width or not */
-  big?: boolean;
+  full?: boolean;
 };
 
 withDefaults(defineProps<Props>(), {
   icon: "",
   count: undefined,
   blank: false,
-  big: false,
+  full: false,
 });
 
 type Slots = {
@@ -68,12 +68,11 @@ defineSlots<Slots>();
   line-height: $spacing;
   text-align: left;
 
-  &.big {
+  &.full {
     width: 100%;
   }
 
-  &:not(.big) {
-    /** keep in sync with AppDetails gap */
+  &:not(.full) {
     width: calc((100% - 30px) / 2);
   }
 

--- a/frontend/src/components/AppNodeBadge.vue
+++ b/frontend/src/components/AppNodeBadge.vue
@@ -21,7 +21,7 @@
       >{{ node.name || node.id }}</AppLink
     >
     <span v-else class="name">{{ node.name }}</span>
-    <span v-if="node.in_taxon_label"> ({{ node.info }})</span>
+    <span v-if="node.in_taxon_label"> ({{ node.in_taxon_label }})</span>
     <span v-if="node.info"> ({{ node.info }})</span>
   </span>
 </template>

--- a/frontend/src/components/AppNodeBadge.vue
+++ b/frontend/src/components/AppNodeBadge.vue
@@ -14,8 +14,8 @@
       v-if="!currentPage"
       :to="`/node/${node.id}`"
       :state="
-        breadcrumb
-          ? { breadcrumbs: [...breadcrumbs, breadcrumb] }
+        breadcrumbs
+          ? { breadcrumbs: [...currentBreadcrumbs, ...breadcrumbs] }
           : state || undefined
       "
       >{{ node.name || node.id }}</AppLink
@@ -30,7 +30,7 @@
 import { computed } from "vue";
 import { getCategoryIcon, getCategoryLabel } from "@/api/categories";
 import type { Node } from "@/api/model";
-import { breadcrumbs } from "@/global/breadcrumbs";
+import { breadcrumbs as currentBreadcrumbs } from "@/global/breadcrumbs";
 import type { Breadcrumb } from "@/global/breadcrumbs";
 
 type Props = {
@@ -42,10 +42,10 @@ type Props = {
   /** whether to include icon */
   icon?: boolean;
   /**
-   * breadcrumb object to add list when badge clicked on. include node that user
-   * came from and relation between that node and this node.
+   * breadcrumb objects to add list when badge clicked on. include node that
+   * user came from and relation between that node and this node.
    */
-  breadcrumb?: Breadcrumb;
+  breadcrumbs?: Breadcrumb[];
   /** state data to pass through to link component */
   state?: { [key: string]: unknown };
 };
@@ -53,7 +53,7 @@ type Props = {
 const props = withDefaults(defineProps<Props>(), {
   icon: true,
   link: true,
-  breadcrumb: undefined,
+  breadcrumbs: undefined,
   state: undefined,
 });
 

--- a/frontend/src/components/AppSelectMulti.vue
+++ b/frontend/src/components/AppSelectMulti.vue
@@ -115,7 +115,7 @@
             {{ option.label || option.id }}
           </span>
           <span
-            v-if="option.count && (allSelected || noneSelected)"
+            v-if="option.count !== undefined && showCounts"
             class="option-count"
           >
             {{ option.count }}
@@ -158,15 +158,20 @@ type Props = {
   options: Options;
   /** visual design */
   design?: "normal" | "small";
+  /** whether to show counts for each option */
+  showCounts?: boolean;
 };
 
 const props = withDefaults(defineProps<Props>(), {
   design: "normal",
+  showCounts: true,
 });
 
 type Emits = {
   /** two-way bound selected items state */
   "update:modelValue": [Options];
+  /** whether specific items are selected, and not all/none selected */
+  partial: [boolean];
   /** when value changed */
   input: [];
   /** when value change "submitted"/"committed" by user */
@@ -343,6 +348,15 @@ const allSelected = computed(
 
 /** are no options selected */
 const noneSelected = computed(() => !selected.value.length);
+
+/** update partial status */
+watch(
+  [allSelected, noneSelected],
+  () => {
+    emit("partial", !(allSelected.value || noneSelected.value));
+  },
+  { immediate: true },
+);
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/src/global/breadcrumbs.ts
+++ b/frontend/src/global/breadcrumbs.ts
@@ -3,8 +3,16 @@ import type { DirectionalAssociation, Node } from "@/api/model";
 import { parse } from "@/util/object";
 
 export type Breadcrumb = {
+  /** node we're coming from */
   node: Partial<Node>;
+  /** association between the previous node and the current node */
   association: Partial<DirectionalAssociation>;
+  /**
+   * whether breadcrumb doesn't have its own history entry (e.g. implicitly
+   * created sub-class association between current node and association
+   * subject)
+   */
+  noEntry?: boolean;
 };
 
 /** breadcrumbs object for breadcrumbs section on node page */

--- a/frontend/src/global/styles.scss
+++ b/frontend/src/global/styles.scss
@@ -234,7 +234,7 @@ strong {
 }
 
 /** for spans of text (not clickable, not links, not buttons) with tooltips */
-[data-tooltip="true"] {
+.tooltip {
   text-decoration: underline;
   text-decoration-style: dotted;
   text-underline-offset: 2px;

--- a/frontend/src/pages/explore/TabSearch.vue
+++ b/frontend/src/pages/explore/TabSearch.vue
@@ -27,7 +27,9 @@
           v-tooltip="`<i>${startCase(facet.label)}</i> filter`"
           :name="startCase(facet.label)"
           :options="dropdownsOptions[facet.label]"
+          :show-counts="!Object.values(dropdownsPartial).some(Boolean)"
           @change="onSelectedChange"
+          @partial="(value) => (dropdownsPartial[facet.label] = value)"
         />
       </template>
     </AppFlex>
@@ -55,11 +57,11 @@
         <AppNodeBadge
           :node="result"
           :state="{ fromSearch: search }"
-          class="name"
+          class="title-name"
         />
         <AppButton
           v-tooltip="'Node ID (click to copy)'"
-          class="id"
+          class="title-id"
           :text="result.id"
           icon="hashtag"
           design="small"
@@ -147,6 +149,8 @@ const facets = ref<NonNullable<SearchResults["facet_fields"]>>([]);
 const dropdownsOptions = ref<{ [key: string]: MultiOptions }>({});
 /** dropdowns selected options */
 const dropdownsSelected = ref<{ [key: string]: MultiOptions }>({});
+/** dropdowns partial status */
+const dropdownsPartial = ref<{ [key: string]: boolean }>({});
 
 /** when user focuses text box */
 async function onFocus() {
@@ -257,9 +261,11 @@ const {
       /** transform dropdown selected options into filters to search for */
       fresh
         ? undefined
-        : mapValues(dropdownsSelected.value, (dropdown) =>
-            dropdown.map((option) => option.id),
-          ),
+        : mapValues(dropdownsSelected.value, (dropdown, key) => {
+            if (dropdownsPartial.value[key])
+              return dropdown.map((option) => option.id);
+            else return [];
+          }),
     );
 
     return response;
@@ -377,35 +383,16 @@ watch(from, () => runGetSearch(false));
   text-align: left;
 }
 
-.name {
+.title-name {
   flex-grow: 1;
   flex-shrink: 0;
 }
 
-.header-box {
-  width: 300px;
-  max-width: 100%;
-}
-
-.header-box :deep(input) {
-  border-top-width: 0;
-  border-right-width: 0;
-  border-left-width: 0;
-  border-radius: 0;
-  border-color: currentColor;
-  background: none;
-  color: currentColor;
-}
-
-.header-box :deep(.icon) {
-  color: currentColor;
-}
-
-.name > :deep(svg) {
+.title-name > :deep(svg) {
   font-size: 2rem;
 }
 
-.id {
+.title-id {
   font-size: 0.9rem;
 }
 
@@ -437,6 +424,25 @@ watch(from, () => runGetSearch(false));
   &:hover {
     box-shadow: $outline;
   }
+}
+
+.header-box {
+  width: 300px;
+  max-width: 100%;
+}
+
+.header-box :deep(input) {
+  border-top-width: 0;
+  border-right-width: 0;
+  border-left-width: 0;
+  border-radius: 0;
+  border-color: currentColor;
+  background: none;
+  color: currentColor;
+}
+
+.header-box :deep(.icon) {
+  color: currentColor;
 }
 </style>
 

--- a/frontend/src/pages/node/AssociationsTable.vue
+++ b/frontend/src/pages/node/AssociationsTable.vue
@@ -279,15 +279,15 @@ const {
 /** download table data */
 async function download() {
   /** max rows to try to query */
-  const max = 100000;
+  const max = 100;
+  const total = associations.value.total;
 
   /** warn user */
   snackbar(
-    `Downloading data for ${Math.min(
-      associations.value.total,
+    `Downloading data for ${total > max ? "first " : ""}${Math.min(
+      total,
       max,
-    )} table entries.` +
-      (associations.value.total >= 100 ? " This may take a minute." : ""),
+    )} table entries.` + (total >= 100 ? " This may take a minute." : ""),
   );
 
   /** attempt to request all rows */

--- a/frontend/src/pages/node/AssociationsTable.vue
+++ b/frontend/src/pages/node/AssociationsTable.vue
@@ -106,7 +106,6 @@ import type { Option } from "@/components/AppSelectSingle.vue";
 import AppTable from "@/components/AppTable.vue";
 import type { Cols, Sort } from "@/components/AppTable.vue";
 import { snackbar } from "@/components/TheSnackbar.vue";
-import type { Breadcrumb } from "@/global/breadcrumbs";
 import { getBreadcrumbs } from "@/pages/node/AssociationsSummary.vue";
 import { useQuery } from "@/util/composables";
 import { downloadJson } from "@/util/download";
@@ -300,15 +299,6 @@ async function download() {
   );
   downloadJson(response);
 }
-
-/** extra link to put between current node and subject, if they are not the same */
-const superClass = computed<Breadcrumb>(() => ({
-  node: props.node,
-  association: {
-    predicate: "is super class of",
-    direction: AssociationDirectionEnum.outgoing,
-  },
-}));
 
 /** get associations when category or table state changes */
 watch(

--- a/frontend/src/pages/node/AssociationsTable.vue
+++ b/frontend/src/pages/node/AssociationsTable.vue
@@ -24,7 +24,7 @@
     :total="associations.total"
     @download="download"
   >
-    <!-- "subject" (current node) -->
+    <!-- subject -->
     <template #subject="{ row }">
       <AppNodeBadge
         :node="{
@@ -33,16 +33,16 @@
           category: row.subject_category,
           info: row.subject_taxon_label,
         }"
-        :link="node.id !== row.subject"
+        :breadcrumbs="getBreadcrumbs(node, row, 'subject')"
       />
     </template>
 
-    <!-- "predicate" (association/relation) -->
+    <!-- predicate -->
     <template #predicate="{ row }">
       <AppPredicateBadge :association="row" />
     </template>
 
-    <!-- "object" (what current node has an association with) -->
+    <!-- object-->
     <template #object="{ row }">
       <AppNodeBadge
         :node="{
@@ -51,7 +51,7 @@
           category: row.object_category,
           info: row.object_taxon_label,
         }"
-        :link="node.id !== row.object"
+        :breadcrumbs="getBreadcrumbs(node, row, 'object')"
       />
     </template>
 
@@ -106,6 +106,8 @@ import type { Option } from "@/components/AppSelectSingle.vue";
 import AppTable from "@/components/AppTable.vue";
 import type { Cols, Sort } from "@/components/AppTable.vue";
 import { snackbar } from "@/components/TheSnackbar.vue";
+import type { Breadcrumb } from "@/global/breadcrumbs";
+import { getBreadcrumbs } from "@/pages/node/AssociationsSummary.vue";
 import { useQuery } from "@/util/composables";
 import { downloadJson } from "@/util/download";
 
@@ -298,6 +300,15 @@ async function download() {
   );
   downloadJson(response);
 }
+
+/** extra link to put between current node and subject, if they are not the same */
+const superClass = computed<Breadcrumb>(() => ({
+  node: props.node,
+  association: {
+    predicate: "is super class of",
+    direction: AssociationDirectionEnum.outgoing,
+  },
+}));
 
 /** get associations when category or table state changes */
 watch(

--- a/frontend/src/pages/node/EvidenceViewer.vue
+++ b/frontend/src/pages/node/EvidenceViewer.vue
@@ -32,7 +32,7 @@
         title="Evidence Codes"
         :count="association.evidence_count"
         icon="flask"
-        :big="true"
+        :full="true"
       >
         <AppFlex gap="small" align-h="left">
           <span
@@ -57,7 +57,7 @@
         title="Publications"
         :count="association.publications?.length"
         icon="book"
-        :big="true"
+        :full="true"
       >
         <AppFlex gap="small" align-h="left">
           <span

--- a/frontend/src/pages/node/HistoPheno.vue
+++ b/frontend/src/pages/node/HistoPheno.vue
@@ -6,7 +6,14 @@
   >
 
   <!-- results -->
-  <Apex v-if="series.length" type="bar" :options="options" :series="series" />
+  <Apex
+    v-if="series[0]?.data?.length"
+    type="bar"
+    :options="options"
+    :series="series"
+  />
+
+  <div v-else>No info</div>
 </template>
 
 <script setup lang="ts">
@@ -84,7 +91,9 @@ const {
 } = useQuery(
   async function () {
     const histopheno = await getHistoPheno(props.node.id || "");
-    const data = histopheno.items?.map((d) => ({ x: d.label, y: d.count }));
+    const data = histopheno.items
+      ?.map((d) => ({ x: d.label, y: d.count }))
+      ?.filter((d) => d.y);
     return [{ name: "phenotypes", data: data }];
   },
 

--- a/frontend/src/pages/node/SectionAssociations.vue
+++ b/frontend/src/pages/node/SectionAssociations.vue
@@ -6,8 +6,12 @@
   <AppSection>
     <AppHeading icon="arrows-left-right">Associations</AppHeading>
 
+    <span v-if="!categoryOptions.length"
+      >No associations with &nbsp;<AppNodeBadge :node="node" />
+    </span>
+
     <!-- select -->
-    <AppFlex gap="small">
+    <AppFlex v-else gap="small">
       <span
         >Associations between &nbsp;<AppNodeBadge :node="node" />&nbsp;
         and</span

--- a/frontend/src/pages/node/SectionBreadcrumbs.vue
+++ b/frontend/src/pages/node/SectionBreadcrumbs.vue
@@ -8,11 +8,13 @@
     >
 
     <AppFlex direction="col">
-      <template v-for="(breadcrumb, index) of breadcrumbs" :key="index">
+      <template v-for="(breadcrumb, index) of _breadcrumbs" :key="index">
         <!-- node -->
         <AppNodeBadge
+          v-tooltip="`Go ${-breadcrumb.back} step(s) back`"
           :node="breadcrumb.node"
-          @click.prevent.capture="$router.go(-breadcrumbs.length + index)"
+          :style="{ opacity: breadcrumb.noEntry ? 0.5 : 1 }"
+          @click.prevent.capture="$router.go(breadcrumb.back)"
         />
         <!-- predicate -->
         <AppPredicateBadge
@@ -41,7 +43,7 @@
 </template>
 
 <script setup lang="ts">
-import { watch } from "vue";
+import { computed, watch } from "vue";
 import { useRoute } from "vue-router";
 import { AssociationDirectionEnum, type Node } from "@/api/model";
 import AppNodeBadge from "@/components/AppNodeBadge.vue";
@@ -57,6 +59,19 @@ defineProps<Props>();
 
 /** route info */
 const route = useRoute();
+
+/**
+ * breadcrumbs, plus computed "back" prop to tell how many history steps to go
+ * back when clicked
+ */
+const _breadcrumbs = computed(() => {
+  let back =
+    -breadcrumbs.value.filter((breadcrumb) => !breadcrumb.noEntry).length - 1;
+  return breadcrumbs.value.map((breadcrumb) => ({
+    ...breadcrumb,
+    back: breadcrumb.noEntry ? back : ++back,
+  }));
+});
 
 /** keep breadcrumbs global variable in sync with history.state.breadcrumbs */
 watch(() => route, updateBreadcrumbs, { immediate: true, deep: true });

--- a/frontend/src/pages/node/SectionDetails.vue
+++ b/frontend/src/pages/node/SectionDetails.vue
@@ -33,7 +33,7 @@
       <AppDetail
         :blank="!node.external_links"
         title="External References"
-        :big="true"
+        :full="true"
       >
         <AppFlex align-h="left" gap="small">
           <AppLink

--- a/frontend/src/pages/node/SectionHierarchy.vue
+++ b/frontend/src/pages/node/SectionHierarchy.vue
@@ -12,7 +12,7 @@
         title="Super-classes"
         icon="angle-up"
         :blank="!node.node_hierarchy?.super_classes.length"
-        :big="true"
+        :full="true"
         :v-tooltip="`Nodes that are &quot;parents&quot; of this node`"
       >
         <AppFlex class="flex" align-h="left" gap="small">
@@ -38,7 +38,7 @@
         title="Sub-classes"
         icon="angle-down"
         :blank="!node.node_hierarchy?.sub_classes.length"
-        :big="true"
+        :full="true"
         :v-tooltip="`Nodes that are &quot;children&quot; of this node`"
       >
         <AppFlex class="flex" align-h="left" gap="small">

--- a/frontend/src/pages/node/SectionHierarchy.vue
+++ b/frontend/src/pages/node/SectionHierarchy.vue
@@ -20,13 +20,15 @@
             v-for="(_class, index) in node.node_hierarchy?.super_classes"
             :key="index"
             :node="_class"
-            :breadcrumb="{
-              node,
-              association: {
-                predicate: 'is super class of',
-                direction: AssociationDirectionEnum.incoming,
+            :breadcrumbs="[
+              {
+                node,
+                association: {
+                  predicate: 'is super class of',
+                  direction: AssociationDirectionEnum.incoming,
+                },
               },
-            }"
+            ]"
           />
         </AppFlex>
       </AppDetail>
@@ -44,10 +46,12 @@
             v-for="(_class, index) in node.node_hierarchy?.sub_classes"
             :key="index"
             :node="_class"
-            :breadcrumb="{
-              node,
-              association: { predicate: 'is sub class of' },
-            }"
+            :breadcrumbs="[
+              {
+                node,
+                association: { predicate: 'is sub class of' },
+              },
+            ]"
           />
         </AppFlex>
       </AppDetail>

--- a/frontend/src/pages/node/SectionOverview.vue
+++ b/frontend/src/pages/node/SectionOverview.vue
@@ -7,11 +7,6 @@
     <AppHeading icon="lightbulb">Overview</AppHeading>
 
     <AppDetails>
-      <!-- synonyms -->
-      <AppDetail :blank="!node.synonym?.length" title="Also Known As">
-        <p v-html="node.synonym?.join(',\n&nbsp;')"></p>
-      </AppDetail>
-
       <!-- symbol (gene specific) -->
       <AppDetail
         v-if="node.category === 'biolink:Gene'"
@@ -28,8 +23,17 @@
         </AppLink>
       </AppDetail>
 
+      <!-- synonyms -->
+      <AppDetail
+        :blank="!node.synonym?.length"
+        title="Also Known As"
+        :full="true"
+      >
+        <p v-html="node.synonym?.join(',\n&nbsp;')"></p>
+      </AppDetail>
+
       <!-- paragraph description -->
-      <AppDetail :blank="!node.description" title="Description" :big="true">
+      <AppDetail :blank="!node.description" title="Description" :full="true">
         <p
           v-tooltip="'Click to expand'"
           class="description truncate-10"


### PR DESCRIPTION
- add back in breadcrumb tracking for associations, including adding "implicit" association/link when clicking on a subject/object that is not the current node but instead a sub-class of it.
- to breadcrumb section, add tooltips for "steps backward in history", and fade "implicit" breadcrumbs.
- fix some css class name collisions from a previous PR
- fix blank () taxon label in node badge component
- fix search filtering. dont pass param to api at all if all/none selected. re-introduce showCounts prop in multi select component to allow global showCounts instead of per-instance showCounts.
- add explicit blank messages for histopheno and association counts sections