### PR TITLE
Move metadata section on explore page to its own tab

### DIFF
--- a/frontend/src/pages/explore/PageExplore.vue
+++ b/frontend/src/pages/explore/PageExplore.vue
@@ -9,40 +9,9 @@
     <AppTabs v-model="tab" name="Explore Mode" :tabs="tabs" />
   </AppSection>
   <TabSearch v-if="tab === 'search'" />
-  <AppSection>
-    <AppGallery :cols="4">
-      <!-- node counts -->
-      <AppTile
-        v-for="(item, index) in metadata.node"
-        :key="index"
-        :icon="item.icon"
-        :title="startCase(item.label.replace(/biolink:/g, ''))"
-        :subtitle="formatNumber(item.count, true)"
-        design="small"
-      />
-      <!-- association counts -->
-      <AppTile
-        v-for="(item, index) in metadata.association"
-        :key="index"
-        :icon="item.icon2 ? undefined : item.icon"
-        :title="startCase(item.label.replace(/biolink:/g, ''))"
-        :subtitle="formatNumber(item.count, true)"
-        design="small"
-      >
-        <AppFlex v-if="item.icon2" gap="tiny" class="association">
-          <AppIcon :icon="item.icon" />
-          <svg viewBox="0 0 9 2" class="line">
-            <line x1="0" y1="1" x2="9" y2="1" />
-          </svg>
-          <AppIcon :icon="item.icon2" />
-        </AppFlex>
-      </AppTile>
-    </AppGallery>
-  </AppSection>
-
   <TabTextAnnotator v-if="tab === 'text-annotator'" />
-
   <TabPhenotypeExplorer v-if="tab === 'phenotype-explorer'" />
+  <TabMetadata v-if="tab === 'metadata'" />
 </template>
 
 <script setup lang="ts">
@@ -53,6 +22,7 @@ import AppTabs from "@/components/AppTabs.vue";
 import { appTitle } from "@/global/meta";
 import { formatNumber } from "@/util/string";
 import metadata from "./metadata.json";
+import TabMetadata from "./TabMetadata.vue";
 import TabPhenotypeExplorer from "./TabPhenotypeExplorer.vue";
 import tabs from "./tabs.json";
 import TabSearch from "./TabSearch.vue";
@@ -73,20 +43,3 @@ watch(
   { immediate: true, flush: "post" },
 );
 </script>
-
-<style lang="scss" scoped>
-.association {
-  font-size: 2rem;
-}
-
-.line {
-  width: 10px;
-
-  line {
-    stroke: currentColor;
-    stroke-width: 2;
-    stroke-dasharray: 1 3;
-    stroke-linecap: round;
-  }
-}
-</style>

--- a/frontend/src/pages/explore/TabMetadata.vue
+++ b/frontend/src/pages/explore/TabMetadata.vue
@@ -1,0 +1,54 @@
+<template>
+  <AppSection>
+    <AppGallery :cols="4">
+      <!-- node counts -->
+      <AppTile
+        v-for="(item, index) in metadata.node"
+        :key="index"
+        :icon="item.icon"
+        :title="startCase(item.label.replace(/biolink:/g, ''))"
+        :subtitle="formatNumber(item.count, true)"
+        design="small"
+      />
+      <!-- association counts -->
+      <AppTile
+        v-for="(item, index) in metadata.association"
+        :key="index"
+        :icon="item.icon2 ? undefined : item.icon"
+        :title="startCase(item.label.replace(/biolink:/g, ''))"
+        :subtitle="formatNumber(item.count, true)"
+        design="small"
+      >
+        <AppFlex v-if="item.icon2" gap="tiny" class="association">
+          <AppIcon :icon="item.icon" />
+          <svg viewBox="0 0 9 2" class="line">
+            <line x1="0" y1="1" x2="9" y2="1" />
+          </svg>
+          <AppIcon :icon="item.icon2" />
+        </AppFlex>
+      </AppTile>
+    </AppGallery>
+  </AppSection>
+</template>
+<script setup lang="ts">
+import { startCase } from "lodash";
+import metadata from "@/pages/explore/metadata.json";
+import { formatNumber } from "@/util/string";
+</script>
+
+<style lang="scss" scoped>
+.association {
+  font-size: 2rem;
+}
+
+.line {
+  width: 10px;
+
+  line {
+    stroke: currentColor;
+    stroke-width: 2;
+    stroke-dasharray: 1 3;
+    stroke-linecap: round;
+  }
+}
+</style>

--- a/frontend/src/pages/explore/tabs.json
+++ b/frontend/src/pages/explore/tabs.json
@@ -16,5 +16,11 @@
     "text": "Phenotype Explorer",
     "icon": "bars-progress",
     "tooltip": "Construct two sets of phenotypes and see comparisons between them"
+  },
+  {
+    "id": "metadata",
+    "text": "Metadata",
+    "icon": "info",
+    "tooltip": "View metadata about the knowledge graph"
   }
 ]


### PR DESCRIPTION
Mostly the goal here is to fix the metadata section showing up above the text annotator and phenotype explorer content, but I took it a step further by making it an additional tab. 