### PR TITLE
Fix taxon name colliding with genotype names in search

### DIFF
--- a/frontend/src/pages/explore/TabSearch.vue
+++ b/frontend/src/pages/explore/TabSearch.vue
@@ -78,6 +78,7 @@
           :copy="true"
           color="secondary"
         />
+
       </div>
       <p class="description truncate-3" tabindex="0">
         {{ result.description || "No description available" }}
@@ -424,8 +425,6 @@ watch(from, () => runGetSearch(false));
 }
 
 .title-taxon {
-  position: absolute;
-  margin-left: 40%;
   color: $dark-gray;
   font-size: 0.9rem;
   text-align: left;

--- a/frontend/src/pages/explore/TabSearch.vue
+++ b/frontend/src/pages/explore/TabSearch.vue
@@ -78,7 +78,6 @@
           :copy="true"
           color="secondary"
         />
-
       </div>
       <p class="description truncate-3" tabindex="0">
         {{ result.description || "No description available" }}


### PR DESCRIPTION
A small css tweak to get long names to wrap so that they don't collide with the taxon label

fixes #753 