### PR TITLE
add send to pheno ex button, obsolete node, misc

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -15,8 +15,8 @@
       ><strong v-if="apiName === 'dev'">DEV VERSION</strong> successor to the
       <AppLink to="https://previous.monarchinitiative.org/"
         >old web app here</AppLink
-      >. Not all features are implemented yet. Please use the feedback form to
-      tell us what you think!
+      >. Not all features are implemented yet. Please use the feedback form
+      <AppIcon icon="comment" /> &nbsp;on any page to tell us what you think!
     </TheBanner>
 
     <TheHeader />

--- a/frontend/src/api/phenotype-explorer.ts
+++ b/frontend/src/api/phenotype-explorer.ts
@@ -64,7 +64,7 @@ const getPhenotypeAssociations = async (id = ""): Promise<Options> => {
       "biolink:GeneToPhenotypicFeatureAssociation",
       "biolink:DiseaseToPhenotypicFeatureAssociation",
     ],
-    limit: 500,
+    limit: 1000,
     direct: true,
   };
 

--- a/frontend/src/components/AppButton.vue
+++ b/frontend/src/components/AppButton.vue
@@ -132,7 +132,6 @@ defineExpose({ button });
   }
 
   &.small {
-    flex-direction: row-reverse;
     padding: 3px;
     border-radius: $rounded;
 

--- a/frontend/src/components/AppSelectTags.vue
+++ b/frontend/src/components/AppSelectTags.vue
@@ -314,12 +314,17 @@ const {
   isError,
 } = useQuery(
   /** get list of results */
-  async function () {
+  async function (forceAutoAccept = false) {
     /** reset highlighted */
     highlighted.value = 0;
 
     /** get results */
-    return await props.options(search.value);
+    const result = await props.options(search.value);
+
+    /** force auto-accept */
+    if (forceAutoAccept) result.autoAccept = true;
+
+    return result;
   },
 
   /** default value */
@@ -390,6 +395,14 @@ watch(highlighted, () => {
     .querySelector(`#option-${id}-${highlighted.value} > *`)
     ?.scrollIntoView({ block: "nearest" });
 });
+
+/** programmatically set search, query results, and auto-accept */
+function runSearch(value: string) {
+  search.value = value;
+  runGetResults(true);
+}
+
+defineExpose({ runSearch });
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/src/components/AppSelectTags.vue
+++ b/frontend/src/components/AppSelectTags.vue
@@ -314,7 +314,7 @@ const {
   isError,
 } = useQuery(
   /** get list of results */
-  async function (forceAutoAccept = false) {
+  async function (passedSearch?: string, forceAutoAccept = false) {
     /** reset highlighted */
     highlighted.value = 0;
 
@@ -399,7 +399,7 @@ watch(highlighted, () => {
 /** programmatically set search, query results, and auto-accept */
 function runSearch(value: string) {
   search.value = value;
-  runGetResults(true);
+  runGetResults("", true);
 }
 
 defineExpose({ runSearch });

--- a/frontend/src/components/AppTable.vue
+++ b/frontend/src/components/AppTable.vue
@@ -175,6 +175,7 @@
         />
         <AppButton
           v-tooltip="expanded ? 'Collapse table' : 'Expand table to full width'"
+          :text="expanded ? 'Collapse' : 'Expand'"
           :icon="expanded ? 'minimize' : 'maximize'"
           design="small"
           @click="expanded = !expanded"

--- a/frontend/src/components/TheFeedbackForm.vue
+++ b/frontend/src/components/TheFeedbackForm.vue
@@ -34,7 +34,7 @@
       <AppTextbox
         v-model.trim="github"
         title="GitHub username"
-        description="So we can tag you"
+        description="So we can tag/notify you"
         placeholder="@janesmith"
         @keydown="preventImplicit"
       />

--- a/frontend/src/pages/explore/TabPhenotypeExplorer.vue
+++ b/frontend/src/pages/explore/TabPhenotypeExplorer.vue
@@ -13,6 +13,7 @@
 
     <!-- set A -->
     <AppSelectTags
+      ref="aBox"
       v-model="aPhenotypes"
       name="First set of phenotypes"
       :options="getPhenotypes"
@@ -194,6 +195,9 @@ const bPhenotypes = ref<Options>([]);
 /** "generated from" helpers after selecting gene or disease */
 const bGeneratedFrom = ref<GeneratedFrom>({});
 
+/** element reference */
+const aBox = ref<{ runSearch: (value: string) => void }>();
+
 /** example phenotype set comparison */
 function doExample() {
   aPhenotypes.value = examples.a.options;
@@ -277,15 +281,21 @@ function description(
 /** clear results when inputs are changed to avoid de-sync */
 watch([aPhenotypes, bMode, bTaxon, bPhenotypes], clearResults, { deep: true });
 
-/** fill in phenotype ids from text annotator */
+/** fill in phenotype ids or search from other pages */
 onMounted(() => {
-  if (window.history.state.phenotypes) {
-    const phenotypes = parse<Options>(window.history.state.phenotypes, []);
-    aPhenotypes.value = phenotypes;
+  const { phenotypes, search } = window.history.state;
+  if (phenotypes) {
+    const _phenotypes = parse<Options>(phenotypes, []);
+    aPhenotypes.value = _phenotypes;
     aGeneratedFrom.value = {
       option: { id: "text annotator" },
-      options: phenotypes,
+      options: _phenotypes,
     };
+  }
+
+  if (search) {
+    const _search = parse<string>(search, "");
+    aBox.value?.runSearch(_search);
   }
 });
 </script>

--- a/frontend/src/pages/explore/TabTextAnnotator.vue
+++ b/frontend/src/pages/explore/TabTextAnnotator.vue
@@ -61,12 +61,12 @@
       <AppButton text="Download" icon="download" @click="download" />
       <AppButton
         v-tooltip="
-          'Send any annotations above that are phenotypes to Phenotype Explorer'
+          'Send any annotations above that are phenotypes to Phenotype Explorer for comparison'
         "
         to="#phenotype-explorer"
         :state="{ phenotypes: getPhenotypes() }"
-        text="Analyze Phenotypes"
-        icon="bars-progress"
+        text="Phenotype Explorer"
+        icon="arrow-right"
       />
     </AppFlex>
   </AppSection>

--- a/frontend/src/pages/help/PageHelp.vue
+++ b/frontend/src/pages/help/PageHelp.vue
@@ -15,13 +15,13 @@
       <AppTile
         icon="comment"
         title="Feedback Form"
-        subtitle="Right here, no account required, one-way"
+        subtitle="Right here, no account required"
         to="/feedback"
       />
       <AppTile
         icon="comments"
         title="Help Desk"
-        subtitle="On GitHub, requires account, two-way"
+        subtitle="On GitHub, requires account"
         to="https://github.com/monarch-initiative/helpdesk"
       />
     </AppFlex>

--- a/frontend/src/pages/node/SectionAssociations.vue
+++ b/frontend/src/pages/node/SectionAssociations.vue
@@ -23,6 +23,20 @@
       />
     </AppFlex>
 
+    <AppButton
+      v-if="
+        (node.category === 'biolink:Disease' &&
+          category?.id.startsWith('biolink:DiseaseToPheno')) ||
+        (node.category === 'biolink:Gene' &&
+          category?.id.startsWith('biolink:GeneToPheno'))
+      "
+      v-tooltip="'Send these phenotypes to Phenotype Explorer for comparison'"
+      to="explore#phenotype-explorer"
+      :state="{ search: node.id }"
+      text="Phenotype Explorer"
+      icon="arrow-right"
+    />
+
     <template v-if="category">
       <!-- table view of associations -->
       <AssociationsTable

--- a/frontend/src/pages/node/SectionTitle.vue
+++ b/frontend/src/pages/node/SectionTitle.vue
@@ -6,7 +6,12 @@
   <AppSection design="fill" class="section">
     <AppFlex dir="column">
       <AppHeading class="heading" :icon="getCategoryIcon(node.category)">
-        {{ node.name }}
+        <span
+          :style="{ textDecoration: node.deprecated ? 'line-through' : '' }"
+        >
+          {{ node.name }}
+        </span>
+        <template v-if="node.deprecated"> (OBSOLETE)</template>
       </AppHeading>
 
       <AppFlex>


### PR DESCRIPTION
closes #473 
closes #481 
closes #475

- add more explanation and icon to banner about feedback form
- expose imperative "runsearch" func from tags component
- show text next to table expand/collapse button to make more obvious
- modify phenotype explorer to accept search term from history state
- add button to node page association section to send phenotypes to pheno explorer
- add strikethrough for deprecated nodes