### PR TITLE
Add option to select metric for semsim search/compare

### DIFF
--- a/backend/src/monarch_py/api/additional_models.py
+++ b/backend/src/monarch_py/api/additional_models.py
@@ -19,6 +19,16 @@ class OutputFormat(str, Enum):
     tsv = "tsv"
 
 
+class SemsimMetric(str, Enum):
+    ANCESTOR_INFORMATION_CONTENT = "ancestor_information_content"
+    COSINE_SIMILARITY = "cosine_similarity"  # Not implemented
+    JACCARD_SIMILARITY = "jaccard_similarity"
+    PHENODIGM_SCORE = "phenodigm_score"
+
+    def __str__(self):
+        return self.value
+
+
 class SemsimSearchGroup(Enum):
     HGNC = "Human Genes"
     MGI = "Mouse Genes"
@@ -31,6 +41,7 @@ class SemsimSearchGroup(Enum):
 class SemsimCompareRequest(BaseModel):
     subjects: List[str] = Field(..., title="List of subjects for comparison")
     objects: List[str] = Field(..., title="List of objects for comparison")
+    metric: SemsimMetric = Field(SemsimMetric.ANCESTOR_INFORMATION_CONTENT, title="Similarity metric to use")
 
 
 class SemsimMultiCompareObject(BaseModel):
@@ -42,11 +53,13 @@ class SemsimMultiCompareObject(BaseModel):
 class SemsimMultiCompareRequest(BaseModel):
     subjects: List[str] = Field(..., title="List of subjects for comparison")
     object_entities: List[SemsimMultiCompareObject] = Field(..., title="List of object sets for comparison")
+    metric: SemsimMetric = Field(SemsimMetric.ANCESTOR_INFORMATION_CONTENT, title="Similarity metric to use")
 
 
 class SemsimSearchRequest(BaseModel):
     termset: List[str] = Field(..., title="Termset to search")
     group: SemsimSearchGroup = Field(..., title="Group of entities to search within (e.g. Human Genes)")
+    metric: SemsimMetric = Field(SemsimMetric.ANCESTOR_INFORMATION_CONTENT, title="Similarity metric to use")
     limit: Optional[int] = Field(10, title="Limit the number of results", ge=1, le=50)
 
 

--- a/backend/src/monarch_py/api/additional_models.py
+++ b/backend/src/monarch_py/api/additional_models.py
@@ -21,7 +21,7 @@ class OutputFormat(str, Enum):
 
 class SemsimMetric(str, Enum):
     ANCESTOR_INFORMATION_CONTENT = "ancestor_information_content"
-    COSINE_SIMILARITY = "cosine_similarity"  # Not implemented
+    # COSINE_SIMILARITY = "cosine_similarity"  # Not implemented
     JACCARD_SIMILARITY = "jaccard_similarity"
     PHENODIGM_SCORE = "phenodigm_score"
 

--- a/backend/src/monarch_py/api/semsim.py
+++ b/backend/src/monarch_py/api/semsim.py
@@ -41,11 +41,11 @@ def autocomplete(
     return response
 
 
-@router.get("/compare/{subjects}/{objects}/{metric}")
+@router.get("/compare/{subjects}/{objects}")
 def _compare(
     subjects: str = Path(..., title="List of subjects for comparison"),
     objects: str = Path(..., title="List of objects for comparison"),
-    metric: SemsimMetric = Path(SemsimMetric.ANCESTOR_INFORMATION_CONTENT, title="Similarity metric to use"),
+    metric: SemsimMetric = Query(SemsimMetric.ANCESTOR_INFORMATION_CONTENT, title="Similarity metric to use"),
 ):
     """Get pairwise similarity between two sets of terms
 
@@ -122,19 +122,19 @@ def _post_multicompare(request: SemsimMultiCompareRequest):
     return semsimian().multi_compare(request)
 
 
-@router.get("/search/{termset}/{group}/{metric}")
+@router.get("/search/{termset}/{group}")
 def _search(
     termset: str = Path(..., title="Termset to search"),
     group: SemsimSearchGroup = Path(..., title="Group of entities to search within (e.g. Human Genes)"),
-    metric: SemsimMetric = Path(SemsimMetric.ANCESTOR_INFORMATION_CONTENT, title="Similarity metric to use"),
+    metric: SemsimMetric = Query(SemsimMetric.ANCESTOR_INFORMATION_CONTENT, title="Similarity metric to use"),
     limit: int = Query(default=10, ge=1, le=50),
 ):
     """Search for terms in a termset
 
     <b>Args:</b> <br>
-        termset (str, optional): Comma separated list of term IDs to find matches for. <br>
-        group (str, optional): Group of entities to search within (e.g. Human Genes) <br>
-        "metric": "ancestor_information_content", <br>
+        termset (str): Comma separated list of term IDs to find matches for. <br>
+        group (str): Group of entities to search within (e.g. Human Genes) <br>
+        metric: (str, optional): Similarity metric to use. Defaults to "ancestor_information_content". <br>
         limit (int, optional): Limit the number of results. Defaults to 10.
 
     <b>Returns:</b> <br>

--- a/backend/src/monarch_py/api/semsim.py
+++ b/backend/src/monarch_py/api/semsim.py
@@ -41,7 +41,7 @@ def autocomplete(
     return response
 
 
-@router.get("/compare/{subjects}/{objects}")
+@router.get("/compare/{subjects}/{objects}/{metric}")
 def _compare(
     subjects: str = Path(..., title="List of subjects for comparison"),
     objects: str = Path(..., title="List of objects for comparison"),
@@ -52,6 +52,7 @@ def _compare(
     <b>Args:</b> <br>
         subjects (str, optional): List of subjects for comparison. Defaults to "". <br>
         objects (str, optional): List of objects for comparison. Defaults to "". <br>
+        metric (str, optional): Similarity metric to use. Defaults to "ancestor_information_content".
 
     <b>Returns:</b> <br>
         TermSetPairwiseSimilarity: Pairwise similarity between subjects and objects
@@ -81,7 +82,8 @@ def _post_compare(request: SemsimCompareRequest):
     <pre>
     {
       "subjects": ["MP:0010771","MP:0002169","MP:0005391","MP:0005389","MP:0005367"],
-      "objects": ["HP:0004325","HP:0000093","MP:0006144"]
+      "objects": ["HP:0004325","HP:0000093","MP:0006144"],
+      "metric": "ancestor_information_content"
     }
     </pre>
     """
@@ -97,6 +99,7 @@ def _post_multicompare(request: SemsimMultiCompareRequest):
             Example: <br>
         <pre>
     {
+      "metric": "ancestor_information_content",
       "subjects": [ "HP:0002616", "HP:0001763", "HP:0004944", "HP:0010749", "HP:0001533", "HP:0002020", "HP:0012450", "HP:0003394", "HP:0003771", "HP:0012378", "HP:0001278", "HP:0002827",
     "HP:0002829", "HP:0002999", "HP:0003010"],
       "object_entities": [
@@ -119,7 +122,7 @@ def _post_multicompare(request: SemsimMultiCompareRequest):
     return semsimian().multi_compare(request)
 
 
-@router.get("/search/{termset}/{group}")
+@router.get("/search/{termset}/{group}/{metric}")
 def _search(
     termset: str = Path(..., title="Termset to search"),
     group: SemsimSearchGroup = Path(..., title="Group of entities to search within (e.g. Human Genes)"),
@@ -131,6 +134,7 @@ def _search(
     <b>Args:</b> <br>
         termset (str, optional): Comma separated list of term IDs to find matches for. <br>
         group (str, optional): Group of entities to search within (e.g. Human Genes) <br>
+        "metric": "ancestor_information_content", <br>
         limit (int, optional): Limit the number of results. Defaults to 10.
 
     <b>Returns:</b> <br>
@@ -151,6 +155,7 @@ def _post_search(request: SemsimSearchRequest):
     {
       "termset": ["HP:0002104", "HP:0012378", "HP:0012378", "HP:0012378"],
       "group": "Human Diseases",
+      "metric": "ancestor_information_content",
       "limit": 5
     }
     </pre>

--- a/backend/src/monarch_py/api/semsim.py
+++ b/backend/src/monarch_py/api/semsim.py
@@ -45,7 +45,7 @@ def autocomplete(
 def _compare(
     subjects: str = Path(..., title="List of subjects for comparison"),
     objects: str = Path(..., title="List of objects for comparison"),
-    metric: SemsimMetric = Query(SemsimMetric.RESNIK, title="Similarity metric to use"),
+    metric: SemsimMetric = Query(SemsimMetric.ANCESTOR_INFORMATION_CONTENT, title="Similarity metric to use"),
 ):
     """Get pairwise similarity between two sets of terms
 

--- a/backend/src/monarch_py/api/semsim.py
+++ b/backend/src/monarch_py/api/semsim.py
@@ -45,7 +45,7 @@ def autocomplete(
 def _compare(
     subjects: str = Path(..., title="List of subjects for comparison"),
     objects: str = Path(..., title="List of objects for comparison"),
-    metric: SemsimMetric = Query(SemsimMetric.ANCESTOR_INFORMATION_CONTENT, title="Similarity metric to use"),
+    metric: SemsimMetric = Path(SemsimMetric.ANCESTOR_INFORMATION_CONTENT, title="Similarity metric to use"),
 ):
     """Get pairwise similarity between two sets of terms
 
@@ -126,7 +126,7 @@ def _post_multicompare(request: SemsimMultiCompareRequest):
 def _search(
     termset: str = Path(..., title="Termset to search"),
     group: SemsimSearchGroup = Path(..., title="Group of entities to search within (e.g. Human Genes)"),
-    metric: SemsimMetric = Query(SemsimMetric.ANCESTOR_INFORMATION_CONTENT, title="Similarity metric to use"),
+    metric: SemsimMetric = Path(SemsimMetric.ANCESTOR_INFORMATION_CONTENT, title="Similarity metric to use"),
     limit: int = Query(default=10, ge=1, le=50),
 ):
     """Search for terms in a termset

--- a/backend/src/monarch_py/cli.py
+++ b/backend/src/monarch_py/cli.py
@@ -7,6 +7,7 @@ import typer
 
 from monarch_py import solr_cli, sql_cli
 from monarch_py.api.config import semsimian
+from monarch_py.api.additional_models import SemsimMetric
 from monarch_py.datamodels.category_enums import (
     AssociationCategory,
     AssociationPredicate,
@@ -315,10 +316,19 @@ def association_table(
     solr_cli.association_table(**locals())
 
 
+### CLI Commands for Semsimian ###
+
+
 @app.command("compare")
 def compare(
     subjects: str = typer.Argument(..., help="Comma separated list of subjects to compare"),
     objects: str = typer.Argument(..., help="Comma separated list of objects to compare"),
+    metric: SemsimMetric = typer.Option(
+        SemsimMetric.ANCESTOR_INFORMATION_CONTENT,
+        "--metric",
+        "-m",
+        help="The metric to use for comparison",
+    ),
     fmt: str = typer.Option(
         "json",
         "--format",
@@ -330,36 +340,11 @@ def compare(
     """Compare two sets of phenotypes using semantic similarity via SemSimian"""
     subjects = subjects.split(",")
     objects = objects.split(",")
-    response = semsimian().compare(subjects, objects)
+    response = semsimian().compare(subjects, objects, metric)
     format_output(fmt, response, output)
 
 
-@app.command("multi-entity-associations")
-def multi_entity_associations(
-    entity: List[str] = typer.Option(None, "--entity", "-e", help="Comma-separated list of entities"),
-    counterpart_category: List[str] = typer.Option(None, "--counterpart-category", "-c"),
-    limit: int = typer.Option(20, "--limit", "-l"),
-    offset: int = typer.Option(0, "--offset"),
-    fmt: str = typer.Option(
-        "json",
-        "--format",
-        "-f",
-        help="The format of the output (json, yaml, tsv, table)",
-    ),
-    output: str = typer.Option(None, "--output", "-O", help="The path to the output file"),
-):
-    """
-    Paginate through associations for multiple entities
-
-    Args:
-        entity: A comma-separated list of entities
-        counterpart_category: A comma-separated list of counterpart categories
-        limit: The number of associations to return
-        offset: The offset of the first association to be retrieved
-        fmt: The format of the output (json, yaml, tsv, table)
-        output: The path to the output file (stdout if not specified)
-    """
-    solr_cli.multi_entity_associations(**locals())
+### Misc CLI Commands ###
 
 
 @app.command("mappings")

--- a/backend/src/monarch_py/service/semsim_service.py
+++ b/backend/src/monarch_py/service/semsim_service.py
@@ -3,7 +3,7 @@ import requests
 
 from pydantic import BaseModel
 
-from monarch_py.api.additional_models import SemsimMultiCompareRequest
+from monarch_py.api.additional_models import SemsimMetric, SemsimMultiCompareRequest
 from monarch_py.datamodels.model import TermSetPairwiseSimilarity, SemsimSearchResult, Entity
 
 
@@ -43,9 +43,11 @@ class SemsimianService(BaseModel):
         }
         return converted_data
 
-    def compare(self, subjects: List[str], objects: List[str]) -> TermSetPairwiseSimilarity:
+    def compare(
+        self, subjects: List[str], objects: List[str], metric: SemsimMetric = SemsimMetric.ANCESTOR_INFORMATION_CONTENT
+    ) -> TermSetPairwiseSimilarity:
         host = f"http://{self.semsim_server_host}:{self.semsim_server_port}"
-        path = f"compare/{','.join(subjects)}/{','.join(objects)}"
+        path = f"compare/{','.join(subjects)}/{','.join(objects)}/{metric}"
         url = f"{host}/{path}"
 
         print(f"Fetching {url}...")
@@ -56,7 +58,8 @@ class SemsimianService(BaseModel):
 
     def multi_compare(self, request: SemsimMultiCompareRequest) -> List[SemsimSearchResult]:
         comparison_results = [
-            self.compare(request.subjects, object_entity.objects) for object_entity in request.object_entities
+            self.compare(request.subjects, object_entity.objects, request.metric)
+            for object_entity in request.object_entities
         ]
         results = [
             SemsimSearchResult(
@@ -68,9 +71,15 @@ class SemsimianService(BaseModel):
         ]
         return results
 
-    def search(self, termset: List[str], prefix: str, limit: int) -> List[SemsimSearchResult]:
+    def search(
+        self,
+        termset: List[str],
+        prefix: str,
+        metric: SemsimMetric = SemsimMetric.ANCESTOR_INFORMATION_CONTENT,
+        limit: int = 10,
+    ) -> List[SemsimSearchResult]:
         host = f"http://{self.semsim_server_host}:{self.semsim_server_port}"
-        path = f"search/{','.join(termset)}/{prefix}?limit={limit}"
+        path = f"search/{','.join(termset)}/{prefix}/{metric}?limit={limit}"
         url = f"{host}/{path}"
 
         print(f"Fetching {url}...")

--- a/backend/tests/api/test_semsim_router.py
+++ b/backend/tests/api/test_semsim_router.py
@@ -3,7 +3,7 @@ from fastapi.testclient import TestClient
 from fastapi import status
 from unittest.mock import MagicMock, patch
 
-from monarch_py.api.additional_models import SemsimSearchGroup
+from monarch_py.api.additional_models import SemsimMetric, SemsimSearchGroup
 from monarch_py.api.semsim import router
 from monarch_py.datamodels.category_enums import AssociationPredicate, EntityCategory
 
@@ -21,44 +21,67 @@ def test_autocomplete_params(mock_autocomplete, autocomplete):
     )
 
 
+@pytest.mark.parametrize(
+    "metric",
+    [
+        SemsimMetric.ANCESTOR_INFORMATION_CONTENT,
+        SemsimMetric.JACCARD_SIMILARITY,
+        SemsimMetric.PHENODIGM_SCORE,
+    ],
+)
 @patch("monarch_py.service.semsim_service.SemsimianService.compare")
-def test_get_compare(mock_compare):
+def test_get_compare(mock_compare, metric):
     mock_compare.return_value = MagicMock()
 
     subjects = "HP:123,HP:456"
-    objects = "HP:789,HP:101112"
+    objects = "HP:789,HP:987"
 
-    response = client.get(f"/compare/{subjects}/{objects}")
+    response = client.get(f"/compare/{subjects}/{objects}?metric={metric}")
 
     assert response.status_code == status.HTTP_200_OK
-    mock_compare.assert_called_once_with(subjects=["HP:123", "HP:456"], objects=["HP:789", "HP:101112"])
+    mock_compare.assert_called_once_with(subjects=["HP:123", "HP:456"], objects=["HP:789", "HP:987"], metric=metric)
 
 
+@pytest.mark.parametrize(
+    "metric",
+    [
+        SemsimMetric.ANCESTOR_INFORMATION_CONTENT,
+        SemsimMetric.JACCARD_SIMILARITY,
+        SemsimMetric.PHENODIGM_SCORE,
+    ],
+)
 @patch("monarch_py.service.semsim_service.SemsimianService.compare")
-def test_post_compare(mock_compare):
+def test_post_compare(mock_compare, metric):
     mock_compare.return_value = MagicMock()
 
     subjects = ["HP:123", "HP:456"]
-    objects = ["HP:789", "HP:101112"]
+    objects = ["HP:789", "HP:987"]
 
-    response = client.post(f"/compare/", json={"subjects": subjects, "objects": objects})
+    response = client.post(f"/compare/", json={"subjects": subjects, "objects": objects, "metric": metric.value})
 
     assert response.status_code == status.HTTP_200_OK
-    mock_compare.assert_called_once_with(subjects=subjects, objects=objects)
+    mock_compare.assert_called_once_with(subjects=subjects, objects=objects, metric=metric)
 
 
 @patch("monarch_py.service.semsim_service.SemsimianService.search")
-@pytest.mark.parametrize("termset", ["HP:123,HP:456", "HP:123, HP:456", " HP:123, HP:456 "])
-def test_get_search(mock_search, termset: str):
+@pytest.mark.parametrize(
+    "termset, metric",
+    [
+        ("HP:123,HP:456", SemsimMetric.ANCESTOR_INFORMATION_CONTENT),
+        ("HP:123, HP:456", SemsimMetric.JACCARD_SIMILARITY),
+        (" HP:123, HP:456 ", SemsimMetric.PHENODIGM_SCORE),
+    ],
+)
+def test_get_search(mock_search, termset: str, metric: SemsimMetric):
     mock_search.return_value = MagicMock()
 
     group = SemsimSearchGroup.HGNC
     limit = 5
 
-    response = client.get(f"/search/{termset}/{group.value}?limit={limit}")
+    response = client.get(f"/search/{termset}/{group.value}?metric={metric}&limit={limit}")
 
     assert response.status_code == status.HTTP_200_OK
-    mock_search.assert_called_once_with(termset=["HP:123", "HP:456"], prefix=group.name, limit=limit)
+    mock_search.assert_called_once_with(termset=["HP:123", "HP:456"], prefix=group.name, metric=metric, limit=limit)
 
 
 @patch("monarch_py.service.semsim_service.SemsimianService.search")
@@ -67,9 +90,12 @@ def test_post_search(mock_search):
 
     termset = ["HP:123", "HP:456"]
     group = SemsimSearchGroup.HGNC
+    metric = SemsimMetric.JACCARD_SIMILARITY
     limit = 5
 
-    response = client.post(f"/search/", json={"termset": termset, "group": group.value, "limit": limit})
+    response = client.post(
+        f"/search/", json={"termset": termset, "group": group.value, "metric": metric, "limit": limit}
+    )
 
     assert response.status_code == status.HTTP_200_OK
-    mock_search.assert_called_once_with(termset=["HP:123", "HP:456"], prefix=group.name, limit=limit)
+    mock_search.assert_called_once_with(termset=["HP:123", "HP:456"], prefix=group.name, metric=metric, limit=limit)

--- a/backend/tests/integration/test_solr_autocomplete.py
+++ b/backend/tests/integration/test_solr_autocomplete.py
@@ -14,8 +14,8 @@ pytestmark = pytest.mark.skipif(
         # we need an edge ngram version of the keyword tokenized field
         # ("down syn", "Down syndrome"),
         ("marf", "Marfan syndrome"),
-        ("BRC", "BRCA1"),
-        ("brc", "BRCA1"),
+        ("BRC", "brc-1"),
+        ("brc", "brc-1"),
     ],
 )
 def test_autocomplete(q, should_return):

--- a/backend/tests/unit/test_semsim_service.py
+++ b/backend/tests/unit/test_semsim_service.py
@@ -1,0 +1,20 @@
+from monarch_py.service.semsim_service import SemsimianService
+
+import pytest
+
+
+@pytest.fixture
+def semsim_service():
+    return SemsimianService(semsim_server_host="localhost", semsim_server_port=8080, entity_implementation=None)
+
+
+@pytest.mark.parametrize(
+    "data, expected",
+    [
+        ({"some_dict": {"a": 1, "b": "NaN", "c": 3}}, {"some_dict": {"a": 1, "b": None, "c": 3}}),
+        ({"some_dict": {"a": 1, "b": "two", "c": 3}}, {"some_dict": {"a": 1, "b": "two", "c": 3}}),
+    ],
+)
+def test_convert_nans(semsim_service, data, expected):
+    result = semsim_service._convert_nans(data)
+    assert result == expected

--- a/frontend/src/api/phenotype-explorer.ts
+++ b/frontend/src/api/phenotype-explorer.ts
@@ -74,12 +74,13 @@ const getPhenotypeAssociations = async (id = "") => {
 export const compareSetToSet = async (
   aPhenotypes: string[],
   bPhenotypes: string[],
+  metric: string = "ancestor_information_content",
 ) => {
   /** make request options */
   const headers = new Headers();
   headers.append("Content-Type", "application/json");
   headers.append("Accept", "application/json");
-  const body = { subjects: aPhenotypes, objects: bPhenotypes };
+  const body = { subjects: aPhenotypes, objects: bPhenotypes, metric: metric };
   const options = { method: "POST", headers, body: stringify(body) };
 
   /** make query */
@@ -101,6 +102,7 @@ export const compareSetToSet = async (
       ...pick(match.similarity, [
         "ancestor_id",
         "ancestor_label",
+        "ancestor_information_content",
         "jaccard_similarity",
         "phenodigm_score",
       ]),
@@ -141,12 +143,13 @@ export type Group = (typeof groups)[number];
 export const compareSetToGroup = async (
   phenotypes: string[],
   group: (typeof groups)[number],
+  metric: string = "ancestor_information_content",
 ) => {
   /** make request options */
   const headers = new Headers();
   headers.append("Content-Type", "application/json");
   headers.append("Accept", "application/json");
-  const body = { termset: phenotypes, group: group };
+  const body = { termset: phenotypes, group: group, metric: metric };
   const options = { method: "POST", headers, body: stringify(body) };
 
   /** make query */
@@ -200,6 +203,7 @@ export const compareSetToGroup = async (
         ...pick(match?.similarity, [
           "ancestor_id",
           "ancestor_label",
+          "ancestor_information_content",
           "jaccard_similarity",
           "phenodigm_score",
         ]),

--- a/frontend/src/components/ThePhenogrid.vue
+++ b/frontend/src/components/ThePhenogrid.vue
@@ -217,16 +217,16 @@
                   Ancestor IC
                 </AppLink>
                 <span>
-                  {{ cell.score?.toFixed(3) }}
+                  {{ cell.ancestor_information_content?.toFixed(3) }}
                 </span>
                 <AppLink
                   to="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3649640/"
                 >
                   Phenodigm
                 </AppLink>
-                <strong>
+                <span>
                   {{ cell.phenodigm_score?.toFixed(3) }}
-                </strong>
+                </span>
                 <AppLink
                   to="https://incatools.github.io/ontology-access-kit/guide/similarity.html#jaccard-similarity"
                 >
@@ -344,6 +344,7 @@ export type Phenogrid = {
       TermPairwiseSimilarity,
       | "ancestor_id"
       | "ancestor_label"
+      | "ancestor_information_content"
       | "jaccard_similarity"
       | "phenodigm_score"
     >;

--- a/frontend/src/pages/explore/TabPhenotypeExplorer.vue
+++ b/frontend/src/pages/explore/TabPhenotypeExplorer.vue
@@ -61,6 +61,14 @@
       @spread-options="(option, options) => spreadOptions(option, options, 'b')"
     />
 
+    <!-- similarity metric -->
+    <strong>using metric:</strong>
+    <AppSelectSingle
+      v-model="metric"
+      name="Similarity metric"
+      :options="metricOptions"
+    />
+
     <!-- run analysis -->
     <AppButton
       text="Analyze"
@@ -148,16 +156,16 @@
                   Ancestor IC
                 </AppLink>
                 <span>
-                  {{ match.score?.toFixed(3) }}
+                  {{ match.ancestor_information_content?.toFixed(3) }}
                 </span>
                 <AppLink
                   to="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3649640/"
                 >
                   Phenodigm
                 </AppLink>
-                <strong>
+                <span>
                   {{ match.phenodigm_score?.toFixed(3) }}
-                </strong>
+                </span>
                 <AppLink
                   to="https://incatools.github.io/ontology-access-kit/guide/similarity.html#jaccard-similarity"
                 >
@@ -281,6 +289,12 @@ const bModeOptions = [
 /** search group options */
 const bGroupOptions = groups.map((group) => ({ id: group, label: group }));
 
+const metricOptions = [
+  { id: "ancestor_information_content", label: "Ancestor Information Content" },
+  { id: "jaccard_similarity", label: "Jaccard Similarity" },
+  { id: "phenodigm_score", label: "Phenodigm Score" },
+];
+
 /** example data */
 type GeneratedFrom = {
   /** the option (gene/disease/phenotype) that the phenotypes came from */
@@ -307,6 +321,8 @@ const bGroup = useParam("b-group", optionParam(), bGroupOptions[0]);
 const bPhenotypes = useParam<Options>("b-set", arrayParam(optionParam()), []);
 /** "generated from" helpers after selecting gene or disease */
 const bGeneratedFrom = ref<GeneratedFrom>({});
+/** selected metric */
+const metric = ref<Option>(metricOptions[0]);
 
 /** element reference */
 const aBox = ref<InstanceType<typeof AppSelectTags>>();
@@ -380,6 +396,7 @@ const {
     return await compareSetToSet(
       aPhenotypes.value.map(({ id }) => id),
       bPhenotypes.value.map(({ id }) => id),
+      metric.value.id,
     );
   },
 
@@ -407,6 +424,7 @@ const {
     return await compareSetToGroup(
       aPhenotypes.value.map(({ id }) => id),
       bGroup.value.id as Group,
+      metric.value.id,
     );
   },
 
@@ -483,7 +501,9 @@ function description(
 }
 
 /** clear results when inputs are changed to avoid de-sync */
-watch([aPhenotypes, bMode, bGroup, bPhenotypes], clearResults, { deep: true });
+watch([aPhenotypes, bMode, bGroup, bPhenotypes, metric], clearResults, {
+  deep: true,
+});
 
 /** fill in phenotype ids or search from other pages */
 onMounted(() => {


### PR DESCRIPTION
Closes #593 

- Adds an option to select from jaccard, phenodigm, and ancestor IC type scoring from semsim search and compare methods in: 
  - CLI
  - API endpoints
  - UI for phenotype explorer
- Updates backend tests
- Also updates frontend api method for calling semsim methods to include and use ancestor IC rather than top level score

I probably should have split front and backend into separate PRs so that the backend changes could be deployed and the frontend deploy previews would actually reflect changes being made. 

We can review this in hackathon tomorrow (3/15) before merging if we want to be sure, I'll screenshare to show it in action. 


Also somehow just noticed phenogrid rows are randomly sorted, just commenting so I remember to bring it up tomorrow. Already made a ticket #636 