### PR TITLE
Add back class that sets overflow on phenogrid container

### DIFF
--- a/frontend/src/components/ThePhenogrid.vue
+++ b/frontend/src/components/ThePhenogrid.vue
@@ -18,7 +18,7 @@
       </template>
     </tooltip>
 
-    <div ref="scroll">
+    <div ref="scroll" class="scroll force-scrollbar">
       <svg
         ref="svg"
         xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
It was removed in 2c878e8 and broke the display of certain embedded phenogrid widgets (see #887)

### Related issues

- Addresses #887 (though keep open until new release is deployed)