### PR TITLE
Remove banner on production version of web app

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -9,15 +9,24 @@
   </template>
 
   <template v-else>
-    <TheBanner>
+    <TheBanner v-if="apiName !== 'prod'">
       This web app is the
-      <strong v-if="apiName === 'beta'">BETA VERSION</strong
-      ><strong v-if="apiName === 'dev'">DEV VERSION</strong> successor to the
-      <AppLink to="https://previous.monarchinitiative.org/"
-        >old web app here</AppLink
-      >. Not all features are implemented yet. Please use the feedback form
-      <AppIcon icon="comment" /> &nbsp;on any page to tell us what you think!
+      <strong v-if="apiName === 'local'">LOCAL VERSION</strong>
+      <strong v-if="apiName === 'beta'">BETA VERSION</strong>
+      <strong v-if="apiName === 'dev'">DEV VERSION</strong>
+      of the
+      <AppLink  to="https://monarchinitiative.org">
+        Monarch Web App
+      </AppLink>. 
+      Not all features are implemented yet. Please use the feedback form
+      <AppIcon icon="comment" />
+      &nbsp;on any page to tell us what you think!
     </TheBanner>
+    <!-- <TheBanner v-else>
+      This banner can be used to make announcements on the production version of the web app. 
+      Uncomment this section and replace this text with your announcement as needed. 
+      Disabling the banner is as simple as commenting out this section.
+    </TheBanner> -->
 
     <TheHeader />
     <main>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -15,9 +15,7 @@
       <strong v-if="apiName === 'beta'">BETA VERSION</strong>
       <strong v-if="apiName === 'dev'">DEV VERSION</strong>
       of the
-      <AppLink  to="https://monarchinitiative.org">
-        Monarch Web App
-      </AppLink>. 
+      <AppLink to="https://monarchinitiative.org"> Monarch Web App </AppLink>.
       Not all features are implemented yet. Please use the feedback form
       <AppIcon icon="comment" />
       &nbsp;on any page to tell us what you think!


### PR DESCRIPTION
Removes the banner linking to the old version of website, since it's now shut down. 

Also adds an optional commented out version of the banner for potential announcements we'd like to make in the production version of the app. (Just uncomment, edit section, then re-comment when we'd like to no longer announce the thing)