### PR TITLE
MappingResult check

### DIFF
--- a/backend/src/monarch_py/api/search.py
+++ b/backend/src/monarch_py/api/search.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Depends, Query, Response
 
 from monarch_py.api.additional_models import OutputFormat, PaginationParams
 from monarch_py.api.config import solr
-from monarch_py.datamodels.model import SearchResults
+from monarch_py.datamodels.model import SearchResults, MappingResults
 from monarch_py.datamodels.category_enums import EntityCategory, MappingPredicate
 from monarch_py.utils.format_utils import to_tsv
 
@@ -69,7 +69,7 @@ async def autocomplete(
     return response
 
 
-@router.get("/mappings")
+@router.get("/mappings", response_model=MappingResults)
 async def mappings(
     entity_id: Union[List[str], None] = Query(default=None),
     subject_id: Union[List[str], None] = Query(default=None),
@@ -92,10 +92,11 @@ async def mappings(
         offset=pagination.offset,
         limit=pagination.limit,
     )
+    if not response.items:
+        return MappingResults(items=[], offset=pagination.offset, limit=pagination.limit, total=0)
     if format == OutputFormat.json:
         return response
     elif format == OutputFormat.tsv:
-        tsv = ""
-        for row in to_tsv(response, print_output=False):
-            tsv += row
-        return Response(content=tsv, media_type="text/tab-separated-values")
+        tsv = to_tsv(response, print_output=False) or ""
+        if tsv:
+            return Response(content=tsv, media_type="text/tab-separated-values")


### PR DESCRIPTION
- adds a MappingResult check into mapping endpoint
- if no items (no results) empty Mapping result is returned

### Related issues

- Closes #1048


### Summary
- prevents to call `to_tsv` if no items listed in the MappingResults from solr

### Checks

- The following tests failm but its not associated with this fix, its some pydantic ?
```
========================================================================================= short test summary info =========================================================================================
FAILED tests/unit/test_utils.py::test_get_headers_from_obj[node-node_headers] - AssertionError: assert ['id', 'categ...ription', ...] == ['id', 'categ...ription', ...]
FAILED tests/unit/test_utils.py::test_get_headers_from_obj[search-search_headers] - AssertionError: assert ['id', 'categ...ription', ...] == ['id', 'categ...ription', ...]
========================================================================= 2 failed, 189 passed, 16 skipped, 12 warnings in 11.91s =========================================================================
```
