### PR TITLE
Rename ortholog phenotype checkbox

### DIFF
--- a/frontend/src/pages/node/SectionAssociations.vue
+++ b/frontend/src/pages/node/SectionAssociations.vue
@@ -26,8 +26,8 @@
     <AppFlex gap="small">
       <AppCheckbox
         v-if="
-          (node.category === 'biolink:Gene' &&
-            category?.id.startsWith('biolink:GeneToPheno'))
+          node.category === 'biolink:Gene' &&
+          category?.id.startsWith('biolink:GeneToPheno')
         "
         v-model="includeOrthologs"
         v-tooltip="

--- a/frontend/src/pages/node/SectionAssociations.vue
+++ b/frontend/src/pages/node/SectionAssociations.vue
@@ -27,17 +27,13 @@
       <AppCheckbox
         v-if="
           (node.category === 'biolink:Gene' &&
-            category?.id.startsWith('biolink:GeneToPheno')) ||
-          (node.category === 'biolink:Gene' &&
-            category?.id.startsWith('biolink:CausalGeneToDisease')) ||
-          (node.category === 'biolink:Gene' &&
-            category?.id.startsWith('biolink:CorrelatedGeneToDisease'))
+            category?.id.startsWith('biolink:GeneToPheno'))
         "
         v-model="includeOrthologs"
         v-tooltip="
           'Include phenotypes for orthologous genes in the associations table'
         "
-        text="Include orthologous genes"
+        text="Include ortholog phenotypes"
       />
       <AppButton
         v-if="


### PR DESCRIPTION
Removes option to traverse orthologs for disease associations, since there's no path to get to it right now. Updates label to be ortholog phenotypes to match naming in V2 ui.