### PR TITLE
Pass the phenio db path to the oak implementation initializer

### DIFF
--- a/backend/src/monarch_py/api/config.py
+++ b/backend/src/monarch_py/api/config.py
@@ -115,5 +115,5 @@ def semsimian():
 @lru_cache(maxsize=1)
 def oak():
     oak_implementation = OakImplementation()
-    oak_implementation.init_phenio_adapter(force_update=False)
+    oak_implementation.init_phenio_adapter(force_update=False, phenio_path=settings.phenio_db_path)
     return oak_implementation


### PR DESCRIPTION
I didn't quite finish hooking the phenio db path settings to the initializer, so this gets it all connceted
