### PR TITLE
Reduce limit on phenotype fetching to the 500 record max

### DIFF
--- a/frontend/src/api/phenotype-explorer.ts
+++ b/frontend/src/api/phenotype-explorer.ts
@@ -64,7 +64,7 @@ const getPhenotypeAssociations = async (id = ""): Promise<Options> => {
       "biolink:GeneToPhenotypicFeatureAssociation",
       "biolink:DiseaseToPhenotypicFeatureAssociation",
     ],
-    limit: 1000,
+    limit: 500,
     direct: true,
   };
 


### PR DESCRIPTION
The request to fetch phenotypes for a disease was failing because it was attempting to fetch 1000, but we have a default limit on the APIs of 500.
