### PR TITLE
Fixes specifying categories on the search endpoint

### DIFF
--- a/backend/src/monarch_py/api/search.py
+++ b/backend/src/monarch_py/api/search.py
@@ -35,7 +35,7 @@ async def search(
     facet_fields = ["category", "in_taxon_label"]
     response = solr().search(
         q=q or "*:*",
-        category=category.value if isinstance(category, EntityCategory) else category,
+        category=[c.value if isinstance(c, EntityCategory) else c for c in category],
         in_taxon_label=in_taxon_label,
         facet_fields=facet_fields,
         offset=pagination.offset,


### PR DESCRIPTION
I forgot to unpack the enum list as a list, it worked when no category was specified but failed when a list was passed in, such as in the phenotype explorer UI
