### PR TITLE
Request logging

### DIFF
--- a/backend/src/monarch_py/api/main.py
+++ b/backend/src/monarch_py/api/main.py
@@ -3,7 +3,9 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import RedirectResponse
 from monarch_py.api import association, entity, histopheno, search, semsim
-from monarch_py.api.config import oak
+from monarch_py.api.config import oak, solr
+from monarch_py.api.middleware.logging_middleware import LoggingMiddleware
+from monarch_py.service.curie_service import CurieService
 
 PREFIX = "/v3/api"
 
@@ -16,6 +18,8 @@ app = FastAPI(
 @app.on_event("startup")
 async def initialize_app():
     oak()
+    # Let the curie service singleton initialize itself
+    CurieService()
 
 
 app.include_router(entity.router, prefix=f"{PREFIX}/entity")
@@ -32,7 +36,7 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
-
+app.add_middleware(LoggingMiddleware)
 
 @app.get("/")
 async def _root():

--- a/backend/src/monarch_py/api/middleware/logging_middleware.py
+++ b/backend/src/monarch_py/api/middleware/logging_middleware.py
@@ -1,0 +1,40 @@
+"""Middleware to log requests."""
+from loguru import logger
+import logging
+
+from fastapi import Request
+from fastapi.logger import logger as fastapi_logger
+from starlette.middleware.base import BaseHTTPMiddleware
+
+fastapi_logger.setLevel(logging.INFO)
+
+
+class LoggingMiddleware(BaseHTTPMiddleware):
+
+    """Middleware to log requests."""
+
+    async def dispatch(self, request: Request, call_next):
+        """
+        Log requests.
+
+        :param request: The request.
+        :param call_next: The next call.
+        :param logger: The logger.
+        :return: The response.
+        """
+        # Log request method and URL
+        logger.info(f"Request URL: {request.url} | Method: {request.method}")
+
+        # Log request headers
+        # logger.info(f"Headers: {dict(request.headers)}")
+
+        # If you need the request body, handle with care:
+        # body = await request.body()
+        # logger.info(f"Body: {body.decode()}")
+        #
+        # Since the body is read and can't be read again,
+        # you need to make it available for the actual route again
+        # request._body = body
+
+        response = await call_next(request)
+        return response


### PR DESCRIPTION
Hooks request logging up to loguru via fastapi middleware
Also instantiates CurieService() on startup to get rid of the stall that happens to the first request a worker sees, reduce stdout output and share the one singleton across workers (I think)