### PR TITLE
Make all oaklib & fastapi non-optional

### DIFF
--- a/.github/workflows/test-backend.yaml
+++ b/.github/workflows/test-backend.yaml
@@ -34,7 +34,7 @@ jobs:
       #    install your root project, if required
       #----------------------------------------------
       - name: Install library
-        run: poetry -C backend install --no-interaction -E api 
+        run: poetry -C backend install --no-interaction
 
       #----------------------------------------------
       #              run pytest

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ install: install-backend install-frontend
 .PHONY: install-backend
 install-backend:
 	cd backend && \
-		poetry install -E api --with dev
+		poetry install --with dev
 
 
 .PHONY: install-frontend

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,6 +1,6 @@
 # Monarch-Py
 
-[![documentation](https://img.shields.io/badge/-Documentation-purple?logo=read-the-docs&logoColor=white&style=for-the-badge)](https://monarch-initiative.github.io/monarch-app/docs)
+[![documentation](https://img.shields.io/badge/-Documentation-purple?logo=read-the-docs&logoColor=white&style=for-the-badge)](https://monarch-initiative.github.io/monarch-app)
 
 Monarch-Py is a Python library for interfacing with the Monarch Initiative Knowledge graph.  
 It can be used from CLI, as a module, or as a FastAPI app

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -656,7 +656,7 @@ importlib-resources = {version = ">=5.0", markers = "python_version < \"3.10\""}
 name = "fastapi"
 version = "0.87.0"
 description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
-optional = true
+optional = false
 python-versions = ">=3.7"
 files = [
     {file = "fastapi-0.87.0-py3-none-any.whl", hash = "sha256:254453a2e22f64e2a1b4e1d8baf67d239e55b6c8165c079d25746a5220c81bb4"},
@@ -2057,13 +2057,13 @@ files = [
 
 [[package]]
 name = "oaklib"
-version = "0.5.18rc2"
+version = "0.5.19"
 description = "Ontology Access Kit: Python library for common ontology operations over a variety of backends"
 optional = false
 python-versions = ">=3.9,<4.0.0"
 files = [
-    {file = "oaklib-0.5.18rc2-py3-none-any.whl", hash = "sha256:6169ad584ac34490ab90b62d0adf82920a52fa9ab3a3645d479b33fba8d66e3e"},
-    {file = "oaklib-0.5.18rc2.tar.gz", hash = "sha256:628b3903f99a0b58466af9fbbb896cb65bacf18094f3b6a246174decaf0044e7"},
+    {file = "oaklib-0.5.19-py3-none-any.whl", hash = "sha256:b2a1ecbbb48c136e1af819a12ed060261de030c222b1d93192e22f975eee370e"},
+    {file = "oaklib-0.5.19.tar.gz", hash = "sha256:f83e8fef748d992eb61089443b93516479ed13e41433f2f4e33bd819cd8fc446"},
 ]
 
 [package.dependencies]
@@ -2090,7 +2090,7 @@ pysolr = ">=3.9.0,<4.0.0"
 pystow = ">=0.5.0"
 ratelimit = ">=2.2.1"
 requests-cache = ">=1.0.1,<2.0.0"
-semsimian = "0.2.4"
+semsimian = "0.2.1"
 semsql = ">=0.3.1"
 SPARQLWrapper = "*"
 SQLAlchemy = ">=1.4.32"
@@ -3418,46 +3418,46 @@ urllib3 = {version = ">=1.26,<3", extras = ["socks"]}
 
 [[package]]
 name = "semsimian"
-version = "0.2.4"
+version = "0.2.1"
 description = ""
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "semsimian-0.2.4-cp310-cp310-macosx_10_7_x86_64.whl", hash = "sha256:c61a087e972e8f4f66e72e9e2862b59d702b433db77b8ab765d3d36ce7a1cf5a"},
-    {file = "semsimian-0.2.4-cp310-cp310-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:03903b17db0eced413b884a82cd06b4a9e36e66d80a9f86bd46de72c8385e5d1"},
-    {file = "semsimian-0.2.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9e1bee43046091ef2e492e737c444b54c89fa60701ab5f7e2f8c1390b85dda3d"},
-    {file = "semsimian-0.2.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:198092326da43d1c7238701ab6d235107824a118d7cc424a6a533f71b280e037"},
-    {file = "semsimian-0.2.4-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:bf0361fc0e3acdb83dc7a1348b40722558f487867f826c6ba5f2abdb7c6efa73"},
-    {file = "semsimian-0.2.4-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:c0ba64d9edd10140001b021eeeea0d19195601754cbc850980625c98213149da"},
-    {file = "semsimian-0.2.4-cp310-none-win_amd64.whl", hash = "sha256:eceb855cf445b2bc7c401f747da1dbe59b8ebb1d55cc9c585e53296309efa0d5"},
-    {file = "semsimian-0.2.4-cp311-cp311-macosx_10_7_x86_64.whl", hash = "sha256:dacfa82552baee3f2cf74c9a52dd66a63b729178a391daba653ff38ad2e244c3"},
-    {file = "semsimian-0.2.4-cp311-cp311-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:e013fd2d20e1bf4d88970e52165ce22bb1db76d7c2fdfdfb4287ed8960d45ec8"},
-    {file = "semsimian-0.2.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cc65cbdce243dc94292a8a87b29cedcd1227ffb04a0a9d9f6dd6b448fbffd9d2"},
-    {file = "semsimian-0.2.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4759cda43815af3022eb8fa9a2e7b6c792b83b1fe55b86b31d3e6b5dcafffac3"},
-    {file = "semsimian-0.2.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:169adfb44cde5b24b104a5ff039f9f66a4a64f4aba5a8e74b04c9880b689f2c9"},
-    {file = "semsimian-0.2.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:a22bf5c3dd2d71dd5ed90dab5dc1eac307db57ca8757904f90dd518b137e22f4"},
-    {file = "semsimian-0.2.4-cp311-none-win_amd64.whl", hash = "sha256:11b8641273a8a6462ace1b48e8405ae0ee9f7800a9db779f6520674c102e9558"},
-    {file = "semsimian-0.2.4-cp37-cp37m-macosx_10_7_x86_64.whl", hash = "sha256:5235a979d101e9adc356c00b2191106eb3fffb08452eed2a4e98565319a10908"},
-    {file = "semsimian-0.2.4-cp37-cp37m-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:264ae5226d53b5b2a187e279a4f0e6a79218a2c1818c63578f887fff33d55f23"},
-    {file = "semsimian-0.2.4-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9538f6be58b981573f307805f8d83ef8da971630b1dbf3610eef34dee0097439"},
-    {file = "semsimian-0.2.4-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f5fbfd3d31c4e01827651848111c49a79ed7455c9e660a556c7eccaad7272a90"},
-    {file = "semsimian-0.2.4-cp37-cp37m-musllinux_1_2_aarch64.whl", hash = "sha256:62b663151ad467e839229c036630ab89ddcd4b3b2534fa0a411c0426d326662e"},
-    {file = "semsimian-0.2.4-cp37-cp37m-musllinux_1_2_x86_64.whl", hash = "sha256:02ef298f9280acf91453b62d907385425680a9904480a07818159b801e068f9b"},
-    {file = "semsimian-0.2.4-cp37-none-win_amd64.whl", hash = "sha256:4696397b6a64a9a5522c9f13c30a218523b9d87c51fa20161ea06ec5dbd6ef10"},
-    {file = "semsimian-0.2.4-cp38-cp38-macosx_10_7_x86_64.whl", hash = "sha256:14a3d8bda1f1715809876ec44aa700e14408b91598e106ad90cb0c89971eb077"},
-    {file = "semsimian-0.2.4-cp38-cp38-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:5f9957ffbaaa8c8dac5c2dd166b0b99e527333707048468e3ff47a2a42387cea"},
-    {file = "semsimian-0.2.4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9b1e3cc8e37429d50f6b2f87328f7f8cd74ac3b1fd042243197ce05072108bb8"},
-    {file = "semsimian-0.2.4-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd36cd6f16c64154dccad2283318ccf6dd856b0d0300388ea3c595f0b333905a"},
-    {file = "semsimian-0.2.4-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:e5b4ae7338a8fc75aae1bed3ae816553e42463b527a032f2ba3610d08ffbc96f"},
-    {file = "semsimian-0.2.4-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:1d75ed9d405531105433323ec55b0e5db725b7b8c8d11d023a1dd91c281c1fce"},
-    {file = "semsimian-0.2.4-cp38-none-win_amd64.whl", hash = "sha256:3936a84528834ad3cc078926c4d177a51bf71499b6891da2be8e6f889b988d3e"},
-    {file = "semsimian-0.2.4-cp39-cp39-macosx_10_7_x86_64.whl", hash = "sha256:a3feeff147f79a0535baadc0a6badcfde502b75dbc0d693cf9288f4651983b34"},
-    {file = "semsimian-0.2.4-cp39-cp39-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:1b37805e081fd4e70fee8ebf4f2e9832484dc63a159b887e0b1dbb80d007440e"},
-    {file = "semsimian-0.2.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1c250cd3781b9acfb0a76865a78991a8eb672968a510806bde408d447cf0517c"},
-    {file = "semsimian-0.2.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f0f85b6b776ddc5058167b98e91a79bc5df1cc193694a02d66b54b71fe9516f"},
-    {file = "semsimian-0.2.4-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:32aa8fca4ac120aaa98fbd8e48878a3f7993844afeab9394edb42b471b149094"},
-    {file = "semsimian-0.2.4-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:d6515e54be9d6c839da23474f02c39e219f0b9abe3ed9469243e3537460d3902"},
-    {file = "semsimian-0.2.4-cp39-none-win_amd64.whl", hash = "sha256:2876a4de38ab4bd60cfee2ae16d4874415be8604ae0ca30b6766a281dd721542"},
+    {file = "semsimian-0.2.1-cp310-cp310-macosx_10_7_x86_64.whl", hash = "sha256:9bae2b1023677c0e4a0fb830830418062b82c56ef198f51b92fe745a664f3686"},
+    {file = "semsimian-0.2.1-cp310-cp310-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:8ecc3d871c4c790c1e5ac8cea128f04755a528ff0eb35c16752151cb96649b6e"},
+    {file = "semsimian-0.2.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b6e1aa442173188cbbb2807e934e101cc9f8bac04c02a83c9e2216b09585707"},
+    {file = "semsimian-0.2.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7382a832c14f0e50fd90ad6ca324daa4a0c7bc8a9e6186700d3f1026a519babf"},
+    {file = "semsimian-0.2.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:862c40d534a3dafa755d0cd5d405a0ec7a05362190061e15030ef1dc4afdffc0"},
+    {file = "semsimian-0.2.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:847a909c6781e2134ea2c453fb7fa6342ba7f88167828efe944ad7d4fb3eef9a"},
+    {file = "semsimian-0.2.1-cp310-none-win_amd64.whl", hash = "sha256:a3c2d6b28d052f4a28a549ab04a550027368f92a9394eb1cbccea2f53ee24f35"},
+    {file = "semsimian-0.2.1-cp311-cp311-macosx_10_7_x86_64.whl", hash = "sha256:e1e4157c4643bda16a5264eabac96c170b8dcb2f7ebed8ca9d3842be8c1372a5"},
+    {file = "semsimian-0.2.1-cp311-cp311-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:2fed3c58f2ecd4f20f213fa5fee3cb7853d482e831037374f9019bfe882b5854"},
+    {file = "semsimian-0.2.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7cc341ea5575dbeea24d99d111c87ecc7a184069882816d6db45457f6aac9947"},
+    {file = "semsimian-0.2.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1fcc12b328ffdd9f19193e09dfc742921c2602f42fc8eae03d2cbf5bef4ea127"},
+    {file = "semsimian-0.2.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:3e9747baa1b15bf85f55b1be183f4beb5e03a3e1e99a9ed4985a35975341aad2"},
+    {file = "semsimian-0.2.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:62d71c7da78fa0aa659f3cfe40b36fff0d2cecc1e387081c1a33c53d82c78b6a"},
+    {file = "semsimian-0.2.1-cp311-none-win_amd64.whl", hash = "sha256:843624749359c47ddded38c667457dc246cb28df87e7d37c86a82cc927750f13"},
+    {file = "semsimian-0.2.1-cp37-cp37m-macosx_10_7_x86_64.whl", hash = "sha256:f678b1b1ff16f1a00618c0ba43d06b009aaf034f6c449fc2129b361a6c673716"},
+    {file = "semsimian-0.2.1-cp37-cp37m-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:ce32899a12e8d720c4e433b78c47163d831e047cf170150e000eb5cf1f1fd8e5"},
+    {file = "semsimian-0.2.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7a4d057eb75c4f1c434f5015fe80656ab86e76fb655cb80a63d09d7abc88c24f"},
+    {file = "semsimian-0.2.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8a9ece04aebfe3f36830b4e50f4272e71a9d9eb6721109778ab8227997ba92fa"},
+    {file = "semsimian-0.2.1-cp37-cp37m-musllinux_1_2_aarch64.whl", hash = "sha256:a256d815091073d8c81451d81e11b4bbf550e3f83c1ef90a4dc9fae9756aff76"},
+    {file = "semsimian-0.2.1-cp37-cp37m-musllinux_1_2_x86_64.whl", hash = "sha256:ef331045ee8157b434a149493e493503846eed59eb16f2b3511fe22a2a9100bf"},
+    {file = "semsimian-0.2.1-cp37-none-win_amd64.whl", hash = "sha256:d858d2a958830bc206ddbb02899fe631965edd8e907c27bc9edebd22833adc06"},
+    {file = "semsimian-0.2.1-cp38-cp38-macosx_10_7_x86_64.whl", hash = "sha256:e81c6bed28497ba280b2a6b6d089b8c45cb19fde54b2b031136e6fc415c48b62"},
+    {file = "semsimian-0.2.1-cp38-cp38-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:777b1ceb01167a6516743f178410de786176cff55dbdf13c9a3caa0ddadaf4da"},
+    {file = "semsimian-0.2.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9778187a8d85a7984e1e82e04204d2948f1dc4eab5f19ef01900725f2f6043d1"},
+    {file = "semsimian-0.2.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0607a1d822434467494b735361791d21a0ea101136e4ffd1ef2560a9fb6bbe06"},
+    {file = "semsimian-0.2.1-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:8acb08944deebda272e45b98f89cd5a6b3e287a8c794bcdc185de1f45a32a5d4"},
+    {file = "semsimian-0.2.1-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:5786dec6d2ea9bbc3765925c0726ee861c359f9c607b7be576b0c9c5da55790a"},
+    {file = "semsimian-0.2.1-cp38-none-win_amd64.whl", hash = "sha256:b9ba29ba3198c81431791e4ab36589a6ab6013d32407db6ce9cb182feceb83a8"},
+    {file = "semsimian-0.2.1-cp39-cp39-macosx_10_7_x86_64.whl", hash = "sha256:1b9dd3bcfa22c77dad95b05b39198edd54199a4b1ebe3bdedb17cccb38d36e0b"},
+    {file = "semsimian-0.2.1-cp39-cp39-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:d8baab2fea8082a8aceae6f896e4b29b3ab101c0009b937f17cf8e706435cd21"},
+    {file = "semsimian-0.2.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:716abdb2acc20199145954c3bf80c6bfc3ea172d4c9c21fc930b56f3a3eb8bff"},
+    {file = "semsimian-0.2.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b25d43736c7286f88d67d7a1cfd5b02f5a6e1e38ba6a177b3c455a44c4029dd3"},
+    {file = "semsimian-0.2.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:842337d6fc213ee1070378d1d0254762afb28973459eb9c06ba5ada5818be475"},
+    {file = "semsimian-0.2.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:953a28dd1e1456327a7e9e83b0db1ed52c3ed1700a93f34a49d5b5570474c7d1"},
+    {file = "semsimian-0.2.1-cp39-none-win_amd64.whl", hash = "sha256:b77564df0f96a4898d47086545e711d66c57dc13e674e89389cb3c8ef9837099"},
 ]
 
 [[package]]
@@ -3932,7 +3932,7 @@ mkdocs-mermaid2-plugin = ">=0.6.0,<0.7.0"
 name = "starlette"
 version = "0.21.0"
 description = "The little ASGI library that shines."
-optional = true
+optional = false
 python-versions = ">=3.7"
 files = [
     {file = "starlette-0.21.0-py3-none-any.whl", hash = "sha256:0efc058261bbcddeca93cad577efd36d0c8a317e44376bcfc0e097a2b3dc24a7"},
@@ -4519,10 +4519,7 @@ files = [
 docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
 testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-ignore-flaky", "pytest-mypy (>=0.9.1)", "pytest-ruff"]
 
-[extras]
-api = ["fastapi", "oaklib"]
-
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "af0cf9328a1afb86e0d48fd324b5d823153bffe0ffcc8e7608b5e68affd012c6"
+content-hash = "d4562850476f9aa21184806df4d8eb8fd8082bdd4d4909379ff137aabfeacccf"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -28,9 +28,8 @@ rich = "*"
 docker = "^6.0.1"
 pystow = ">=0.5.0"
 loguru = "*"
-### Optional API dependencies
-fastapi ={ version = "^0.87.0", optional = true }
-oaklib = "0.5.18rc2"
+fastapi = "^0.87.0"
+oaklib = "^0.5.19"
 
 
 [tool.poetry.group.dev.dependencies]
@@ -47,13 +46,9 @@ habanero = "*"
 manubot = "*"
 
 
-[tool.poetry.extras]
-api = ["fastapi", "oaklib"]
-
-
 [tool.poetry.scripts]
 monarch = "monarch_py.cli:app"
-monarch-api = { callable = "monarch_py.api.main:run", extras = ["api"] }
+monarch-api = { callable = "monarch_py.api.main:run"}
 
 
 [tool.ruff]


### PR DESCRIPTION
Fixes #316 

- [x] Move oaklib and fastapi to core dependencies
- [x] Update install commands in makefile and github actions
- [x] Update link to documentation in backend readme
- [ ] Anything else?