### PR TITLE
add ssh cache and key expiration for deployment workflow

### DIFF
--- a/.github/workflows/build-and-deploy-images.yaml
+++ b/.github/workflows/build-and-deploy-images.yaml
@@ -104,12 +104,18 @@ jobs:
         with:
           version: ">= 447.0.0"
 
+      - name: "Cache SSH Key"
+        uses: actions/cache@v3
+        with:
+          path: ~/.ssh/google_compute_engine
+          key: ${{ runner.os }}-ssh-key
+
       - name: "Update API Service"
         run: | 
-          gcloud compute ssh --zone us-central1-a monarch-v3-dev-manager -- sudo docker system prune -f
-          gcloud compute ssh --zone us-central1-a monarch-v3-dev-manager -- sudo docker service update monarch-v3_api --with-registry-auth  --update-order=start-first --force --image us-central1-docker.pkg.dev/monarch-initiative/monarch-api/monarch-api:${{ github.sha }}
+          gcloud compute ssh --ssh-key-expiration 60m --zone us-central1-a monarch-v3-dev-manager -- sudo docker system prune -f
+          gcloud compute ssh --ssh-key-expiration 60m --zone us-central1-a monarch-v3-dev-manager -- sudo docker service update monarch-v3_api --with-registry-auth  --update-order=start-first --force --image us-central1-docker.pkg.dev/monarch-initiative/monarch-api/monarch-api:${{ github.sha }}
           
       - name: "Update UI Service"
         run: |
-          gcloud compute ssh --zone us-central1-a monarch-v3-dev-manager -- sudo docker system prune -f
-          gcloud compute ssh --zone us-central1-a monarch-v3-dev-manager -- sudo docker service update monarch-v3_nginx --with-registry-auth  --update-order=start-first --force --image us-central1-docker.pkg.dev/monarch-initiative/monarch-api/monarch-ui:${{ github.sha }}
+          gcloud compute ssh --ssh-key-expiration 60m --zone us-central1-a monarch-v3-dev-manager -- sudo docker system prune -f
+          gcloud compute ssh --ssh-key-expiration 60m --zone us-central1-a monarch-v3-dev-manager -- sudo docker service update monarch-v3_nginx --with-registry-auth  --update-order=start-first --force --image us-central1-docker.pkg.dev/monarch-initiative/monarch-api/monarch-ui:${{ github.sha }}


### PR DESCRIPTION
Attempt to resolve deployment action failing due to:
`ERROR: (gcloud.compute.ssh) INVALID_ARGUMENT: Login profile size exceeds 32 KiB. Delete profile values to make additional space.`