### PR TITLE
Update test for changed data

### DIFF
--- a/backend/tests/integration/test_solr_association.py
+++ b/backend/tests/integration/test_solr_association.py
@@ -84,7 +84,7 @@ def test_multi_entity_associations():
             assert c.total > 0
 
 
-@pytest.mark.parametrize("q", ["eyebrow", "thick", "Thick", "Thick eyebrow", "thick eyebrow", "Thick eyebrow (HPO)"])
+@pytest.mark.parametrize("q", ["eyebrow", "thick", "Thick", "Thick eyebrow", "thick eyebrow"])
 def test_association_search_partial_match(q: str):
     si = SolrImplementation()
     response = si.get_associations(
@@ -95,7 +95,7 @@ def test_association_search_partial_match(q: str):
     assert "HP:0000574" in [item.object for item in response.items]
 
 
-@pytest.mark.parametrize("q", ["eyebrow", "thick", "Thick", "Thick eyebrow", "thick eyebrow", "Thick eyebrow (HPO)"])
+@pytest.mark.parametrize("q", ["eyebrow", "thick", "Thick", "Thick eyebrow", "thick eyebrow"])
 def test_association_table_search_partial_match(q: str):
     si = SolrImplementation()
     response = si.get_association_table(


### PR DESCRIPTION
Updates a table searching test that used the "(HPO)" suffix on a phenotype name to remove the suffix, since it's not in the name anymore.