### PR TITLE
Move `update_publications` make target outside of `make data`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,10 +107,14 @@ fixtures:
 data:
 	@echo "Generating frontpage metadata..."
 	$(RUN) python scripts/generate_fixtures.py --metadata
-	@echo "Generating publications data..."
-	$(RUN) python scripts/get_publications.py update --update-data
 	@echo "Generating resources data..."
 	wget https://raw.githubusercontent.com/monarch-initiative/monarch-documentation/main/src/docs/resources/monarch-app-resources.json -O frontend/src/pages/resources/resources.json
+	make format-frontend
+
+.PHONY: update_publications
+update_publications:
+	@echo "Generating publications data..."
+	$(RUN) python scripts/get_publications.py update --update-data
 	make format-frontend
 
 .PHONY: category-enums

--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,6 @@ data:
 update_publications:
 	@echo "Generating publications data..."
 	$(RUN) python scripts/get_publications.py update --update-data
-	make format-frontend
 
 .PHONY: category-enums
 category-enums:

--- a/scripts/get_publications.py
+++ b/scripts/get_publications.py
@@ -339,6 +339,7 @@ def update(
 
     with output_file.open("w") as fd:
         fd.write(output)
+        fd.write("\n")
 
 
 @app.command()
@@ -351,6 +352,7 @@ def fetch_metadata(
 
     with open(outfile, "w") as fd:
         fd.write(output)
+        fd.write("\n")
 
 
 @app.command()
@@ -363,6 +365,7 @@ def fetch_publications(
 
     with open(outfile, "w") as fd:
         fd.write(output)
+        fd.write("\n")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This creates a separate `make update_publications` command which is separate from `make data`. The latter depends on an up-to-date Solr server to be running, while the former does not. It would be useful for people who don't continually run and update the Solr backend to be able to update the publications file.