### PR TITLE
Add google group button

### DIFF
--- a/frontend/src/global/icons.ts
+++ b/frontend/src/global/icons.ts
@@ -20,6 +20,7 @@ const icons = [
   far.faComment,
   far.faComments,
   far.faCopy,
+  far.faEnvelope,
   far.faEye,
   far.faFileLines,
   far.faFloppyDisk,

--- a/frontend/src/pages/PageHome.vue
+++ b/frontend/src/pages/PageHome.vue
@@ -138,6 +138,13 @@
 
     <AppFlex align-v="top">
       <AppTile
+        to="https://groups.google.com/g/monarch-friends/"
+        icon="envelope"
+        title="Subscribe"
+        subtitle="Mailing list"
+        design="small"
+      />
+      <AppTile
         to="https://medium.com/@MonarchInit"
         icon="medium"
         title="Medium"
@@ -162,7 +169,7 @@
         to="https://www.linkedin.com/company/the-monarch-initiative"
         icon="linkedin"
         title="LinkedIn"
-        subtitle="Major updates"
+        subtitle="Social updates"
         design="small"
       />
     </AppFlex>


### PR DESCRIPTION
Closes #572 

Let me know if you'd suggest a different icon for the Google Groups button, this just made the most sense for something called "mailing list", but I recognize both the envelope and button name are somewhat misleading