### PR TITLE
Add Taxon, adjust positioning

### DIFF
--- a/frontend/src/pages/explore/TabSearch.vue
+++ b/frontend/src/pages/explore/TabSearch.vue
@@ -59,7 +59,8 @@
           :state="{ fromSearch: search }"
           class="title-name"
         />
-        <AppButton v-if="result.in_taxon_label"
+        <AppButton
+          v-if="result.in_taxon_label"
           v-tooltip="'Taxon Name'"
           class="title-taxon"
           :text="result.in_taxon_label || ''"
@@ -406,11 +407,11 @@ watch(from, () => runGetSearch(false));
 
 <style lang="scss" scoped>
 .title {
-  position: relative;
   display: flex;
+  position: relative;
   align-items: center;
-  gap: 15px;
   justify-content: space-between;
+  gap: 15px;
   text-align: left;
 }
 

--- a/frontend/src/pages/explore/TabSearch.vue
+++ b/frontend/src/pages/explore/TabSearch.vue
@@ -59,6 +59,15 @@
           :state="{ fromSearch: search }"
           class="title-name"
         />
+        <AppButton v-if="result.in_taxon_label"
+          v-tooltip="'Taxon Name'"
+          class="title-taxon"
+          :text="result.in_taxon_label || ''"
+          icon=""
+          design="small"
+          :copy="true"
+          color="none"
+        />
         <AppButton
           v-tooltip="'Node ID (click to copy)'"
           class="title-id"
@@ -397,19 +406,28 @@ watch(from, () => runGetSearch(false));
 
 <style lang="scss" scoped>
 .title {
+  position: relative;
   display: flex;
   align-items: center;
   gap: 15px;
+  justify-content: space-between;
   text-align: left;
 }
 
 .title-name {
-  flex-grow: 1;
-  flex-shrink: 0;
+  flex-grow: 0;
 }
 
 .title-name > :deep(svg) {
   font-size: 2rem;
+}
+
+.title-taxon {
+  position: absolute;
+  margin-left: 40%;
+  color: $dark-gray;
+  font-size: 0.9rem;
+  text-align: left;
 }
 
 .title-id {


### PR DESCRIPTION
### Related issues

- Closes #688

### Summary

- adds Taxon to gene search results
- changes spacing and flow of Title components on search results page
- fixes Users unable to identify gene differences without clicking through or decoding curies

### Checks

- [ ] All tests have passed (or issues created for failing tests)
