### PR TITLE
issue 667, show all descendants

### DIFF
--- a/backend/src/monarch_py/implementations/solr/solr_implementation.py
+++ b/backend/src/monarch_py/implementations/solr/solr_implementation.py
@@ -165,7 +165,7 @@ class SolrImplementation(EntityInterface, AssociationInterface, SearchInterface,
 
         return entity
 
-    def _get_counterpart_entities(
+    def get_counterpart_entities(
         self,
         this_entity: Entity,
         entity: Optional[str] = None,
@@ -192,6 +192,7 @@ class SolrImplementation(EntityInterface, AssociationInterface, SearchInterface,
                 predicate=predicate,
                 object=object,
                 direct=True,
+                limit=1000,
                 offset=0,
             ).items
         ]
@@ -208,10 +209,10 @@ class SolrImplementation(EntityInterface, AssociationInterface, SearchInterface,
             NodeHierarchy: A NodeHierarchy object
         """
 
-        super_classes = self._get_counterpart_entities(
+        super_classes = self.get_counterpart_entities(
             this_entity=entity, subject=entity.id, predicate=[AssociationPredicate.SUBCLASS_OF]
         )
-        sub_classes = self._get_counterpart_entities(
+        sub_classes = self.get_counterpart_entities(
             this_entity=entity, object=entity.id, predicate=[AssociationPredicate.SUBCLASS_OF]
         )
 

--- a/backend/tests/integration/test_solr_entity.py
+++ b/backend/tests/integration/test_solr_entity.py
@@ -12,3 +12,10 @@ def test_entity():
     entity = si.get_entity("MONDO:0007947", extra=False)
     assert entity
     assert entity.name == "Marfan syndrome"
+
+
+def test_hierarchy_limit():
+    si = SolrImplementation()
+    entity = si.get_entity("MONDO:0700096", extra=True)
+    assert entity.node_hierarchy
+    assert len(entity.node_hierarchy.sub_classes) > 20

--- a/backend/tests/unit/test_solr_implementation.py
+++ b/backend/tests/unit/test_solr_implementation.py
@@ -1,0 +1,12 @@
+from unittest.mock import patch
+
+from monarch_py.implementations.solr.solr_implementation import SolrImplementation
+
+
+def test_get_counterpart_entities_limit():
+    # Make sure that we don't accidentally end up with the default limit again
+    with patch.object(SolrImplementation, "get_associations") as mock_get_associations:
+        si = SolrImplementation()
+        si.get_counterpart_entities("MONDO:0007947")
+        assert mock_get_associations.called
+        assert mock_get_associations.call_args_list[0].kwargs['limit'] == 1000


### PR DESCRIPTION
Updates get_counterpart_entities to be non-private so that it can be tested, and then add both an integration and unit test so confirm that we aren't hitting the default limit when fetching the hierarchy
