### PR TITLE
drop /docs from link to API in about section

### DIFF
--- a/frontend/src/pages/about/PageAbout.vue
+++ b/frontend/src/pages/about/PageAbout.vue
@@ -34,7 +34,7 @@
         subtitle="How all the pieces of Monarch fit together"
       />
       <AppTile
-        to="https://monarch-app.monarchinitiative.org/docs/"
+        to="https://monarch-app.monarchinitiative.org/"
         icon="code"
         title="API"
         subtitle="The API serving this website"


### PR DESCRIPTION
Since we're not hosting the site from GH Pages anymore, the API documentation no longer lives at `m-app.mi.org/docs`

This PR just drops the `/docs` part so that it successfully links