### PR TITLE
tweak unit test setup funcs

### DIFF
--- a/frontend/unit/setup.ts
+++ b/frontend/unit/setup.ts
@@ -2,27 +2,14 @@ import { nextTick } from "vue";
 import type { Component } from "vue";
 import { cloneDeep } from "lodash";
 import { setupServer } from "msw/node";
-import { afterAll, afterEach, beforeAll, beforeEach, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, vi } from "vitest";
 import type { ComponentMountingOptions, VueWrapper } from "@vue/test-utils";
 import { mount as _mount } from "@vue/test-utils";
 import components from "@/global/components";
 import plugins from "@/global/plugins";
-import router from "@/router";
 import { sleep } from "@/util/debug";
 import { handlers } from "../fixtures";
 import "@/global/icons";
-
-/** run before each test */
-beforeEach(async () => {
-  /** set default route and wait until ready */
-  await router.push("/");
-  await router.isReady();
-});
-
-/** https://github.com/vuejs/router/issues/615 */
-afterAll(async () => {
-  await sleep();
-});
 
 /** setup mock-service-worker */
 const server = setupServer(...handlers);
@@ -33,13 +20,14 @@ afterAll(() => server.close());
 /** util function to wait for api calls to mock */
 export const apiCall = async (): Promise<void> => {
   /**
-   * wait for mocks to finish. why two "flushPromises" calls? see:
+   * wait for mocks to finish. multiple sleeps needed because msw wraps
+   * callbacks in multiple promises. more arbitrary sleeps may be needed in
+   * future, depending on msw implementation details. see:
    * https://github.com/vuejs/test-utils/issues/137
    */
   await sleep();
   await sleep();
-  /** extra buffer time to make extra sure mocks finish */
-  await sleep(10);
+  await sleep();
 };
 
 /** mount wrapper with standard options */


### PR DESCRIPTION
Addresses #315 

I've done extensive testing with [tmate on github actions](https://github.com/mxschmitt/action-tmate), messing with sleep locations/counts, package versions, test setup/teardown, logging at various places, etc. I also managed to reproduce the bug locally, seemingly by updating all packages, clearing yarn cache, and reinstalling (even though I'm fairly sure I did this before).

I'm more certain now that the error is due to `msw` arbitrarily wrapping things in promises. Now the magic number of sleeps seems to be 3, and may need to be increased in the future depending on `msw` implementation details. I've added a comment about this. I've also determined I could get rid of some test setup/teardown functions.