### PR TITLE
exclude multi-entity association endpoint from api

### DIFF
--- a/backend/src/monarch_py/api/association.py
+++ b/backend/src/monarch_py/api/association.py
@@ -41,7 +41,7 @@ async def _get_associations(
     return response
 
 
-@router.get("/multi")
+@router.get("/multi", include_in_schema=False)
 async def _get_multi_entity_associations(
     entity: Union[List[str], None] = Query(default=None),
     counterpart_category: Union[List[str], None] = Query(default=None),


### PR DESCRIPTION
We're reworking this endpoint entirely, probably removing it from SolrImplementation at some point. 
So it doesn't make sense for it to show up in the swagger UI