### PR TITLE
Fix TSV downloads, option to include orthologs in table download

### DIFF
--- a/backend/src/monarch_py/api/association.py
+++ b/backend/src/monarch_py/api/association.py
@@ -1,6 +1,6 @@
 from typing import List, Union
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, Query, Response
 
 from monarch_py.api.additional_models import OutputFormat, PaginationParams
 from monarch_py.api.config import solr
@@ -59,7 +59,7 @@ async def _get_associations(
         tsv = ""
         for row in to_tsv(response, print_output=False):
             tsv += row
-        return tsv
+        return Response(content=tsv, media_type="text/tab-separated-values")
 
 
 @router.get("/multi", include_in_schema=False)
@@ -86,4 +86,4 @@ async def _get_multi_entity_associations(
         tsv = ""
         for row in to_tsv(response, print_output=False):
             tsv += row
-        return tsv
+        return Response(content=tsv, media_type="text/tab-separated-values")

--- a/backend/src/monarch_py/api/entity.py
+++ b/backend/src/monarch_py/api/entity.py
@@ -1,7 +1,7 @@
 from io import StringIO
 from typing import List, Union
 
-from fastapi import APIRouter, Depends, HTTPException, Path, Query
+from fastapi import APIRouter, Depends, HTTPException, Path, Query, Response
 from fastapi.responses import StreamingResponse
 
 from monarch_py.api.additional_models import PaginationParams
@@ -46,7 +46,7 @@ async def _get_entity(
         tsv = ""
         for row in to_tsv(response, print_output=False):
             tsv += row
-        return tsv
+        return Response(content=tsv, media_type="text/tab-separated-values")
 
 
 @router.get("/{id}/{category}")
@@ -111,7 +111,7 @@ def _association_table(
         )
         stream = StringIO(string_response)
         response = StreamingResponse(
-            stream, media_type="text/csv" if format == OutputFormat.tsv else "application/json"
+            stream, media_type="text/tab-separated-values" if format == OutputFormat.tsv else "application/json"
         )
         response.headers["Content-Disposition"] = f"attachment; filename=assoc-table-{id}.{format.value}"
         return response
@@ -121,4 +121,4 @@ def _association_table(
         tsv = ""
         for row in to_tsv(response, print_output=False):
             tsv += row
-        return tsv
+        return Response(content=tsv, media_type="text/tab-separated-values")

--- a/backend/src/monarch_py/api/histopheno.py
+++ b/backend/src/monarch_py/api/histopheno.py
@@ -1,6 +1,6 @@
 from typing import Union
 
-from fastapi import APIRouter, HTTPException, Path, Query
+from fastapi import APIRouter, HTTPException, Path, Query, Response
 
 from monarch_py.api.config import solr
 from monarch_py.api.additional_models import OutputFormat
@@ -35,4 +35,4 @@ async def _get_histopheno(
         tsv = ""
         for row in to_tsv(response, print_output=False):
             tsv += row
-        return tsv
+        return Response(content=tsv, media_type="text/tab-separated-values")

--- a/backend/src/monarch_py/api/search.py
+++ b/backend/src/monarch_py/api/search.py
@@ -1,6 +1,6 @@
 from typing import List, Union
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, Query, Response
 
 from monarch_py.api.additional_models import OutputFormat, PaginationParams
 from monarch_py.api.config import solr
@@ -97,4 +97,4 @@ async def mappings(
         tsv = ""
         for row in to_tsv(response, print_output=False):
             tsv += row
-        return tsv
+        return Response(content=tsv, media_type="text/tab-separated-values")

--- a/frontend/src/api/associations.ts
+++ b/frontend/src/api/associations.ts
@@ -37,6 +37,7 @@ export const maxDownload = 500;
 export const downloadAssociations = async (
   nodeId = "",
   associationCategory = "",
+  traverseOrthologs = false,
   search?: string,
   sort: Sort = null,
 ) => {
@@ -44,6 +45,7 @@ export const downloadAssociations = async (
   const params = {
     limit: maxDownload,
     query: search || "",
+    traverse_orthologs: !!traverseOrthologs,
     sort: sort
       ? `${sort.key} ${sort.direction === "up" ? "asc" : "desc"}`
       : null,
@@ -61,6 +63,3 @@ export const getTopAssociations = async (
   nodeId = "",
   associationCategory = "",
 ) => await getAssociations(nodeId, associationCategory, 0, 5);
-
-/** maximum associations downloadable at once */
-export const downloadLimit = 500;

--- a/frontend/src/pages/node/AssociationsTable.vue
+++ b/frontend/src/pages/node/AssociationsTable.vue
@@ -327,6 +327,7 @@ async function download() {
   await downloadAssociations(
     props.node.id,
     props.category.id,
+    props.includeOrthologs,
     search.value,
     sort.value,
   );


### PR DESCRIPTION
- Fixes TSV downloads of association table
- Allows for including ortholog phenotypes in downloaded table if toggled

Note: Using `curl` on the API to get the TSV formatted table will return the content, but using the swagger UI will download as a file regardless of whether `download=False`