### PR TITLE
Relax codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: 1%


### PR DESCRIPTION
### Related issues

- Closes #613

### Summary

- adds codecov.yml as a YAML configuration file for Codecov
- changes the threshold for Codecov to fail on coverage reduction to 1% this should prevent all of the build failures we've been seeing.

### Checks

- [ ] All tests have passed (or issues created for failing tests)
