### PR TITLE
better response when entity not found

### DIFF
--- a/backend/src/monarch_py/implementations/solr/solr_implementation.py
+++ b/backend/src/monarch_py/implementations/solr/solr_implementation.py
@@ -92,8 +92,8 @@ class SolrImplementation(EntityInterface, AssociationInterface, SearchInterface)
             [ExpandedCurie(id=curie, url=CurieService().expand(curie)) for curie in node.xref] if node.xref else []
         )
         node.provided_by_link = ExpandedCurie(
-            id=node.provided_by.replace("_nodes", "").replace("_edges", "") if node.provided_by else None
-            , url=get_provided_by_link(node.provided_by)
+            id=node.provided_by.replace("_nodes", "").replace("_edges", "") if node.provided_by else None,
+            url=get_provided_by_link(node.provided_by),
         )
         return node
 
@@ -320,8 +320,12 @@ class SolrImplementation(EntityInterface, AssociationInterface, SearchInterface)
             offset=0,
             total=query_result.response.num_found,
             items=[],
-            facet_fields=convert_facet_fields(query_result.facet_counts.facet_fields) if query_result.facet_counts else [],
-            facet_queries=convert_facet_queries(query_result.facet_counts.facet_queries) if query_result.facet_counts else [],
+            facet_fields=convert_facet_fields(query_result.facet_counts.facet_fields)
+            if query_result.facet_counts
+            else [],
+            facet_queries=convert_facet_queries(query_result.facet_counts.facet_queries)
+            if query_result.facet_counts
+            else [],
         )
 
     def get_association_table(

--- a/backend/src/monarch_py/service/solr_service.py
+++ b/backend/src/monarch_py/service/solr_service.py
@@ -20,8 +20,8 @@ class SolrService(BaseModel):
         entity = response.json()["doc"]
         try:
             self._strip_json(entity, "_version_")
-        except TypeError:
-            pass  # what if entity is None?
+        except TypeError:  # if entity is None
+            return None
         return entity
 
     def query(self, q: SolrQuery) -> SolrQueryResult:
@@ -53,7 +53,6 @@ class SolrService(BaseModel):
         return dict(zip(facet_list[::2], facet_list[1::2]))
 
     def get_filtered_facet(self, id, filter_field, facet_field):
-
         query = SolrQuery(
             rows=0,
             facet=True,

--- a/backend/src/monarch_py/solr_cli.py
+++ b/backend/src/monarch_py/solr_cli.py
@@ -112,9 +112,13 @@ def entity(
     if not id:
         console.print("\n[bold red]Entity ID required.[/]\n")
         raise typer.Exit(1)
-    data = get_solr(update=False)
-    response = data.get_entity(id, extra)
-    format_output(fmt, response, output)
+    solr = get_solr(update=False)
+    response = solr.get_entity(id, extra)
+    if response is not None:
+        format_output(fmt, response, output)
+    else:
+        console.print(f"\n[bold red]Entity {id} not found.[/]\n")
+        raise typer.Exit(1)
 
 
 @solr_app.command("associations")
@@ -160,8 +164,8 @@ def associations(
     args.pop("fmt", None)
     args.pop("output", None)
 
-    data = get_solr(update=False)
-    response = data.get_associations(**args)
+    solr = get_solr(update=False)
+    response = solr.get_associations(**args)
     format_output(fmt, response, output)
 
 
@@ -201,8 +205,8 @@ def search(
     params.pop("fmt", None)
     params.pop("output", None)
 
-    data = get_solr(update=False)
-    response = data.search(**params)
+    solr = get_solr(update=False)
+    response = solr.search(**params)
     format_output(fmt, response, output)
 
 
@@ -226,8 +230,8 @@ def autocomplete(
         output: The path to the output file (stdout if not specified)
 
     """
-    data = get_solr(update=False)
-    response = data.autocomplete(q)
+    solr = get_solr(update=False)
+    response = solr.autocomplete(q)
     format_output(fmt, response, output)
 
 
@@ -258,8 +262,8 @@ def histopheno(
         console.print("\n[bold red]Subject ID required.[/]\n")
         raise typer.Exit(1)
 
-    data = get_solr(update=False)
-    response = data.get_histopheno(subject)
+    solr = get_solr(update=False)
+    response = solr.get_histopheno(subject)
     format_output(fmt, response, output)
 
 
@@ -288,8 +292,8 @@ def association_counts(
     if not entity:
         console.print("\n[bold red]Entity ID required.[/]\n")
         raise typer.Exit(1)
-    data = get_solr(update=False)
-    response = data.get_association_counts(entity)
+    solr = get_solr(update=False)
+    response = solr.get_association_counts(entity)
     format_output(fmt, response, output)
 
 
@@ -311,6 +315,6 @@ def association_table(
     ),
     output: str = typer.Option(None, "--output", "-o", help="The path to the output file"),
 ):
-    data = get_solr(update=False)
-    response = data.get_association_table(entity=entity, category=category, q=q, limit=limit, offset=offset)
+    solr = get_solr(update=False)
+    response = solr.get_association_table(entity=entity, category=category, q=q, limit=limit, offset=offset)
     format_output(fmt, response, output)

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -51,7 +51,7 @@ if (apiName === "production")
 if (apiName === "relative") monarch = suffix;
 
 /** locally running server */
-if (apiName === "local") monarch = `127.0.0.1:8000${suffix}`;
+if (apiName === "local") monarch = `http://127.0.0.1:8000${suffix}`;
 
 export { monarch };
 


### PR DESCRIPTION
Addresses #297 

- `SolrImplementation.get_entity()` now returns None if an entity is not found, previously no TypeError handling 
- FastAPI still returns 404 
- Also fix #307 
