### PR TITLE
Additional phenogrid fixes

### DIFF
--- a/frontend/src/components/AppNodeText.vue
+++ b/frontend/src/components/AppNodeText.vue
@@ -45,7 +45,7 @@ const props = withDefaults(defineProps<Props>(), {
 
 const container = ref<HTMLSpanElement | SVGTSpanElement | null>(null);
 
-type ReplacedTag = "sup" | "a" | "i";
+type ReplacedTag = "sup" | "a" | "i" | "b";
 
 type Replacement = {
   type: ReplacedTag;
@@ -126,6 +126,21 @@ const replacementTags = new Map([
         const tagTextNode = el.previousSibling!;
         const href = tagTextNode.textContent!.slice(9, -2);
         el.setAttribute("href", href);
+      },
+    },
+  ],
+  [
+    "b" as ReplacedTag,
+    {
+      regex: /(<b>).*?(<\/b>)/dg,
+      createSurroundingEl(isSvg: Boolean) {
+        return isSvg
+          ? document.createElementNS("http://www.w3.org/2000/svg", "tspan")
+          : document.createElement("b");
+      },
+      afterMount(isSvg: Boolean, el: Element) {
+        if (!isSvg) return;
+        el.classList.add("svg-bold");
       },
     },
   ],
@@ -224,5 +239,8 @@ onUpdated(() => {
 }
 .svg-italic {
   font-style: italic;
+}
+.svg-bold {
+  font-weight: bold;
 }
 </style>

--- a/frontend/src/components/ThePhenogrid.vue
+++ b/frontend/src/components/ThePhenogrid.vue
@@ -66,7 +66,7 @@
         >
           <tooltip
             v-for="(col, colIndex) in cols"
-            :key="colIndex"
+            :key="col.id"
             :interactive="true"
             placement="bottom"
             follow-cursor="initial"
@@ -103,7 +103,7 @@
         >
           <tooltip
             v-for="(row, rowIndex) in rows"
-            :key="rowIndex"
+            :key="row.id"
             :interactive="true"
             placement="bottom"
             follow-cursor="initial"


### PR DESCRIPTION
Allow `<b>` tags in node labels (including phenogrid labels), and add appropriate keys for phenogrid row/column tooltips.