### PR TITLE
Update the banner to point to previous.mi.org!

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -13,9 +13,10 @@
       This web app is the
       <strong v-if="apiName === 'beta'">BETA VERSION</strong
       ><strong v-if="apiName === 'dev'">DEV VERSION</strong> successor to the
-      <AppLink to="https://previous.monarchinitiative.org/">old web app here</AppLink>.
-      Not all features are implemented yet. Please use the feedback form to tell
-      us what you think!
+      <AppLink to="https://previous.monarchinitiative.org/"
+        >old web app here</AppLink
+      >. Not all features are implemented yet. Please use the feedback form to
+      tell us what you think!
     </TheBanner>
 
     <TheHeader />

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -11,10 +11,9 @@
   <template v-else>
     <TheBanner>
       This web app is the
-      <strong v-if="apiName === 'v3'">BETA VERSION</strong
-      ><strong v-if="apiName === 'beta'">BETA VERSION</strong
+      <strong v-if="apiName === 'beta'">BETA VERSION</strong
       ><strong v-if="apiName === 'dev'">DEV VERSION</strong> successor to the
-      <AppLink to="https://monarchinitiative.org/">old web app here</AppLink>.
+      <AppLink to="https://previous.monarchinitiative.org/">old web app here</AppLink>.
       Not all features are implemented yet. Please use the feedback form to tell
       us what you think!
     </TheBanner>


### PR DESCRIPTION
Should just show the regular text when running as production, and show BETA or DEV when it's running as beta.mi.org or dev.mi.org
