### PR TITLE
Fix rendering association frequencies; use proper field for sorting them

### DIFF
--- a/frontend/src/pages/node/AssociationsTable.vue
+++ b/frontend/src/pages/node/AssociationsTable.vue
@@ -244,7 +244,7 @@ const cols = computed((): Cols<Datum> => {
     extraCols.push(
       {
         slot: "frequency",
-        key: "frequency_computed_sortable_float",
+        key: "frequency_qualifier",
         heading: "Frequency",
         sortable: true,
       },

--- a/frontend/src/pages/node/AssociationsTable.vue
+++ b/frontend/src/pages/node/AssociationsTable.vue
@@ -57,7 +57,7 @@
 
     <template #frequency="{ row }">
       <AppPercentage
-        v-if="frequencyPercentage(row) !== undefined"
+        v-if="frequencyPercentage(row) != undefined"
         type="bar"
         :percent="frequencyPercentage(row) || 0"
         :tooltip="frequencyTooltip(row)"
@@ -244,7 +244,7 @@ const cols = computed((): Cols<Datum> => {
     extraCols.push(
       {
         slot: "frequency",
-        key: "frequency_qualifier",
+        key: "frequency_computed_sortable_float",
         heading: "Frequency",
         sortable: true,
       },
@@ -358,14 +358,14 @@ async function download() {
 /** get phenotype frequency percentage 0-1 */
 const frequencyPercentage = (row: DirectionalAssociation) => {
   /** frequency from % out of 100 */
-  if (row.has_percentage !== undefined) return row.has_percentage / 100;
+  if (row.has_percentage != undefined) return row.has_percentage / 100;
 
   /** frequency from ratio */
-  if (row.has_count !== undefined && row.has_total !== undefined) {
+  if (row.has_count != undefined && row.has_total != undefined) {
     return row.has_count / row.has_total;
   }
   /** enumerated frequencies */
-  if (row.frequency_qualifier !== undefined)
+  if (row.frequency_qualifier != undefined)
     switch (row.frequency_qualifier) {
       case "HP:0040280":
         return 1;
@@ -385,12 +385,12 @@ const frequencyPercentage = (row: DirectionalAssociation) => {
 /** get frequency tooltip */
 const frequencyTooltip = (row: DirectionalAssociation) => {
   // display fraction if possible
-  if (row.has_count !== undefined && row.has_total !== undefined) {
+  if (row.has_count != undefined && row.has_total != undefined) {
     return `${row.has_count} of ${row.has_total} cases`;
   }
 
   // if percentage is present but fraction isn't, that's what was originally in the data
-  if (row.has_percentage !== undefined && row.has_total !== undefined) {
+  if (row.has_percentage != undefined && row.has_total != undefined) {
     return `${row.has_percentage.toFixed(0)}%`;
   }
   // if no percentage or fraction, display the qualifier label


### PR DESCRIPTION
### Related issues

- Closes #910

### Summary

* Fixes rendering of frequency values in Disease-Phenotype association tables
* Makes API calls to sort by computed frequency rather than just `frequency_qualifier`

### Checks

- [x] All tests have passed (or issues created for failing tests)
