### PR TITLE
fix table component

### DIFF
--- a/frontend/src/components/AppSelectSingle.vue
+++ b/frontend/src/components/AppSelectSingle.vue
@@ -280,7 +280,6 @@ watch(
   padding: 5px 10px;
   gap: 10px;
   text-align: left;
-  white-space: nowrap;
   cursor: pointer;
   transition: background $fast;
 }

--- a/frontend/src/components/AppTable.vue
+++ b/frontend/src/components/AppTable.vue
@@ -26,7 +26,8 @@
               :aria-sort="col.slot === 'divider' ? undefined : ariaSort"
             >
               <div
-                :class="['cell', col.align || 'left']"
+                v-if="col.slot !== 'divider'"
+                :class="['cell', col.align || 'left', ,]"
                 :style="{ width: col.width || '' }"
               >
                 <span>
@@ -74,7 +75,12 @@
               :aria-colindex="col.slot === 'divider' ? undefined : colIndex + 1"
             >
               <div
-                :class="['cell', col.align || 'left']"
+                v-if="col.slot !== 'divider'"
+                :class="[
+                  'cell',
+                  col.align || 'left',
+                  { divider: col.slot === 'divider' },
+                ]"
                 :style="{ width: col.width || '' }"
               >
                 <!-- if col has slot name, use to custom format/template cell -->
@@ -444,19 +450,28 @@ watch(
       order: -1;
     }
   }
+}
+
+.th,
+.td {
+  padding: 0;
 
   &.divider {
-    width: 2px !important;
-    margin: 0 auto;
-    padding: 0;
-    background: $light-gray;
+    position: relative;
+    min-width: 20px;
+
+    &::after {
+      position: absolute;
+      inset: 0 calc(50% - 1px);
+      background: $light-gray;
+      content: "";
+    }
   }
 }
 
 /** heading cells */
 .th {
   padding-bottom: 10px;
-  font-weight: 400;
   font-weight: 600;
   text-transform: capitalize;
 }

--- a/frontend/src/pages/node/AssociationsTable.vue
+++ b/frontend/src/pages/node/AssociationsTable.vue
@@ -167,14 +167,13 @@ const cols = computed((): Cols<Datum> => {
       heading: getCategoryLabel(
         associations.value.items[0]?.subject_category || "Subject",
       ),
-      width: 3,
+      width: "200px",
       sortable: true,
     },
     {
       slot: "predicate",
       key: "predicate",
       heading: "Association",
-      width: 2,
       sortable: true,
     },
     {
@@ -183,14 +182,13 @@ const cols = computed((): Cols<Datum> => {
       heading: getCategoryLabel(
         associations.value.items[0]?.object_category || "Object",
       ),
-      width: 3,
+      width: "200px",
       sortable: true,
     },
     {
       slot: "details",
       key: "evidence_count",
       heading: "Details",
-      width: 1,
       align: "center",
       sortable: true,
     },
@@ -208,7 +206,6 @@ const cols = computed((): Cols<Datum> => {
     extraCols.push({
       slot: "taxon",
       heading: "Taxon",
-      width: 2,
     });
 
   /** phenotype specific columns */
@@ -257,18 +254,15 @@ const cols = computed((): Cols<Datum> => {
   //     {
   //       key: "author",
   //       heading: "Author",
-  //       width: "max-content",
   //     },
   //     {
   //       key: "year",
   //       heading: "Year",
   //       align: "center",
-  //       width: "max-content",
   //     },
   //     {
   //       key: "publisher",
   //       heading: "Publisher",
-  //       width: "max-content",
   //     },
   //   );
 


### PR DESCRIPTION
This reverts the table component back to a true raw table. Previously I was using [this method](https://adamlynch.com/flexible-data-tables-with-css-grid/) to have the flexibility of CSS grid layout, with the accessibility of `<table>`. However, years later, and it does not appear that [this implementational limit](https://developer.mozilla.org/en-US/docs/Web/CSS/display#display_contents) has been fixed yet in all browsers, so it is not optimally accessible. Further, I noticed that the fractional grid column widths e.g. `3fr 1fr 3fr 20px` in both our component and the article example don't really work. The browser does not respect the fractional widths, and seems to make them either constant width or some kind of auto width. If I remove the `<thead>` element (required for accessibility), it does, for some reason. I think this is a browser bug actually, but Chrome and FF both do it. Anyway, the simpler solution is to just revert to ordinary table layout. While it is less flexible, it is less complicated and more time-tested.