### PR TITLE
Revert "Add (minimal) sssom mapping class and association grouping key to schema"

### DIFF
--- a/backend/src/monarch_py/datamodels/model.py
+++ b/backend/src/monarch_py/datamodels/model.py
@@ -389,19 +389,6 @@ class HistoBin(FacetValue):
     count: Optional[int] = Field(None, description="""count of documents""")
 
 
-class Mapping(ConfiguredBaseModel):
-    """
-    A minimal class to hold a SSSOM mapping
-    """
-
-    subject_id: str = Field(..., description="""The first of the two entities being compared""")
-    subject_label: Optional[str] = Field(None, description="""The name of the subject entity""")
-    predicate_id: str = Field(...)
-    object_id: Optional[str] = Field(None, description="""The second of the two entities being compared""")
-    object_label: Optional[str] = Field(None, description="""The name of the object entity""")
-    mapping_justification: Optional[str] = Field(None)
-
-
 class Node(Entity):
     """
     UI container class extending Entity with additional information
@@ -639,7 +626,6 @@ AssociationCount.update_forward_refs()
 FacetField.update_forward_refs()
 HistoPheno.update_forward_refs()
 HistoBin.update_forward_refs()
-Mapping.update_forward_refs()
 Node.update_forward_refs()
 NodeHierarchy.update_forward_refs()
 Results.update_forward_refs()

--- a/backend/src/monarch_py/datamodels/model.yaml
+++ b/backend/src/monarch_py/datamodels/model.yaml
@@ -62,11 +62,6 @@ classes:
       - onset_qualifier
       - sex_qualifier
       - stage_qualifier
-      - qualifiers_label
-      - qualifiers_namespace
-      - qualifiers_category
-      - qualifiers_closure
-      - qualifiers_closure_label
       - frequency_qualifier_label
       - frequency_qualifier_namespace
       - frequency_qualifier_category
@@ -198,16 +193,6 @@ classes:
     is_a: FacetValue
     slots:
       - id
-  Mapping:
-    description: >-
-      A minimal class to hold a SSSOM mapping
-    slots:
-      - subject_id
-      - subject_label
-      - predicate_id
-      - object_id
-      - object_label
-      - mapping_justification
   MultiEntityAssociationResults:
     is_a: Results
     slots:
@@ -331,9 +316,6 @@ slots:
     range: string
   full_name:
     description: The long form name of an entity
-    range: string
-  grouping_key:
-    description: A concatenation of fields used to group associations with the same essential/defining properties
     range: string
   has_evidence:
     range: string
@@ -556,13 +538,3 @@ slots:
   stage_qualifier_closure_label:
     multivalued: true
     description: Field containing stage_qualifier name and the names of all of it's ancestors
-# sssom slots
-  # subject_id already exists in similarity.yaml
-  # subject label is already included in this schema
-  predicate_id:
-      range: string
-      required: true
-  # object_id already exists in similarity.yaml
-  # object label is already included in this schema
-  mapping_justification:
-      range: string

--- a/backend/tests/fixtures/association_counts_response.py
+++ b/backend/tests/fixtures/association_counts_response.py
@@ -5,7 +5,7 @@ import pytest
 def association_counts_response():
     return {
         "responseHeader": {
-            "QTime": 1,
+            "QTime": 2,
             "params": {
                 "facet.query": [
                     '(category:"biolink:DiseaseToPhenotypicFeatureAssociation") AND (subject:"MONDO:0020121" OR subject_closure:"MONDO:0020121")',

--- a/backend/tests/fixtures/association_table_response.py
+++ b/backend/tests/fixtures/association_table_response.py
@@ -5,7 +5,7 @@ import pytest
 def association_table_response():
     return {
         "responseHeader": {
-            "QTime": 0,
+            "QTime": 1,
             "params": {
                 "mm": "100%",
                 "q": "*:*",

--- a/backend/tests/fixtures/autocomplete_response.py
+++ b/backend/tests/fixtures/autocomplete_response.py
@@ -5,7 +5,7 @@ import pytest
 def autocomplete_response():
     return {
         "responseHeader": {
-            "QTime": 0,
+            "QTime": 1,
             "params": {
                 "mm": "100%",
                 "q": "fanc",

--- a/backend/tests/fixtures/histopheno_response.py
+++ b/backend/tests/fixtures/histopheno_response.py
@@ -5,7 +5,7 @@ import pytest
 def histopheno_response():
     return {
         "responseHeader": {
-            "QTime": 1,
+            "QTime": 3,
             "params": {
                 "facet.query": [
                     'object_closure:"HP:0000924"',

--- a/backend/tests/fixtures/search_response.py
+++ b/backend/tests/fixtures/search_response.py
@@ -5,7 +5,7 @@ import pytest
 def search_response():
     return {
         "responseHeader": {
-            "QTime": 0,
+            "QTime": 2,
             "params": {
                 "mm": "100%",
                 "q": "fanconi",

--- a/frontend/src/api/model.ts
+++ b/frontend/src/api/model.ts
@@ -337,21 +337,6 @@ export interface HistoBin extends FacetValue {
     /** count of documents */
     count?: number,
 };
-/**
- * A minimal class to hold a SSSOM mapping
- */
-export interface Mapping {
-    /** The first of the two entities being compared */
-    subject_id: string,
-    /** The name of the subject entity */
-    subject_label?: string,
-    predicate_id: string,
-    /** The second of the two entities being compared */
-    object_id?: string,
-    /** The name of the object entity */
-    object_label?: string,
-    mapping_justification?: string,
-};
 
 export interface MultiEntityAssociationResults extends Results {
     id: string,


### PR DESCRIPTION
Reverts monarch-initiative/monarch-app#435

I'm realizing that we can't generate fixtures that match this schema until we have a new Solr that actually produces data with this schema, which means I need to ingest to get the schema from a branch... It really doesn't work well to have the ingest depend on the app for the schema. 