### PR TITLE
Proxies API requests made to nginx to the API container

### DIFF
--- a/services/nginx/config/default.conf
+++ b/services/nginx/config/default.conf
@@ -1,12 +1,43 @@
+upstream api {
+    server api:8000;
+}
 server {
     listen 80 default_server;
     listen [::]:80 default_server;
 
-    server_name  localhost;
+    server_name  _;
 
     location / {
         root /var/www;
         index index.html;
         try_files $uri /index.html;
+    }
+
+    # redirect requests incorrectly made to /api/blah to /v3/api/blah
+    location ~ ^(/api) {
+        # nginx's default behavior (absolute_redirect: on) is to construct and
+        # send back a full URL when redirecting, but we just need a relative
+        # redirect to the same origin, so i've turned off absolute_redirect.
+        # since it's running in a container it's not necessarily aware of how to
+        # construct the full URL anyway.
+        absolute_redirect off;
+
+        return 302 /v3$request_uri;
+    }
+
+    location ~ ^(/openapi.json$|/v3/) {
+        # proxy requests to upstream api
+        proxy_pass http://api;
+
+        # pass request headers to upstream
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+        # upgrade http
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
     }
 }


### PR DESCRIPTION
Currently, the nginx container just serves the frontend as a static bundle. This PR adds proxying of `/openapi.json` and any path starting with `/v3/` to the API container, with all other requests being handled by the frontend. Requests to anything starting with `/api` are also redirected to `/v3/api<rest of request URL>`.

### Related issues

- (no related issues)

### Summary

- changes nginx's configuration to proxy requests intended for the API to the API container

### Checks

- [ ] All tests have passed (or issues created for failing tests)
