### PR TITLE
Fix off by one error on association tables

### DIFF
--- a/frontend/src/components/TheTableContols.vue
+++ b/frontend/src/components/TheTableContols.vue
@@ -46,14 +46,14 @@
       <template v-if="showControls">
         <AppButton
           v-tooltip="'Go to next page'"
-          :disabled="start + perPage > total"
+          :disabled="start + perPage >= total"
           icon="angle-right"
           design="small"
           @click="clickNext"
         />
         <AppButton
           v-tooltip="'Go to last page'"
-          :disabled="start + perPage > total"
+          :disabled="start + perPage >= total"
           icon="angles-right"
           design="small"
           @click="clickLast"

--- a/frontend/unit/TableControls.test.ts
+++ b/frontend/unit/TableControls.test.ts
@@ -43,3 +43,25 @@ test("Downloads", async () => {
   await wrapper.find(".controls div:nth-child(3) button").trigger("click");
   expect(emitted(wrapper, "download")).toEqual([]);
 });
+
+test("Terminal page switching buttons", async () => {
+  const fiveItemsProps = {
+    ...props,
+    perPage: 5,
+    start: 0,
+    total: 5,
+  };
+
+  const wrapper = mount(TableControls as unknown as Component, {
+    props: fiveItemsProps,
+  });
+  const navButtons = wrapper
+    .findAll(".controls div:nth-child(2) button")
+    .slice(1);
+
+  // first, prev, next, last
+  expect(navButtons.length).toEqual(4);
+  for (const button of navButtons) {
+    expect(button.attributes("disabled")).not.toBeUndefined();
+  }
+});


### PR DESCRIPTION
Fixes #880.

In an association table, if there are `n` items to display; a page limit of `limit`; and `mod(n, limit)` is 0, then the "next page" and "last page" buttons are not disabled on what should be the last page. This fixes that!