### PR TITLE
Eliminate use of v-html when rendering node names and descriptions

### DIFF
--- a/frontend/src/components/AppNodeBadge.vue
+++ b/frontend/src/components/AppNodeBadge.vue
@@ -18,10 +18,13 @@
           ? { breadcrumbs: [...currentBreadcrumbs, ...breadcrumbs] }
           : state || undefined
       "
-      v-html="name"
-    ></AppLink>
+    >
+      <AppNodeText :text="name" />
+    </AppLink>
     <span v-else>
-      <span class="name" v-html="name"></span>
+      <span class="name">
+        <AppNodeText :text="name" />
+      </span>
       <span v-if="info">({{ info }})</span>
     </span>
   </span>
@@ -31,6 +34,7 @@
 import { computed } from "vue";
 import { getCategoryIcon, getCategoryLabel } from "@/api/categories";
 import type { Node } from "@/api/model";
+import AppNodeText from "@/components/AppNodeText.vue";
 import { breadcrumbs as currentBreadcrumbs } from "@/global/breadcrumbs";
 import type { Breadcrumb } from "@/global/breadcrumbs";
 

--- a/frontend/src/components/AppNodeText.vue
+++ b/frontend/src/components/AppNodeText.vue
@@ -4,7 +4,21 @@
   Selectively renders the following tags in HTML and SVG:
     - <sup>
     - <i>
-    - <a> with an `href` property surrounded in double quotes
+    - <a> with an `href` attribute surrounded in double quotes
+
+  There are two alternatives to the approach taken here, but neither are
+  sufficient.
+
+  1. We could use a sanitizer like [DOMPurify](https://github.com/cure53/DOMPurify)
+     to sanitize arbitrary strings, but that would strip out legitimate text
+     that an HTML parser might confuse for a tag. An example of such text can be
+     found here: <https://github.com/monarch-initiative/monarch-app/issues/887#issuecomment-2479676335>
+
+  2. We could escape the entire string, selectively unescape `&lt;sup&gt;` (and
+     so on), and then pass the string to `containerEl.innerHTML`. However, this
+     would lead to markup without the desired effect in SVG, since the <sup> and
+     <i> elements do not do anything in SVG.
+
 -->
 
 <template>
@@ -31,10 +45,10 @@ const props = withDefaults(defineProps<Props>(), {
 
 const container = ref<HTMLSpanElement | SVGTSpanElement | null>(null);
 
-type ReplacementTag = "sup" | "a" | "i";
+type ReplacedTag = "sup" | "a" | "i";
 
 type Replacement = {
-  type: ReplacementTag;
+  type: ReplacedTag;
   start: [number, number];
   end: [number, number];
   startNode?: Text;
@@ -49,26 +63,27 @@ type ReplacementPosition = {
 
 const replacementTags = new Map([
   [
-    "sup" as ReplacementTag,
+    "sup" as ReplacedTag,
     {
       regex: /(<sup>).*?(<\/sup>)/dg,
-      createSurroundingTag(isSvg: Boolean) {
+      createSurroundingEl(isSvg: Boolean) {
         return isSvg
           ? document.createElementNS("http://www.w3.org/2000/svg", "tspan")
           : document.createElement("sup");
       },
-      afterMount(isSvg: Boolean, node: Element) {
+      afterMount(isSvg: Boolean, el: Element) {
         if (!isSvg) return;
-        node.setAttribute("dy", "-1ex");
-        node.classList.add("svg-superscript");
+        el.setAttribute("dy", "-1ex");
+        el.classList.add("svg-superscript");
 
         // The next sibling will be the text node "</sup>". Check if there is
         // remaining text after that. If there is, adjust the text baseline back
         // down to the normal level.
-        const nextSibling = node.nextSibling!.nextSibling;
+        const nextSibling = el.nextSibling!.nextSibling;
         if (!nextSibling) return;
 
         const range = new Range();
+        range.selectNode(nextSibling);
 
         const tspan = document.createElementNS(
           "http://www.w3.org/2000/svg",
@@ -77,59 +92,58 @@ const replacementTags = new Map([
 
         tspan.setAttribute("dy", "+1ex");
 
-        range.selectNode(nextSibling);
         range.surroundContents(tspan);
       },
     },
   ],
   [
-    "i" as ReplacementTag,
+    "i" as ReplacedTag,
     {
       regex: /(<i>).*?(<\/i>)/dg,
-      createSurroundingTag(isSvg: Boolean) {
+      createSurroundingEl(isSvg: Boolean) {
         return isSvg
           ? document.createElementNS("http://www.w3.org/2000/svg", "tspan")
           : document.createElement("i");
       },
-      afterMount(isSvg: Boolean, node: Element) {
+      afterMount(isSvg: Boolean, el: Element) {
         if (!isSvg) return;
-        node.classList.add("svg-italic");
+        el.classList.add("svg-italic");
       },
     },
   ],
   [
-    "a" as ReplacementTag,
+    "a" as ReplacedTag,
     {
       regex: /(<a href="http[^"]+">).*?(<\/a>)/dg,
-      createSurroundingTag(isSvg: Boolean) {
+      createSurroundingEl(isSvg: Boolean) {
         return isSvg
           ? document.createElementNS("http://www.w3.org/2000/svg", "a")
           : document.createElement("a");
       },
-      afterMount(isSvg: Boolean, node: Element) {
+      afterMount(isSvg: Boolean, el: Element) {
         // The previous sibling will be the text node containing the string
         // <a href="http...">. Slice it to get the value of the href.
-        const tagTextNode = node.previousSibling!;
+        const tagTextNode = el.previousSibling!;
         const href = tagTextNode.textContent!.slice(9, -2);
-        node.setAttribute("href", href);
+        el.setAttribute("href", href);
       },
     },
   ],
 ]);
 
-function buildDOM(el: Element) {
+function buildDOM(containerEl: Element) {
   const text = props.text;
 
   const containsOnlyText =
-    el.childNodes.length === 1 &&
-    el.firstChild?.nodeType === Node.TEXT_NODE &&
+    containerEl.childNodes.length === 1 &&
+    containerEl.firstChild?.nodeType === Node.TEXT_NODE &&
     text !== null;
 
   // This should always be false, but just in case-- bail out of the function
   // if the element contains anything but a single text node.
   if (!containsOnlyText) return;
 
-  const textNode = el.firstChild as Text;
+  const textNode = containerEl.firstChild as Text;
 
   const replacements: Replacement[] = [];
 
@@ -157,8 +171,8 @@ function buildDOM(el: Element) {
   // first and the first token last).
   //
   // After that, iterate through each of the token positions and split the
-  // text node at the boundaries of each token. Store the text node of each
-  // start and end tag in the `replacements` array to be used later.
+  // text node at the token's boundaries. Store the text node of each start
+  // and end tag in the `replacements` array to be used later.
   positions
     .sort((a, b) => {
       return b.at[0] - a.at[0];
@@ -172,7 +186,7 @@ function buildDOM(el: Element) {
   // Build the correct DOM tree for each replacement found
   replacements.forEach((replacement) => {
     const { startNode, endNode, type } = replacement;
-    const { createSurroundingTag, afterMount } = replacementTags.get(type)!;
+    const { createSurroundingEl, afterMount } = replacementTags.get(type)!;
 
     // Select the range that goes from the end of the opening tag text node to
     // the start of the closing tag text node.
@@ -181,7 +195,7 @@ function buildDOM(el: Element) {
     range.setEndBefore(endNode!);
 
     // Surround that range with the appropriate DOM element.
-    const el = createSurroundingTag(props.isSvg);
+    const el = createSurroundingEl(props.isSvg);
     range.surroundContents(el);
 
     // Run any code required after the container element is mounted.

--- a/frontend/src/components/AppNodeText.vue
+++ b/frontend/src/components/AppNodeText.vue
@@ -1,0 +1,130 @@
+<!--
+  The text of a node in the knowledge graph. Specially renders any text wrapped
+  in <sup> as superscripted in HTML and SVG.
+-->
+
+<template>
+  <tspan v-if="isSVG" ref="container">
+    {{ text }}
+  </tspan>
+  <span v-else ref="container">
+    {{ text }}
+  </span>
+</template>
+
+<script setup lang="ts">
+import { onMounted, onUpdated, ref } from "vue";
+
+type Props = {
+  text: string;
+  isSVG?: boolean;
+};
+
+const props = withDefaults(defineProps<Props>(), {
+  isSVG: false,
+});
+
+const container = ref<HTMLSpanElement | SVGTSpanElement | null>(null);
+
+function renderSups(el: HTMLSpanElement | SVGTSpanElement) {
+  // State to keep track if the current last element in the child nodes is
+  // superscripted. (This is necessary because the `dy` attribute affects
+  // the current and next sibling <tspan> elements).
+  let svgCurrentlySup = false;
+
+  const text = props.text;
+
+  const containsOnlyText =
+    el.childNodes.length === 1 &&
+    el.firstChild?.nodeType === Node.TEXT_NODE &&
+    text !== null;
+
+  // This should always be false, but just in case-- bail out of the function
+  // if the element contains anything but a single text node.
+  if (!containsOnlyText) return;
+
+  const regex = /<sup>(.*?)<\/sup>/g;
+  const newChildren: Node[] = [];
+
+  let idx = 0;
+
+  // Add text to the list of new child nodes. For SVG, this is a <tspan>
+  // element. For HTML, it's a TextNode.
+  const addText = (text: string) => {
+    if (props.isSVG) {
+      const el = document.createElementNS(
+        "http://www.w3.org/2000/svg",
+        "tspan",
+      );
+      el.textContent = text;
+
+      // If the last <tspan> was superscripted (i.e. has dy="-1ex", then return
+      // the text to the normal baseline.
+      if (svgCurrentlySup) {
+        el.setAttribute("dy", "+1ex");
+        svgCurrentlySup = true;
+      }
+
+      newChildren.push(el);
+    } else {
+      newChildren.push(new Text(text));
+    }
+  };
+
+  for (const match of text.matchAll(regex)) {
+    const [outer, inner] = match;
+
+    const startText = text.slice(idx, match.index);
+
+    // If there is text before the match, add it as a text node.
+    if (startText) {
+      addText(startText);
+    }
+
+    const newNode = props.isSVG
+      ? document.createElementNS("http://www.w3.org/2000/svg", "tspan")
+      : document.createElement("sup");
+
+    newNode.textContent = inner;
+    newChildren.push(newNode);
+
+    if (props.isSVG) {
+      newNode.classList.add("svg-superscript");
+    }
+
+    // If the baseline isn't currently superscripted, move the baseline up.
+    if (!svgCurrentlySup) {
+      newNode.setAttribute("dy", "-1ex");
+      svgCurrentlySup = true;
+    }
+
+    // Advance the current index to the end of the match.
+    idx += match.index + outer.length;
+  }
+
+  // Add any remaining text beyond the match.
+  const remainingText = text.slice(idx);
+
+  if (remainingText) {
+    addText(remainingText);
+  }
+
+  el.replaceChildren(...newChildren);
+}
+
+onMounted(() => {
+  if (!container.value) return;
+  renderSups(container.value);
+});
+
+onUpdated(() => {
+  if (!container.value) return;
+  renderSups(container.value);
+});
+</script>
+
+<style>
+.svg-superscript {
+  font-size: 0.7rem;
+}
+</style>

--- a/frontend/src/components/AppNodeText.vue
+++ b/frontend/src/components/AppNodeText.vue
@@ -1,6 +1,10 @@
 <!--
-  The text of a node in the knowledge graph. Specially renders any text wrapped
-  in <sup> as superscripted in HTML and SVG.
+  The text of a node in the knowledge graph.
+
+  Selectively renders the following tags in HTML and SVG:
+    - <sup>
+    - <i>
+    - <a> with an `href` property surrounded in double quotes
 -->
 
 <template>
@@ -90,6 +94,24 @@ const replacementTags = new Map([
       afterMount(isSvg: Boolean, node: Element) {
         if (!isSvg) return;
         node.classList.add("svg-italic");
+      },
+    },
+  ],
+  [
+    "a" as ReplacementTag,
+    {
+      regex: /(<a href="http[^"]+">).*?(<\/a>)/dg,
+      createSurroundingTag(isSvg: Boolean) {
+        return isSvg
+          ? document.createElementNS("http://www.w3.org/2000/svg", "a")
+          : document.createElement("a");
+      },
+      afterMount(isSvg: Boolean, node: Element) {
+        // The previous sibling will be the text node containing the string
+        // <a href="http...">. Slice it to get the value of the href.
+        const tagTextNode = node.previousSibling!;
+        const href = tagTextNode.textContent!.slice(9, -2);
+        node.setAttribute("href", href);
       },
     },
   ],

--- a/frontend/src/components/AppNodeText.vue
+++ b/frontend/src/components/AppNodeText.vue
@@ -135,7 +135,7 @@ function buildDOM(el: Element) {
 
   // Create a list of every place there's a match for a start and end tag
   // matched from the defined regexes.
-  replacementTags.entries().forEach(([type, { regex }]) => {
+  Array.from(replacementTags.entries()).forEach(([type, { regex }]) => {
     for (const match of text.matchAll(regex)) {
       const { indices } = match;
 

--- a/frontend/src/pages/node/SectionOverview.vue
+++ b/frontend/src/pages/node/SectionOverview.vue
@@ -31,8 +31,9 @@
           v-tooltip="'Click to expand'"
           class="description truncate-10"
           tabindex="0"
-          v-html="node.description?.trim()"
-        ></p>
+        >
+          <AppNodeText :text="node.description?.trim()" />
+        </p>
       </AppDetail>
 
       <!-- inheritance -->
@@ -71,11 +72,9 @@
         title="Also Known As"
         :full="true"
       >
-        <p
-          class="truncate-2"
-          tabindex="0"
-          v-html="node.synonym?.join(',\n&nbsp;')"
-        ></p>
+        <p class="truncate-2" tabindex="0">
+          <AppNodeText :text="node.synonym?.join(',\n&nbsp;')" />
+        </p>
       </AppDetail>
 
       <!-- URI -->
@@ -155,6 +154,7 @@ import type { Node } from "@/api/model";
 import AppDetail from "@/components/AppDetail.vue";
 import AppDetails from "@/components/AppDetails.vue";
 import AppNodeBadge from "@/components/AppNodeBadge.vue";
+import AppNodeText from "@/components/AppNodeText.vue";
 import { scrollTo } from "@/router";
 import { sleep } from "@/util/debug";
 

--- a/frontend/src/pages/node/SectionTitle.vue
+++ b/frontend/src/pages/node/SectionTitle.vue
@@ -26,8 +26,8 @@
       >
         <span
           :style="{ textDecoration: node.deprecated ? 'line-through' : '' }"
-          v-html="node.name"
         >
+          <AppNodeText :text="node.name" />
         </span>
         <template v-if="node.deprecated"> (OBSOLETE)</template>
       </AppHeading>
@@ -48,6 +48,7 @@ import { computed } from "vue";
 import { truncate } from "lodash";
 import { getCategoryIcon, getCategoryLabel } from "@/api/categories";
 import type { Node } from "@/api/model";
+import AppNodeText from "@/components/AppNodeText.vue";
 import { parse } from "@/util/object";
 
 type Props = {


### PR DESCRIPTION
### Related issues

- Closes #902

### Summary

- Adds a new component, `<AppNodeText>` which safely renders text containing `<i>`, `<sup>`, and `<a>` tags, while also leaving arbitrary text \<enclosed in brackets\> untouched.
- Removes the usage of the unsafe `v-html` directive when rendering nodes, replacing it with `<AppNodeText>`

### Checks

- [x] All tests have passed (or issues created for failing tests)
