### PR TITLE
Fixes the constraint spec for posting to the compare endpoint

### DIFF
--- a/backend/src/monarch_py/api/additional_models.py
+++ b/backend/src/monarch_py/api/additional_models.py
@@ -1,5 +1,7 @@
+from typing import List
+
 from fastapi import Query, Request
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class PaginationParams(BaseModel):
@@ -9,3 +11,8 @@ class PaginationParams(BaseModel):
 
     class Config:
         arbitrary_types_allowed = True
+
+
+class CompareRequest(BaseModel):
+    subjects: List[str] = Field(..., title="List of subjects for comparison")
+    objects: List[str] = Field(..., title="List of objects for comparison")

--- a/backend/src/monarch_py/api/semsim.py
+++ b/backend/src/monarch_py/api/semsim.py
@@ -1,6 +1,8 @@
 from typing import List
 
 from fastapi import APIRouter, Path, Query
+
+from monarch_py.api.additional_models import CompareRequest
 from monarch_py.api.config import oak
 
 router = APIRouter(tags=["semsim"], responses={404: {"description": "Not Found"}})
@@ -35,10 +37,7 @@ def _compare(
 
 
 @router.post("/compare")
-def _post_compare(
-    subjects: List[str] = Query(...,title="List of subjects for comparison"),
-    objects: List[str] = Query(...,title="List of objects for comparison")
-):
+def _post_compare(request: CompareRequest):
     """
         Pairwise similarity between two sets of terms <br>
         <br>
@@ -50,4 +49,4 @@ def _post_compare(
     }
     </pre>
     """
-    return oak().compare(subjects, objects)
+    return oak().compare(request.subjects, request.objects)


### PR DESCRIPTION
I used Query to add some constraints to the compare by post endpoint, but that moved the subject & object lists to query string. Using a pydantic class as the argument to the post solves this.