### PR TITLE
Makes compare() method connect to backend RPC server with each request

### DIFF
--- a/backend/src/monarch_py/api/config.py
+++ b/backend/src/monarch_py/api/config.py
@@ -32,6 +32,9 @@ def solr():
 
 class OakRPCMarshaller:
     def __init__(self) -> None:
+        pass
+
+    def connect_to_oak(self):
         ctx = zmq.Context()
         rpc_client = RPCClient(
             JSONRPCProtocol(),
@@ -39,9 +42,14 @@ class OakRPCMarshaller:
                 ctx, f'tcp://{settings.oak_server_host}:{settings.oak_server_port}'
             )
         )
-        self.oak_server = rpc_client.get_proxy()
+        return rpc_client.get_proxy()
 
     def compare(self, *args, **kwargs):
+        # make the connection each time to the backend server, to get around it timing out
+        # (note to future readers: if we find this to be too expensive, we can
+        # try the existing connection and reconnect if there's an exception)
+        self.oak_server = self.connect_to_oak()
+
         # for some reason TermSetPairwiseSimilarity is not JSON-serializable so
         # we can't call compare() directly. instead, we call compare_as_dict(),
         # which sends back a dict, and then we convert it into the expected


### PR DESCRIPTION
### Related issues

- Closes #364 

### Summary

- changes the behavior of the OakRPCMarshaller's compare() method to first establish a connection to Oak, then perform the request. previously the connection was made once when the API booted

### Checks

- [ ] All tests have passed (or issues created for failing tests)
