### PR TITLE
Simplify loading of converter in CurieService

### DIFF
--- a/backend/src/monarch_py/service/curie_service.py
+++ b/backend/src/monarch_py/service/curie_service.py
@@ -1,7 +1,7 @@
 ### make a singleton class that uses prefixmap and curies to expand curies
 
 from curies import Converter
-from prefixmaps.io.parser import load_multi_context
+from prefixmaps import load_converter
 
 
 class CurieService:
@@ -17,9 +17,7 @@ class CurieService:
     def initialize(self):
         # this is a magic keyword that represents the "merged" context from Chris M's algorithm
         # (https://github.com/linkml/prefixmaps/blob/main/src/prefixmaps/data/merged.csv)
-        context = load_multi_context(["merged"])
-        extended_prefix_map = context.as_extended_prefix_map()
-        self.converter = Converter.from_extended_prefix_map(extended_prefix_map)
+        self.converter = load_converter(["merged"])
 
     def expand(self, curie: str) -> str:
         return self.converter.expand(curie)


### PR DESCRIPTION
Uses newer code from `prefixmaps` that directly instantiates a converter