### PR TITLE
Add infores api endpoints

### DIFF
--- a/.github/workflows/codecov_main.yaml
+++ b/.github/workflows/codecov_main.yaml
@@ -37,7 +37,7 @@ jobs:
         run: uv lock --check
 
       - name: Install library
-        run: uv sync --extra dev
+        run: uv sync
 
       - name: Run tests
         run: uv run pytest tests

--- a/.github/workflows/deploy-documentation.yaml
+++ b/.github/workflows/deploy-documentation.yaml
@@ -35,7 +35,7 @@ jobs:
           uv lock --directory backend --check
 
       - name: Install Dependencies
-        run: uv sync --directory backend --extra dev
+        run: uv sync --directory backend 
 
       - name: Build Documentation
         run: make docs

--- a/.github/workflows/test-backend.yaml
+++ b/.github/workflows/test-backend.yaml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Install library
         run: |
-          uv sync --extra dev
+          uv sync
 
       - name: Run tests
         run: |

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ install: install-backend install-frontend
 .PHONY: install-backend
 install-backend:
 	cd backend && \
-		uv sync --extra dev && \
+		uv sync && \
 		uv pip install -e .[dev]
 
 
@@ -78,7 +78,7 @@ install-frontend:
 
 .PHONY: model
 model: install-backend	
-	$(RUN) gen-pydantic --meta None --extra-fields allow $(SCHEMADIR)/model.yaml > $(SCHEMADIR)/model.py
+	$(RUN) gen-pydantic --meta NONE --extra-fields allow $(SCHEMADIR)/model.yaml > $(SCHEMADIR)/model.py
 	$(RUN) gen-typescript $(SCHEMADIR)/model.yaml > $(ROOTDIR)/frontend/src/api/model.ts
 	make format
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "docker>=7.1.0",
     "fastapi>=0.115.12,<1",
     "gunicorn>=23.0.0",
-    "linkml==1.8.3",
+    "linkml==1.9.2",
     "loguru",
     "oaklib>=0.6.6",
     "prefixmaps==0.2.4",

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "typer>=0.12.0",
 ]
 
-[project.optional-dependencies]
+[dependency-groups]
 dev = [
     "pytest>=8.2.0",
     "mkdocs>=1.6.0",

--- a/backend/src/monarch_py/api/infores.py
+++ b/backend/src/monarch_py/api/infores.py
@@ -1,0 +1,91 @@
+from typing import Union, List
+
+from fastapi import APIRouter, HTTPException, Path, Query, Response
+
+from monarch_py.api.config import solr
+from monarch_py.api.additional_models import OutputFormat
+from monarch_py.datamodels.model import InformationResource
+
+router = APIRouter(tags=["infores"], responses={404: {"description": "Not Found"}})
+
+
+@router.get("/")
+async def _get_infores_catalog(
+    format: OutputFormat = Query(
+        default=OutputFormat.json,
+        title="Output format for the response",
+        examples=["json", "tsv"],
+    ),
+) -> Union[List[InformationResource], str]:
+    """Retrieves all information resources from the catalog
+
+    <b>Returns:</b> <br>
+        List[InformationResource]: Complete collection of information resources
+    """
+    response = solr().get_infores_catalog()
+    if format == OutputFormat.json:
+        return response
+    elif format == OutputFormat.tsv:
+        if not response:
+            return Response(content="", media_type="text/tab-separated-values")
+        
+        # Create TSV from pydantic models
+        headers = list(response[0].model_dump().keys()) if response else []
+        tsv_lines = ["\t".join(headers)]
+        
+        for item in response:
+            row = []
+            for header in headers:
+                value = getattr(item, header, "")
+                if isinstance(value, list):
+                    value = ";".join(str(v) for v in value) if value else ""
+                row.append(str(value) if value is not None else "")
+            tsv_lines.append("\t".join(row))
+        
+        tsv_content = "\n".join(tsv_lines)
+        return Response(content=tsv_content, media_type="text/tab-separated-values")
+
+
+@router.get("/{id}")
+async def _get_entity(
+    id: str = Path(
+        title="ID of the information resource to retrieve",
+        examples=["infores:zfin"],
+    ),
+    format: OutputFormat = Query(
+        default=OutputFormat.json,
+        title="Output format for the response",
+        examples=["json", "tsv"],
+    ),
+) -> Union[InformationResource, str]:
+    """Retrieves the information resource with the specified id
+
+    <b>Args:</b> <br>
+        id (str): ID for the entity to retrieve, ex: infores:zfin
+
+    <b>Raises:</b> <br>
+        HTTPException: 404 if the entity is not found
+
+    <b>Returns:</b> <br>
+        InformationResource: Information resource details for the specified id
+    """
+    response = solr().get_infores(id)
+    if response is None:
+        raise HTTPException(status_code=404, detail="Information resource not found")
+    if format == OutputFormat.json:
+        return response
+    elif format == OutputFormat.tsv:
+        # Create TSV from pydantic model
+        headers = list(response.model_dump().keys())
+        tsv_lines = ["\t".join(headers)]
+        
+        row = []
+        for header in headers:
+            value = getattr(response, header, "")
+            if isinstance(value, list):
+                value = ";".join(str(v) for v in value) if value else ""
+            row.append(str(value) if value is not None else "")
+        tsv_lines.append("\t".join(row))
+        
+        tsv_content = "\n".join(tsv_lines)
+        return Response(content=tsv_content, media_type="text/tab-separated-values")

--- a/backend/src/monarch_py/api/main.py
+++ b/backend/src/monarch_py/api/main.py
@@ -4,7 +4,7 @@ from fastapi import FastAPI, Query
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import RedirectResponse
 
-from monarch_py.api import association, entity, histopheno, search, semsim, text_annotation
+from monarch_py.api import association, entity, histopheno, infores, search, semsim, text_annotation
 from monarch_py.api.config import semsimian, spacyner
 from monarch_py.api.middleware.logging_middleware import LoggingMiddleware
 from monarch_py.utils.utils import get_release_metadata, get_release_versions
@@ -28,6 +28,7 @@ async def lifespan(app: FastAPI):
 app.include_router(association.router, prefix=f"{PREFIX}/association")
 app.include_router(entity.router, prefix=f"{PREFIX}/entity")
 app.include_router(histopheno.router, prefix=f"{PREFIX}/histopheno")
+app.include_router(infores.router, prefix=f"{PREFIX}/infores")
 app.include_router(search.router, prefix=PREFIX)
 app.include_router(semsim.router, prefix=f"{PREFIX}/semsim")
 app.include_router(text_annotation.router, prefix=PREFIX)

--- a/backend/src/monarch_py/datamodels/model.py
+++ b/backend/src/monarch_py/datamodels/model.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
-from datetime import datetime, date, time
-from decimal import Decimal
-from enum import Enum
+
 import re
 import sys
-from typing import Any, ClassVar, List, Literal, Dict, Optional, Union
+from datetime import date, datetime, time
+from decimal import Decimal
+from enum import Enum
+from typing import Any, ClassVar, Literal, Optional, Union
+
 from pydantic import BaseModel, ConfigDict, Field, RootModel, field_validator
+
 
 metamodel_version = "None"
 version = "None"
@@ -24,7 +27,7 @@ class ConfiguredBaseModel(BaseModel):
 
 
 class LinkMLMeta(RootModel):
-    root: Dict[str, Any] = {}
+    root: dict[str, Any] = {}
     model_config = ConfigDict(frozen=True)
 
     def __getattr__(self, key: str):
@@ -40,21 +43,7 @@ class LinkMLMeta(RootModel):
         return key in self.root
 
 
-linkml_meta = LinkMLMeta(
-    {
-        "default_prefix": "https://w3id.org/monarch/monarch-py/",
-        "default_range": "string",
-        "description": "Data models for the Monarch Initiative data access library",
-        "id": "https://w3id.org/monarch/monarch-py",
-        "imports": ["linkml:types", "similarity"],
-        "name": "monarch-py",
-        "prefixes": {
-            "biolink": {"prefix_prefix": "biolink", "prefix_reference": "https://w3id.org/biolink/vocab/"},
-            "linkml": {"prefix_prefix": "linkml", "prefix_reference": "https://w3id.org/linkml/"},
-        },
-        "source_file": "/Users/divya/Documents/Dev/monarch-app/backend/src/monarch_py/datamodels/model.yaml",
-    }
-)
+linkml_meta = None
 
 
 class AssociationDirectionEnum(str, Enum):
@@ -62,20 +51,20 @@ class AssociationDirectionEnum(str, Enum):
     The directionality of an association as it relates to a specified entity, with edges being categorized as incoming or outgoing
     """
 
-    # An association for which a specified entity is the object or part of the object closure
     incoming = "incoming"
-    # An association for which a specified entity is the subject or part of the subject closure
+    """
+    An association for which a specified entity is the object or part of the object closure
+    """
     outgoing = "outgoing"
+    """
+    An association for which a specified entity is the subject or part of the subject closure
+    """
 
 
 class PairwiseSimilarity(ConfiguredBaseModel):
     """
     Abstract grouping for representing individual pairwise similarities
     """
-
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {"abstract": True, "from_schema": "https://w3id.org/monarch/monarch-py-similarity"}
-    )
 
     pass
 
@@ -85,157 +74,30 @@ class TermPairwiseSimilarity(PairwiseSimilarity):
     A simple pairwise similarity between two atomic concepts/terms
     """
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({"from_schema": "https://w3id.org/monarch/monarch-py-similarity"})
-
-    subject_id: str = Field(
-        ...,
-        json_schema_extra={"linkml_meta": {"alias": "subject_id", "domain_of": ["TermPairwiseSimilarity", "Mapping"]}},
-    )
-    subject_label: Optional[str] = Field(
-        None,
-        description="""The name of the subject entity""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "subject_label",
-                "domain_of": [
-                    "TermPairwiseSimilarity",
-                    "Association",
-                    "CompactAssociation",
-                    "AssociationTypeMapping",
-                    "Mapping",
-                    "AssociationHighlighting",
-                ],
-                "is_a": "name",
-            }
-        },
-    )
-    subject_source: Optional[str] = Field(
-        None,
-        description="""the source for the first entity""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "subject_source",
-                "domain_of": ["TermPairwiseSimilarity"],
-                "slot_uri": "sssom:subject_source",
-            }
-        },
-    )
-    object_id: str = Field(
-        ...,
-        json_schema_extra={"linkml_meta": {"alias": "object_id", "domain_of": ["TermPairwiseSimilarity", "Mapping"]}},
-    )
-    object_label: Optional[str] = Field(
-        None,
-        description="""The name of the object entity""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "object_label",
-                "domain_of": [
-                    "TermPairwiseSimilarity",
-                    "Association",
-                    "CompactAssociation",
-                    "AssociationTypeMapping",
-                    "Mapping",
-                    "AssociationHighlighting",
-                ],
-                "is_a": "name",
-            }
-        },
-    )
-    object_source: Optional[str] = Field(
-        None,
-        description="""the source for the second entity""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "object_source",
-                "domain_of": ["TermPairwiseSimilarity"],
-                "slot_uri": "sssom:object_source",
-            }
-        },
-    )
+    subject_id: str = Field(default=...)
+    subject_label: Optional[str] = Field(default=None, description="""The name of the subject entity""")
+    subject_source: Optional[str] = Field(default=None, description="""the source for the first entity""")
+    object_id: str = Field(default=...)
+    object_label: Optional[str] = Field(default=None, description="""The name of the object entity""")
+    object_source: Optional[str] = Field(default=None, description="""the source for the second entity""")
     ancestor_id: Optional[str] = Field(
-        None,
+        default=None,
         description="""the most recent common ancestor of the two compared entities. If there are multiple MRCAs then the most informative one is selected""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "ancestor_id",
-                "domain_of": ["TermPairwiseSimilarity"],
-                "todos": ["decide on what to do when there are multiple possible ancestos"],
-            }
-        },
     )
-    ancestor_label: Optional[str] = Field(
-        None,
-        description="""the name or label of the ancestor concept""",
-        json_schema_extra={"linkml_meta": {"alias": "ancestor_label", "domain_of": ["TermPairwiseSimilarity"]}},
-    )
-    ancestor_source: Optional[str] = Field(
-        None, json_schema_extra={"linkml_meta": {"alias": "ancestor_source", "domain_of": ["TermPairwiseSimilarity"]}}
-    )
-    object_information_content: Optional[float] = Field(
-        None,
-        description="""The IC of the object""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "object_information_content",
-                "domain_of": ["TermPairwiseSimilarity"],
-                "is_a": "information_content",
-            }
-        },
-    )
-    subject_information_content: Optional[float] = Field(
-        None,
-        description="""The IC of the subject""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "subject_information_content",
-                "domain_of": ["TermPairwiseSimilarity"],
-                "is_a": "information_content",
-            }
-        },
-    )
-    ancestor_information_content: Optional[float] = Field(
-        None,
-        description="""The IC of the object""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "ancestor_information_content",
-                "domain_of": ["TermPairwiseSimilarity"],
-                "is_a": "information_content",
-            }
-        },
-    )
+    ancestor_label: Optional[str] = Field(default=None, description="""the name or label of the ancestor concept""")
+    ancestor_source: Optional[str] = Field(default=None)
+    object_information_content: Optional[float] = Field(default=None, description="""The IC of the object""")
+    subject_information_content: Optional[float] = Field(default=None, description="""The IC of the subject""")
+    ancestor_information_content: Optional[float] = Field(default=None, description="""The IC of the object""")
     jaccard_similarity: Optional[float] = Field(
-        None,
-        description="""The number of concepts in the intersection divided by the number in the union""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "jaccard_similarity", "domain_of": ["TermPairwiseSimilarity"], "is_a": "score"}
-        },
+        default=None, description="""The number of concepts in the intersection divided by the number in the union"""
     )
     cosine_similarity: Optional[float] = Field(
-        None,
-        description="""the dot product of two node embeddings divided by the product of their lengths""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "cosine_similarity", "domain_of": ["TermPairwiseSimilarity"], "is_a": "score"}
-        },
+        default=None, description="""the dot product of two node embeddings divided by the product of their lengths"""
     )
-    dice_similarity: Optional[float] = Field(
-        None,
-        json_schema_extra={
-            "linkml_meta": {"alias": "dice_similarity", "domain_of": ["TermPairwiseSimilarity"], "is_a": "score"}
-        },
-    )
+    dice_similarity: Optional[float] = Field(default=None)
     phenodigm_score: Optional[float] = Field(
-        None,
-        description="""the geometric mean of the jaccard similarity and the information content""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "phenodigm_score",
-                "domain_of": ["TermPairwiseSimilarity"],
-                "equals_expression": "sqrt({jaccard_similarity} * {information_content})",
-                "is_a": "score",
-            }
-        },
+        default=None, description="""the geometric mean of the jaccard similarity and the information content"""
     )
 
 
@@ -244,701 +106,238 @@ class TermSetPairwiseSimilarity(PairwiseSimilarity):
     A simple pairwise similarity between two sets of concepts/terms
     """
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({"from_schema": "https://w3id.org/monarch/monarch-py-similarity"})
-
-    subject_termset: Optional[Dict[str, Union[str, TermInfo]]] = Field(
-        None,
-        json_schema_extra={"linkml_meta": {"alias": "subject_termset", "domain_of": ["TermSetPairwiseSimilarity"]}},
-    )
-    object_termset: Optional[Dict[str, Union[str, TermInfo]]] = Field(
-        None, json_schema_extra={"linkml_meta": {"alias": "object_termset", "domain_of": ["TermSetPairwiseSimilarity"]}}
-    )
-    subject_best_matches: Optional[Dict[str, BestMatch]] = Field(
-        None,
-        json_schema_extra={
-            "linkml_meta": {"alias": "subject_best_matches", "domain_of": ["TermSetPairwiseSimilarity"]}
-        },
-    )
-    object_best_matches: Optional[Dict[str, BestMatch]] = Field(
-        None,
-        json_schema_extra={"linkml_meta": {"alias": "object_best_matches", "domain_of": ["TermSetPairwiseSimilarity"]}},
-    )
-    average_score: Optional[float] = Field(
-        None, json_schema_extra={"linkml_meta": {"alias": "average_score", "domain_of": ["TermSetPairwiseSimilarity"]}}
-    )
-    best_score: Optional[float] = Field(
-        None, json_schema_extra={"linkml_meta": {"alias": "best_score", "domain_of": ["TermSetPairwiseSimilarity"]}}
-    )
-    metric: Optional[str] = Field(
-        None, json_schema_extra={"linkml_meta": {"alias": "metric", "domain_of": ["TermSetPairwiseSimilarity"]}}
-    )
+    subject_termset: Optional[dict[str, Union[str, TermInfo]]] = Field(default=None)
+    object_termset: Optional[dict[str, Union[str, TermInfo]]] = Field(default=None)
+    subject_best_matches: Optional[dict[str, BestMatch]] = Field(default=None)
+    object_best_matches: Optional[dict[str, BestMatch]] = Field(default=None)
+    average_score: Optional[float] = Field(default=None)
+    best_score: Optional[float] = Field(default=None)
+    metric: Optional[str] = Field(default=None)
 
 
 class TermInfo(ConfiguredBaseModel):
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({"from_schema": "https://w3id.org/monarch/monarch-py-similarity"})
-
-    id: str = Field(
-        ...,
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "id",
-                "domain_of": [
-                    "TermInfo",
-                    "Association",
-                    "ExpandedCurie",
-                    "Entity",
-                    "HistoPheno",
-                    "HistoBin",
-                    "Mapping",
-                    "MultiEntityAssociationResults",
-                ],
-            }
-        },
-    )
-    label: Optional[str] = Field(
-        None,
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "label",
-                "domain_of": ["TermInfo", "FacetValue", "FacetField"],
-                "slot_uri": "rdfs:label",
-            }
-        },
-    )
+    id: str = Field(default=...)
+    label: Optional[str] = Field(default=None)
 
 
 class BestMatch(ConfiguredBaseModel):
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({"from_schema": "https://w3id.org/monarch/monarch-py-similarity"})
-
-    match_source: str = Field(
-        ...,
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "match_source",
-                "comments": ["note that the match_source is either the subject or the object"],
-                "domain_of": ["BestMatch"],
-            }
-        },
-    )
-    match_source_label: Optional[str] = Field(
-        None, json_schema_extra={"linkml_meta": {"alias": "match_source_label", "domain_of": ["BestMatch"]}}
-    )
-    match_target: Optional[str] = Field(
-        None,
-        description="""the entity matches""",
-        json_schema_extra={"linkml_meta": {"alias": "match_target", "domain_of": ["BestMatch"]}},
-    )
-    match_target_label: Optional[str] = Field(
-        None, json_schema_extra={"linkml_meta": {"alias": "match_target_label", "domain_of": ["BestMatch"]}}
-    )
-    score: float = Field(
-        ...,
-        json_schema_extra={
-            "linkml_meta": {"alias": "score", "domain_of": ["BestMatch", "SemsimSearchResult", "SearchResult"]}
-        },
-    )
-    match_subsumer: Optional[str] = Field(
-        None, json_schema_extra={"linkml_meta": {"alias": "match_subsumer", "domain_of": ["BestMatch"]}}
-    )
-    match_subsumer_label: Optional[str] = Field(
-        None, json_schema_extra={"linkml_meta": {"alias": "match_subsumer_label", "domain_of": ["BestMatch"]}}
-    )
-    similarity: TermPairwiseSimilarity = Field(
-        ...,
-        json_schema_extra={"linkml_meta": {"alias": "similarity", "domain_of": ["BestMatch", "SemsimSearchResult"]}},
-    )
+    match_source: str = Field(default=...)
+    match_source_label: Optional[str] = Field(default=None)
+    match_target: Optional[str] = Field(default=None, description="""the entity matches""")
+    match_target_label: Optional[str] = Field(default=None)
+    score: float = Field(default=...)
+    match_subsumer: Optional[str] = Field(default=None)
+    match_subsumer_label: Optional[str] = Field(default=None)
+    similarity: TermPairwiseSimilarity = Field(default=...)
 
 
 class SemsimSearchResult(ConfiguredBaseModel):
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {
-            "from_schema": "https://w3id.org/monarch/monarch-py-similarity",
-            "slot_usage": {"subject": {"inlined": True, "name": "subject", "range": "Entity"}},
-        }
-    )
-
-    subject: Entity = Field(
-        ...,
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "subject",
-                "domain_of": ["SemsimSearchResult", "Association", "CompactAssociation"],
-            }
-        },
-    )
-    score: Optional[float] = Field(
-        None,
-        json_schema_extra={
-            "linkml_meta": {"alias": "score", "domain_of": ["BestMatch", "SemsimSearchResult", "SearchResult"]}
-        },
-    )
-    similarity: Optional[TermSetPairwiseSimilarity] = Field(
-        None,
-        json_schema_extra={"linkml_meta": {"alias": "similarity", "domain_of": ["BestMatch", "SemsimSearchResult"]}},
-    )
+    subject: Entity = Field(default=...)
+    score: Optional[float] = Field(default=None)
+    similarity: Optional[TermSetPairwiseSimilarity] = Field(default=None)
 
 
 class Association(ConfiguredBaseModel):
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({"from_schema": "https://w3id.org/monarch/monarch-py"})
-
-    id: str = Field(
-        ...,
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "id",
-                "domain_of": [
-                    "TermInfo",
-                    "Association",
-                    "ExpandedCurie",
-                    "Entity",
-                    "HistoPheno",
-                    "HistoBin",
-                    "Mapping",
-                    "MultiEntityAssociationResults",
-                ],
-            }
-        },
+    id: str = Field(default=...)
+    category: Optional[str] = Field(default=None)
+    subject: str = Field(default=...)
+    original_subject: Optional[str] = Field(default=None)
+    subject_namespace: Optional[str] = Field(default=None, description="""The namespace/prefix of the subject entity""")
+    subject_category: Optional[str] = Field(default=None, description="""The category of the subject entity""")
+    subject_closure: Optional[list[str]] = Field(
+        default=None, description="""Field containing subject id and the ids of all of it's ancestors"""
     )
-    category: Optional[str] = Field(
-        None,
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "category",
-                "domain_of": [
-                    "Association",
-                    "AssociationCount",
-                    "CompactAssociation",
-                    "AssociationTypeMapping",
-                    "Entity",
-                ],
-            }
-        },
+    subject_label: Optional[str] = Field(default=None, description="""The name of the subject entity""")
+    subject_closure_label: Optional[list[str]] = Field(
+        default=None, description="""Field containing subject name and the names of all of it's ancestors"""
     )
-    subject: str = Field(
-        ...,
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "subject",
-                "domain_of": ["SemsimSearchResult", "Association", "CompactAssociation"],
-            }
-        },
-    )
-    original_subject: Optional[str] = Field(
-        None, json_schema_extra={"linkml_meta": {"alias": "original_subject", "domain_of": ["Association"]}}
-    )
-    subject_namespace: Optional[str] = Field(
-        None,
-        description="""The namespace/prefix of the subject entity""",
-        json_schema_extra={"linkml_meta": {"alias": "subject_namespace", "domain_of": ["Association"]}},
-    )
-    subject_category: Optional[str] = Field(
-        None,
-        description="""The category of the subject entity""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "subject_category", "domain_of": ["Association"], "is_a": "category"}
-        },
-    )
-    subject_closure: Optional[List[str]] = Field(
-        None,
-        description="""Field containing subject id and the ids of all of it's ancestors""",
-        json_schema_extra={"linkml_meta": {"alias": "subject_closure", "domain_of": ["Association"]}},
-    )
-    subject_label: Optional[str] = Field(
-        None,
-        description="""The name of the subject entity""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "subject_label",
-                "domain_of": [
-                    "TermPairwiseSimilarity",
-                    "Association",
-                    "CompactAssociation",
-                    "AssociationTypeMapping",
-                    "Mapping",
-                    "AssociationHighlighting",
-                ],
-                "is_a": "name",
-            }
-        },
-    )
-    subject_closure_label: Optional[List[str]] = Field(
-        None,
-        description="""Field containing subject name and the names of all of it's ancestors""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "subject_closure_label", "domain_of": ["Association", "AssociationHighlighting"]}
-        },
-    )
-    subject_taxon: Optional[str] = Field(
-        None,
-        json_schema_extra={"linkml_meta": {"alias": "subject_taxon", "domain_of": ["Association"], "is_a": "in_taxon"}},
-    )
-    subject_taxon_label: Optional[str] = Field(
-        None,
-        json_schema_extra={
-            "linkml_meta": {"alias": "subject_taxon_label", "domain_of": ["Association"], "is_a": "in_taxon_label"}
-        },
-    )
-    predicate: str = Field(
-        ...,
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "predicate",
-                "domain_of": ["Association", "CompactAssociation", "AssociationHighlighting"],
-            }
-        },
-    )
+    subject_taxon: Optional[str] = Field(default=None)
+    subject_taxon_label: Optional[str] = Field(default=None)
+    predicate: str = Field(default=...)
     original_predicate: Optional[str] = Field(
-        None,
+        default=None,
         description="""used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.""",
-        json_schema_extra={"linkml_meta": {"alias": "original_predicate", "domain_of": ["Association"]}},
     )
-    object: str = Field(
-        ..., json_schema_extra={"linkml_meta": {"alias": "object", "domain_of": ["Association", "CompactAssociation"]}}
+    object: str = Field(default=...)
+    original_object: Optional[str] = Field(default=None)
+    object_namespace: Optional[str] = Field(default=None, description="""The namespace/prefix of the object entity""")
+    object_category: Optional[str] = Field(default=None, description="""The category of the object entity""")
+    object_closure: Optional[list[str]] = Field(
+        default=None, description="""Field containing object id and the ids of all of it's ancestors"""
     )
-    original_object: Optional[str] = Field(
-        None, json_schema_extra={"linkml_meta": {"alias": "original_object", "domain_of": ["Association"]}}
+    object_label: Optional[str] = Field(default=None, description="""The name of the object entity""")
+    object_closure_label: Optional[list[str]] = Field(
+        default=None, description="""Field containing object name and the names of all of it's ancestors"""
     )
-    object_namespace: Optional[str] = Field(
-        None,
-        description="""The namespace/prefix of the object entity""",
-        json_schema_extra={"linkml_meta": {"alias": "object_namespace", "domain_of": ["Association"]}},
-    )
-    object_category: Optional[str] = Field(
-        None,
-        description="""The category of the object entity""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "object_category", "domain_of": ["Association"], "is_a": "category"}
-        },
-    )
-    object_closure: Optional[List[str]] = Field(
-        None,
-        description="""Field containing object id and the ids of all of it's ancestors""",
-        json_schema_extra={"linkml_meta": {"alias": "object_closure", "domain_of": ["Association"]}},
-    )
-    object_label: Optional[str] = Field(
-        None,
-        description="""The name of the object entity""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "object_label",
-                "domain_of": [
-                    "TermPairwiseSimilarity",
-                    "Association",
-                    "CompactAssociation",
-                    "AssociationTypeMapping",
-                    "Mapping",
-                    "AssociationHighlighting",
-                ],
-                "is_a": "name",
-            }
-        },
-    )
-    object_closure_label: Optional[List[str]] = Field(
-        None,
-        description="""Field containing object name and the names of all of it's ancestors""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "object_closure_label", "domain_of": ["Association", "AssociationHighlighting"]}
-        },
-    )
-    object_taxon: Optional[str] = Field(
-        None,
-        json_schema_extra={"linkml_meta": {"alias": "object_taxon", "domain_of": ["Association"], "is_a": "in_taxon"}},
-    )
-    object_taxon_label: Optional[str] = Field(
-        None,
-        json_schema_extra={
-            "linkml_meta": {"alias": "object_taxon_label", "domain_of": ["Association"], "is_a": "in_taxon_label"}
-        },
-    )
-    primary_knowledge_source: Optional[str] = Field(
-        None, json_schema_extra={"linkml_meta": {"alias": "primary_knowledge_source", "domain_of": ["Association"]}}
-    )
-    aggregator_knowledge_source: Optional[List[str]] = Field(
-        None, json_schema_extra={"linkml_meta": {"alias": "aggregator_knowledge_source", "domain_of": ["Association"]}}
-    )
-    negated: Optional[bool] = Field(
-        None,
-        json_schema_extra={"linkml_meta": {"alias": "negated", "domain_of": ["Association", "CompactAssociation"]}},
-    )
-    pathway: Optional[str] = Field(
-        None, json_schema_extra={"linkml_meta": {"alias": "pathway", "domain_of": ["Association"]}}
-    )
+    object_taxon: Optional[str] = Field(default=None)
+    object_taxon_label: Optional[str] = Field(default=None)
+    primary_knowledge_source: Optional[str] = Field(default=None)
+    aggregator_knowledge_source: Optional[list[str]] = Field(default=None)
+    negated: Optional[bool] = Field(default=None)
+    pathway: Optional[str] = Field(default=None)
     evidence_count: Optional[int] = Field(
-        None,
-        description="""count of supporting documents, evidence codes, and sources supplying evidence""",
-        json_schema_extra={"linkml_meta": {"alias": "evidence_count", "domain_of": ["Association"]}},
+        default=None, description="""count of supporting documents, evidence codes, and sources supplying evidence"""
     )
     knowledge_level: str = Field(
-        ...,
+        default=...,
         description="""Describes the level of knowledge expressed in a statement, based on the reasoning or analysis methods used to generate the statement, or the scope or specificity of what the statement expresses to be true.""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "knowledge_level",
-                "domain_of": ["Association"],
-                "notes": [
-                    "The range in this schema is represented as a string, but is "
-                    "constrained  to values from biolink:KnowledgeLevelEnum at ingest "
-                    "time"
-                ],
-                "slot_uri": "biolink:knowledge_level",
-            }
-        },
     )
     agent_type: str = Field(
-        ...,
+        default=...,
         description="""Describes the high-level category of agent who originally generated a  statement of knowledge or other type of information.""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "agent_type",
-                "domain_of": ["Association"],
-                "notes": [
-                    "The range in this schema is represented as a string, but is "
-                    "constrained  to values from biolink:AgentTypeEnum at ingest time"
-                ],
-                "slot_uri": "biolink:agent_type",
-            }
-        },
     )
-    has_evidence: Optional[List[str]] = Field(
-        None, json_schema_extra={"linkml_meta": {"alias": "has_evidence", "domain_of": ["Association"]}}
+    has_evidence: Optional[list[str]] = Field(default=None)
+    has_evidence_links: Optional[list[ExpandedCurie]] = Field(
+        default=None, description="""List of ExpandedCuries with id and url for evidence"""
     )
-    has_evidence_links: Optional[List[ExpandedCurie]] = Field(
-        None,
-        description="""List of ExpandedCuries with id and url for evidence""",
-        json_schema_extra={"linkml_meta": {"alias": "has_evidence_links", "domain_of": ["Association"]}},
-    )
-    has_count: Optional[int] = Field(
-        None,
-        description="""count of out of has_total representing a frequency""",
-        json_schema_extra={"linkml_meta": {"alias": "has_count", "domain_of": ["Association"]}},
-    )
+    has_count: Optional[int] = Field(default=None, description="""count of out of has_total representing a frequency""")
     has_total: Optional[int] = Field(
-        None,
-        description="""total, devided by has_count, representing a frequency""",
-        json_schema_extra={"linkml_meta": {"alias": "has_total", "domain_of": ["Association"]}},
+        default=None, description="""total, devided by has_count, representing a frequency"""
     )
     has_percentage: Optional[float] = Field(
-        None,
+        default=None,
         description="""percentage, which may be calculated from has_count and has_total, as 100 * quotient or provided directly, rounded to the integer level""",
-        json_schema_extra={"linkml_meta": {"alias": "has_percentage", "domain_of": ["Association"]}},
     )
     has_quotient: Optional[float] = Field(
-        None,
-        description="""quotient, which should be 1/100 of has_percentage""",
-        json_schema_extra={"linkml_meta": {"alias": "has_quotient", "domain_of": ["Association"]}},
+        default=None, description="""quotient, which should be 1/100 of has_percentage"""
     )
     grouping_key: Optional[str] = Field(
-        None,
+        default=None,
         description="""A concatenation of fields used to group associations with the same essential/defining properties""",
-        json_schema_extra={"linkml_meta": {"alias": "grouping_key", "domain_of": ["Association"]}},
     )
-    provided_by: Optional[str] = Field(
-        None, json_schema_extra={"linkml_meta": {"alias": "provided_by", "domain_of": ["Association", "Entity"]}}
-    )
+    provided_by: Optional[str] = Field(default=None)
     provided_by_link: Optional[ExpandedCurie] = Field(
-        None,
-        description="""A link to the docs for the knowledge source that provided the node/edge.""",
-        json_schema_extra={"linkml_meta": {"alias": "provided_by_link", "domain_of": ["Association", "Node"]}},
+        default=None, description="""A link to the docs for the knowledge source that provided the node/edge."""
     )
-    publications: Optional[List[str]] = Field(
-        None, json_schema_extra={"linkml_meta": {"alias": "publications", "domain_of": ["Association"]}}
+    publications: Optional[list[str]] = Field(default=None)
+    publications_links: Optional[list[ExpandedCurie]] = Field(
+        default=None, description="""List of ExpandedCuries with id and url for publications"""
     )
-    publications_links: Optional[List[ExpandedCurie]] = Field(
-        None,
-        description="""List of ExpandedCuries with id and url for publications""",
-        json_schema_extra={"linkml_meta": {"alias": "publications_links", "domain_of": ["Association"]}},
-    )
-    frequency_qualifier: Optional[str] = Field(
-        None, json_schema_extra={"linkml_meta": {"alias": "frequency_qualifier", "domain_of": ["Association"]}}
-    )
-    onset_qualifier: Optional[str] = Field(
-        None, json_schema_extra={"linkml_meta": {"alias": "onset_qualifier", "domain_of": ["Association"]}}
-    )
-    sex_qualifier: Optional[str] = Field(
-        None, json_schema_extra={"linkml_meta": {"alias": "sex_qualifier", "domain_of": ["Association"]}}
-    )
-    stage_qualifier: Optional[str] = Field(
-        None, json_schema_extra={"linkml_meta": {"alias": "stage_qualifier", "domain_of": ["Association"]}}
-    )
-    qualifiers: Optional[List[str]] = Field(
-        None, json_schema_extra={"linkml_meta": {"alias": "qualifiers", "domain_of": ["Association"]}}
-    )
-    qualifiers_label: Optional[str] = Field(
-        None,
-        description="""The name of the frequency_qualifier entity""",
-        json_schema_extra={"linkml_meta": {"alias": "qualifiers_label", "domain_of": ["Association"], "is_a": "name"}},
-    )
+    frequency_qualifier: Optional[str] = Field(default=None)
+    onset_qualifier: Optional[str] = Field(default=None)
+    sex_qualifier: Optional[str] = Field(default=None)
+    stage_qualifier: Optional[str] = Field(default=None)
+    qualifiers: Optional[list[str]] = Field(default=None)
+    qualifiers_label: Optional[str] = Field(default=None, description="""The name of the frequency_qualifier entity""")
     qualifiers_namespace: Optional[str] = Field(
-        None,
-        description="""The namespace/prefix of the frequency_qualifier entity""",
-        json_schema_extra={"linkml_meta": {"alias": "qualifiers_namespace", "domain_of": ["Association"]}},
+        default=None, description="""The namespace/prefix of the frequency_qualifier entity"""
     )
     qualifiers_category: Optional[str] = Field(
-        None,
-        description="""The category of the frequency_qualifier entity""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "qualifiers_category", "domain_of": ["Association"], "is_a": "category"}
-        },
+        default=None, description="""The category of the frequency_qualifier entity"""
     )
-    qualifier: Optional[List[str]] = Field(
-        None, json_schema_extra={"linkml_meta": {"alias": "qualifier", "domain_of": ["Association"]}}
-    )
-    qualifier_label: Optional[str] = Field(
-        None,
-        description="""The name of the frequency_qualifier entity""",
-        json_schema_extra={"linkml_meta": {"alias": "qualifier_label", "domain_of": ["Association"], "is_a": "name"}},
-    )
+    qualifier: Optional[list[str]] = Field(default=None)
+    qualifier_label: Optional[str] = Field(default=None, description="""The name of the frequency_qualifier entity""")
     qualifier_namespace: Optional[str] = Field(
-        None,
-        description="""The namespace/prefix of the frequency_qualifier entity""",
-        json_schema_extra={"linkml_meta": {"alias": "qualifier_namespace", "domain_of": ["Association"]}},
+        default=None, description="""The namespace/prefix of the frequency_qualifier entity"""
     )
     qualifier_category: Optional[str] = Field(
-        None,
-        description="""The category of the frequency_qualifier entity""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "qualifier_category", "domain_of": ["Association"], "is_a": "category"}
-        },
+        default=None, description="""The category of the frequency_qualifier entity"""
     )
     frequency_qualifier_label: Optional[str] = Field(
-        None,
-        description="""The name of the frequency_qualifier entity""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "frequency_qualifier_label", "domain_of": ["Association"], "is_a": "name"}
-        },
+        default=None, description="""The name of the frequency_qualifier entity"""
     )
     frequency_qualifier_namespace: Optional[str] = Field(
-        None,
-        description="""The namespace/prefix of the frequency_qualifier entity""",
-        json_schema_extra={"linkml_meta": {"alias": "frequency_qualifier_namespace", "domain_of": ["Association"]}},
+        default=None, description="""The namespace/prefix of the frequency_qualifier entity"""
     )
     frequency_qualifier_category: Optional[str] = Field(
-        None,
-        description="""The category of the frequency_qualifier entity""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "frequency_qualifier_category", "domain_of": ["Association"], "is_a": "category"}
-        },
+        default=None, description="""The category of the frequency_qualifier entity"""
     )
-    onset_qualifier_label: Optional[str] = Field(
-        None,
-        description="""The name of the onset_qualifier entity""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "onset_qualifier_label", "domain_of": ["Association"], "is_a": "name"}
-        },
-    )
+    onset_qualifier_label: Optional[str] = Field(default=None, description="""The name of the onset_qualifier entity""")
     onset_qualifier_namespace: Optional[str] = Field(
-        None,
-        description="""The namespace/prefix of the onset_qualifier entity""",
-        json_schema_extra={"linkml_meta": {"alias": "onset_qualifier_namespace", "domain_of": ["Association"]}},
+        default=None, description="""The namespace/prefix of the onset_qualifier entity"""
     )
     onset_qualifier_category: Optional[str] = Field(
-        None,
-        description="""The category of the onset_qualifier entity""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "onset_qualifier_category", "domain_of": ["Association"], "is_a": "category"}
-        },
+        default=None, description="""The category of the onset_qualifier entity"""
     )
-    sex_qualifier_label: Optional[str] = Field(
-        None,
-        description="""The name of the sex_qualifier entity""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "sex_qualifier_label", "domain_of": ["Association"], "is_a": "name"}
-        },
-    )
+    sex_qualifier_label: Optional[str] = Field(default=None, description="""The name of the sex_qualifier entity""")
     sex_qualifier_namespace: Optional[str] = Field(
-        None,
-        description="""The namespace/prefix of the sex_qualifier entity""",
-        json_schema_extra={"linkml_meta": {"alias": "sex_qualifier_namespace", "domain_of": ["Association"]}},
+        default=None, description="""The namespace/prefix of the sex_qualifier entity"""
     )
     sex_qualifier_category: Optional[str] = Field(
-        None,
-        description="""The category of the sex_qualifier entity""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "sex_qualifier_category", "domain_of": ["Association"], "is_a": "category"}
-        },
+        default=None, description="""The category of the sex_qualifier entity"""
     )
-    stage_qualifier_label: Optional[str] = Field(
-        None,
-        description="""The name of the stage_qualifier entity""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "stage_qualifier_label", "domain_of": ["Association"], "is_a": "name"}
-        },
-    )
+    stage_qualifier_label: Optional[str] = Field(default=None, description="""The name of the stage_qualifier entity""")
     stage_qualifier_namespace: Optional[str] = Field(
-        None,
-        description="""The namespace/prefix of the stage_qualifier entity""",
-        json_schema_extra={"linkml_meta": {"alias": "stage_qualifier_namespace", "domain_of": ["Association"]}},
+        default=None, description="""The namespace/prefix of the stage_qualifier entity"""
     )
     stage_qualifier_category: Optional[str] = Field(
-        None,
-        description="""The category of the stage_qualifier entity""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "stage_qualifier_category", "domain_of": ["Association"], "is_a": "category"}
-        },
+        default=None, description="""The category of the stage_qualifier entity"""
     )
     disease_context_qualifier: Optional[str] = Field(
-        None,
+        default=None,
         description="""A context qualifier representing a disease or condition in which a relationship expressed in an association took place.""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "disease_context_qualifier",
-                "domain_of": ["Association"],
-                "examples": [{"value": "MONDO:0004979"}, {"value": "MONDO:0005148"}],
-            }
-        },
     )
     disease_context_qualifier_label: Optional[str] = Field(
-        None,
-        description="""The name of the disease_context_qualifier entity""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "disease_context_qualifier_label", "domain_of": ["Association"], "is_a": "name"}
-        },
+        default=None, description="""The name of the disease_context_qualifier entity"""
     )
     disease_context_qualifier_namespace: Optional[str] = Field(
-        None,
-        description="""The namespace/prefix of the disease_context_qualifier entity""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "disease_context_qualifier_namespace", "domain_of": ["Association"]}
-        },
+        default=None, description="""The namespace/prefix of the disease_context_qualifier entity"""
     )
     disease_context_qualifier_category: Optional[str] = Field(
-        None,
-        description="""The category of the disease_context_qualifier entity""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "disease_context_qualifier_category",
-                "domain_of": ["Association"],
-                "is_a": "category",
-            }
-        },
+        default=None, description="""The category of the disease_context_qualifier entity"""
     )
-    disease_context_qualifier_closure: Optional[List[str]] = Field(
-        None,
+    disease_context_qualifier_closure: Optional[list[str]] = Field(
+        default=None,
         description="""Field containing disease_context_qualifier id and the ids of all of it's ancestors""",
-        json_schema_extra={"linkml_meta": {"alias": "disease_context_qualifier_closure", "domain_of": ["Association"]}},
     )
-    disease_context_qualifier_closure_label: Optional[List[str]] = Field(
-        None,
+    disease_context_qualifier_closure_label: Optional[list[str]] = Field(
+        default=None,
         description="""Field containing disease_context_qualifier name and the names of all of it's ancestors""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "disease_context_qualifier_closure_label", "domain_of": ["Association"]}
-        },
     )
     species_context_qualifier: Optional[str] = Field(
-        None,
+        default=None,
         description="""A context qualifier representing a species in which a relationship expressed in an association took place.""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "species_context_qualifier",
-                "domain_of": ["Association"],
-                "examples": [{"value": "NCBITaxon:9606"}],
-            }
-        },
     )
     species_context_qualifier_label: Optional[str] = Field(
-        None,
-        description="""The name of the species_context_qualifier entity""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "species_context_qualifier_label", "domain_of": ["Association"], "is_a": "name"}
-        },
+        default=None, description="""The name of the species_context_qualifier entity"""
     )
     species_context_qualifier_namespace: Optional[str] = Field(
-        None,
-        description="""The namespace/prefix of the species_context_qualifier entity""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "species_context_qualifier_namespace", "domain_of": ["Association"]}
-        },
+        default=None, description="""The namespace/prefix of the species_context_qualifier entity"""
     )
     species_context_qualifier_category: Optional[str] = Field(
-        None,
-        description="""The category of the species_context_qualifier entity""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "species_context_qualifier_category",
-                "domain_of": ["Association"],
-                "is_a": "category",
-            }
-        },
+        default=None, description="""The category of the species_context_qualifier entity"""
     )
     subject_specialization_qualifier: Optional[str] = Field(
-        None,
+        default=None,
         description="""A qualifier that composes with a core subject/object concept to define a more specific version of the subject concept, specifically using an ontology term that is not a subclass or descendant of the core concept and in the vast majority of cases, is of a different ontological namespace than the category or namespace of the subject identifier.""",
-        json_schema_extra={"linkml_meta": {"alias": "subject_specialization_qualifier", "domain_of": ["Association"]}},
     )
     subject_specialization_qualifier_label: Optional[str] = Field(
-        None,
-        description="""A label for the subject_specialization_qualifier""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "subject_specialization_qualifier_label", "domain_of": ["Association"]}
-        },
+        default=None, description="""A label for the subject_specialization_qualifier"""
     )
     subject_specialization_qualifier_namespace: Optional[str] = Field(
-        None,
-        description="""The namespace/prefix of the subject_specialization_qualifier""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "subject_specialization_qualifier_namespace", "domain_of": ["Association"]}
-        },
+        default=None, description="""The namespace/prefix of the subject_specialization_qualifier"""
     )
     subject_specialization_qualifier_category: Optional[str] = Field(
-        None,
-        description="""The category of the subject_specialization_qualifier""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "subject_specialization_qualifier_category", "domain_of": ["Association"]}
-        },
+        default=None, description="""The category of the subject_specialization_qualifier"""
     )
     subject_specialization_qualifier_closure: Optional[str] = Field(
-        None,
+        default=None,
         description="""A closure of the subject_specialization_qualifier, including the subject_specialization_qualifier itself and all of its ancestors""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "subject_specialization_qualifier_closure", "domain_of": ["Association"]}
-        },
     )
     subject_specialization_qualifier_closure_label: Optional[str] = Field(
-        None,
+        default=None,
         description="""A closure of the subject_specialization_qualifier, including the subject_specialization_qualifier itself and all of its ancestors""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "subject_specialization_qualifier_closure_label", "domain_of": ["Association"]}
-        },
     )
     object_specialization_qualifier: Optional[str] = Field(
-        None,
+        default=None,
         description="""A qualifier that composes with a core subject/object concept to define a more specific version of the object concept, specifically using an ontology term that is not a subclass or descendant of the core concept and in the vast majority of cases, is of a different ontological namespace than the category or namespace of the object identifier.""",
-        json_schema_extra={"linkml_meta": {"alias": "object_specialization_qualifier", "domain_of": ["Association"]}},
     )
     object_specialization_qualifier_label: Optional[str] = Field(
-        None,
-        description="""A label for the object_specialization_qualifier""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "object_specialization_qualifier_label", "domain_of": ["Association"]}
-        },
+        default=None, description="""A label for the object_specialization_qualifier"""
     )
     object_specialization_qualifier_namespace: Optional[str] = Field(
-        None,
-        description="""The namespace/prefix of the object_specialization_qualifier""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "object_specialization_qualifier_namespace", "domain_of": ["Association"]}
-        },
+        default=None, description="""The namespace/prefix of the object_specialization_qualifier"""
     )
     object_specialization_qualifier_category: Optional[str] = Field(
-        None,
-        description="""The category of the object_specialization_qualifier""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "object_specialization_qualifier_category", "domain_of": ["Association"]}
-        },
+        default=None, description="""The category of the object_specialization_qualifier"""
     )
     object_specialization_qualifier_closure: Optional[str] = Field(
-        None,
+        default=None,
         description="""A closure of the object_specialization_qualifier, including the object_specialization_qualifier itself and all of its ancestors""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "object_specialization_qualifier_closure", "domain_of": ["Association"]}
-        },
     )
     object_specialization_qualifier_closure_label: Optional[str] = Field(
-        None,
+        default=None,
         description="""A closure of the object_specialization_qualifier, including the object_specialization_qualifier itself and all of its ancestors""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "object_specialization_qualifier_closure_label", "domain_of": ["Association"]}
-        },
     )
 
 
@@ -947,114 +346,19 @@ class AssociationCountList(ConfiguredBaseModel):
     Container class for a list of association counts
     """
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {
-            "from_schema": "https://w3id.org/monarch/monarch-py",
-            "slot_usage": {"items": {"name": "items", "range": "AssociationCount"}},
-        }
-    )
-
-    items: List[AssociationCount] = Field(
-        ...,
-        description="""A collection of items, with the type to be overriden by slot_usage""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "items",
-                "domain_of": [
-                    "AssociationCountList",
-                    "AssociationResults",
-                    "CompactAssociationResults",
-                    "AssociationTableResults",
-                    "CategoryGroupedAssociationResults",
-                    "EntityResults",
-                    "HistoPheno",
-                    "MappingResults",
-                    "SearchResults",
-                ],
-            }
-        },
+    items: list[AssociationCount] = Field(
+        default=..., description="""A collection of items, with the type to be overriden by slot_usage"""
     )
 
 
 class CompactAssociation(ConfiguredBaseModel):
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({"from_schema": "https://w3id.org/monarch/monarch-py"})
-
-    category: Optional[str] = Field(
-        None,
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "category",
-                "domain_of": [
-                    "Association",
-                    "AssociationCount",
-                    "CompactAssociation",
-                    "AssociationTypeMapping",
-                    "Entity",
-                ],
-            }
-        },
-    )
-    subject: str = Field(
-        ...,
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "subject",
-                "domain_of": ["SemsimSearchResult", "Association", "CompactAssociation"],
-            }
-        },
-    )
-    subject_label: Optional[str] = Field(
-        None,
-        description="""The name of the subject entity""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "subject_label",
-                "domain_of": [
-                    "TermPairwiseSimilarity",
-                    "Association",
-                    "CompactAssociation",
-                    "AssociationTypeMapping",
-                    "Mapping",
-                    "AssociationHighlighting",
-                ],
-                "is_a": "name",
-            }
-        },
-    )
-    predicate: str = Field(
-        ...,
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "predicate",
-                "domain_of": ["Association", "CompactAssociation", "AssociationHighlighting"],
-            }
-        },
-    )
-    object: str = Field(
-        ..., json_schema_extra={"linkml_meta": {"alias": "object", "domain_of": ["Association", "CompactAssociation"]}}
-    )
-    object_label: Optional[str] = Field(
-        None,
-        description="""The name of the object entity""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "object_label",
-                "domain_of": [
-                    "TermPairwiseSimilarity",
-                    "Association",
-                    "CompactAssociation",
-                    "AssociationTypeMapping",
-                    "Mapping",
-                    "AssociationHighlighting",
-                ],
-                "is_a": "name",
-            }
-        },
-    )
-    negated: Optional[bool] = Field(
-        None,
-        json_schema_extra={"linkml_meta": {"alias": "negated", "domain_of": ["Association", "CompactAssociation"]}},
-    )
+    category: Optional[str] = Field(default=None)
+    subject: str = Field(default=...)
+    subject_label: Optional[str] = Field(default=None, description="""The name of the subject entity""")
+    predicate: str = Field(default=...)
+    object: str = Field(default=...)
+    object_label: Optional[str] = Field(default=None, description="""The name of the object entity""")
+    negated: Optional[bool] = Field(default=None)
 
 
 class AssociationTypeMapping(ConfiguredBaseModel):
@@ -1062,101 +366,20 @@ class AssociationTypeMapping(ConfiguredBaseModel):
     A data class to hold the necessary information to produce association type counts for given  entities with appropriate directional labels
     """
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {
-            "from_schema": "https://w3id.org/monarch/monarch-py",
-            "slot_usage": {
-                "category": {
-                    "description": "The biolink category to use in " "queries for this association type",
-                    "multivalued": False,
-                    "name": "category",
-                    "required": True,
-                },
-                "object_label": {
-                    "description": "A label to describe the "
-                    "objects of the association "
-                    "type as a whole for use in "
-                    "the UI",
-                    "name": "object_label",
-                },
-                "subject_label": {
-                    "description": "A label to describe the "
-                    "subjects of the association "
-                    "type as a whole for use in "
-                    "the UI",
-                    "name": "subject_label",
-                },
-                "symmetric": {
-                    "description": "Whether the association type is "
-                    "symmetric, meaning that the "
-                    "subject and object labels should "
-                    "be interchangeable",
-                    "ifabsent": "False",
-                    "name": "symmetric",
-                    "required": True,
-                },
-            },
-        }
-    )
-
     subject_label: Optional[str] = Field(
-        None,
+        default=None,
         description="""A label to describe the subjects of the association type as a whole for use in the UI""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "subject_label",
-                "domain_of": [
-                    "TermPairwiseSimilarity",
-                    "Association",
-                    "CompactAssociation",
-                    "AssociationTypeMapping",
-                    "Mapping",
-                    "AssociationHighlighting",
-                ],
-                "is_a": "name",
-            }
-        },
     )
     object_label: Optional[str] = Field(
-        None,
+        default=None,
         description="""A label to describe the objects of the association type as a whole for use in the UI""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "object_label",
-                "domain_of": [
-                    "TermPairwiseSimilarity",
-                    "Association",
-                    "CompactAssociation",
-                    "AssociationTypeMapping",
-                    "Mapping",
-                    "AssociationHighlighting",
-                ],
-                "is_a": "name",
-            }
-        },
     )
     symmetric: bool = Field(
-        False,
+        default=False,
         description="""Whether the association type is symmetric, meaning that the subject and object labels should be interchangeable""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "symmetric", "domain_of": ["AssociationTypeMapping"], "ifabsent": "False"}
-        },
     )
     category: str = Field(
-        ...,
-        description="""The biolink category to use in queries for this association type""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "category",
-                "domain_of": [
-                    "Association",
-                    "AssociationCount",
-                    "CompactAssociation",
-                    "AssociationTypeMapping",
-                    "Entity",
-                ],
-            }
-        },
+        default=..., description="""The biolink category to use in queries for this association type"""
     )
 
 
@@ -1165,581 +388,213 @@ class DirectionalAssociation(Association):
     An association that gives it's direction relative to a specified entity
     """
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {
-            "from_schema": "https://w3id.org/monarch/monarch-py",
-            "slot_usage": {"highlighting": {"name": "highlighting", "range": "AssociationHighlighting"}},
-        }
-    )
-
     direction: AssociationDirectionEnum = Field(
-        ...,
+        default=...,
         description="""The directionality of the association relative to a given entity for an association_count. If the entity is the subject or in the subject closure, the direction is forwards, if it is the object or in the object closure, the direction is backwards.""",
-        json_schema_extra={"linkml_meta": {"alias": "direction", "domain_of": ["DirectionalAssociation"]}},
     )
     highlighting: Optional[AssociationHighlighting] = Field(
-        None,
-        description="""Optional highlighting information for search results""",
-        json_schema_extra={"linkml_meta": {"alias": "highlighting", "domain_of": ["DirectionalAssociation"]}},
+        default=None, description="""Optional highlighting information for search results"""
     )
-    id: str = Field(
-        ...,
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "id",
-                "domain_of": [
-                    "TermInfo",
-                    "Association",
-                    "ExpandedCurie",
-                    "Entity",
-                    "HistoPheno",
-                    "HistoBin",
-                    "Mapping",
-                    "MultiEntityAssociationResults",
-                ],
-            }
-        },
+    id: str = Field(default=...)
+    category: Optional[str] = Field(default=None)
+    subject: str = Field(default=...)
+    original_subject: Optional[str] = Field(default=None)
+    subject_namespace: Optional[str] = Field(default=None, description="""The namespace/prefix of the subject entity""")
+    subject_category: Optional[str] = Field(default=None, description="""The category of the subject entity""")
+    subject_closure: Optional[list[str]] = Field(
+        default=None, description="""Field containing subject id and the ids of all of it's ancestors"""
     )
-    category: Optional[str] = Field(
-        None,
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "category",
-                "domain_of": [
-                    "Association",
-                    "AssociationCount",
-                    "CompactAssociation",
-                    "AssociationTypeMapping",
-                    "Entity",
-                ],
-            }
-        },
+    subject_label: Optional[str] = Field(default=None, description="""The name of the subject entity""")
+    subject_closure_label: Optional[list[str]] = Field(
+        default=None, description="""Field containing subject name and the names of all of it's ancestors"""
     )
-    subject: str = Field(
-        ...,
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "subject",
-                "domain_of": ["SemsimSearchResult", "Association", "CompactAssociation"],
-            }
-        },
-    )
-    original_subject: Optional[str] = Field(
-        None, json_schema_extra={"linkml_meta": {"alias": "original_subject", "domain_of": ["Association"]}}
-    )
-    subject_namespace: Optional[str] = Field(
-        None,
-        description="""The namespace/prefix of the subject entity""",
-        json_schema_extra={"linkml_meta": {"alias": "subject_namespace", "domain_of": ["Association"]}},
-    )
-    subject_category: Optional[str] = Field(
-        None,
-        description="""The category of the subject entity""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "subject_category", "domain_of": ["Association"], "is_a": "category"}
-        },
-    )
-    subject_closure: Optional[List[str]] = Field(
-        None,
-        description="""Field containing subject id and the ids of all of it's ancestors""",
-        json_schema_extra={"linkml_meta": {"alias": "subject_closure", "domain_of": ["Association"]}},
-    )
-    subject_label: Optional[str] = Field(
-        None,
-        description="""The name of the subject entity""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "subject_label",
-                "domain_of": [
-                    "TermPairwiseSimilarity",
-                    "Association",
-                    "CompactAssociation",
-                    "AssociationTypeMapping",
-                    "Mapping",
-                    "AssociationHighlighting",
-                ],
-                "is_a": "name",
-            }
-        },
-    )
-    subject_closure_label: Optional[List[str]] = Field(
-        None,
-        description="""Field containing subject name and the names of all of it's ancestors""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "subject_closure_label", "domain_of": ["Association", "AssociationHighlighting"]}
-        },
-    )
-    subject_taxon: Optional[str] = Field(
-        None,
-        json_schema_extra={"linkml_meta": {"alias": "subject_taxon", "domain_of": ["Association"], "is_a": "in_taxon"}},
-    )
-    subject_taxon_label: Optional[str] = Field(
-        None,
-        json_schema_extra={
-            "linkml_meta": {"alias": "subject_taxon_label", "domain_of": ["Association"], "is_a": "in_taxon_label"}
-        },
-    )
-    predicate: str = Field(
-        ...,
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "predicate",
-                "domain_of": ["Association", "CompactAssociation", "AssociationHighlighting"],
-            }
-        },
-    )
+    subject_taxon: Optional[str] = Field(default=None)
+    subject_taxon_label: Optional[str] = Field(default=None)
+    predicate: str = Field(default=...)
     original_predicate: Optional[str] = Field(
-        None,
+        default=None,
         description="""used to hold the original relation/predicate that an external knowledge source uses before transformation to match the biolink-model specification.""",
-        json_schema_extra={"linkml_meta": {"alias": "original_predicate", "domain_of": ["Association"]}},
     )
-    object: str = Field(
-        ..., json_schema_extra={"linkml_meta": {"alias": "object", "domain_of": ["Association", "CompactAssociation"]}}
+    object: str = Field(default=...)
+    original_object: Optional[str] = Field(default=None)
+    object_namespace: Optional[str] = Field(default=None, description="""The namespace/prefix of the object entity""")
+    object_category: Optional[str] = Field(default=None, description="""The category of the object entity""")
+    object_closure: Optional[list[str]] = Field(
+        default=None, description="""Field containing object id and the ids of all of it's ancestors"""
     )
-    original_object: Optional[str] = Field(
-        None, json_schema_extra={"linkml_meta": {"alias": "original_object", "domain_of": ["Association"]}}
+    object_label: Optional[str] = Field(default=None, description="""The name of the object entity""")
+    object_closure_label: Optional[list[str]] = Field(
+        default=None, description="""Field containing object name and the names of all of it's ancestors"""
     )
-    object_namespace: Optional[str] = Field(
-        None,
-        description="""The namespace/prefix of the object entity""",
-        json_schema_extra={"linkml_meta": {"alias": "object_namespace", "domain_of": ["Association"]}},
-    )
-    object_category: Optional[str] = Field(
-        None,
-        description="""The category of the object entity""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "object_category", "domain_of": ["Association"], "is_a": "category"}
-        },
-    )
-    object_closure: Optional[List[str]] = Field(
-        None,
-        description="""Field containing object id and the ids of all of it's ancestors""",
-        json_schema_extra={"linkml_meta": {"alias": "object_closure", "domain_of": ["Association"]}},
-    )
-    object_label: Optional[str] = Field(
-        None,
-        description="""The name of the object entity""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "object_label",
-                "domain_of": [
-                    "TermPairwiseSimilarity",
-                    "Association",
-                    "CompactAssociation",
-                    "AssociationTypeMapping",
-                    "Mapping",
-                    "AssociationHighlighting",
-                ],
-                "is_a": "name",
-            }
-        },
-    )
-    object_closure_label: Optional[List[str]] = Field(
-        None,
-        description="""Field containing object name and the names of all of it's ancestors""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "object_closure_label", "domain_of": ["Association", "AssociationHighlighting"]}
-        },
-    )
-    object_taxon: Optional[str] = Field(
-        None,
-        json_schema_extra={"linkml_meta": {"alias": "object_taxon", "domain_of": ["Association"], "is_a": "in_taxon"}},
-    )
-    object_taxon_label: Optional[str] = Field(
-        None,
-        json_schema_extra={
-            "linkml_meta": {"alias": "object_taxon_label", "domain_of": ["Association"], "is_a": "in_taxon_label"}
-        },
-    )
-    primary_knowledge_source: Optional[str] = Field(
-        None, json_schema_extra={"linkml_meta": {"alias": "primary_knowledge_source", "domain_of": ["Association"]}}
-    )
-    aggregator_knowledge_source: Optional[List[str]] = Field(
-        None, json_schema_extra={"linkml_meta": {"alias": "aggregator_knowledge_source", "domain_of": ["Association"]}}
-    )
-    negated: Optional[bool] = Field(
-        None,
-        json_schema_extra={"linkml_meta": {"alias": "negated", "domain_of": ["Association", "CompactAssociation"]}},
-    )
-    pathway: Optional[str] = Field(
-        None, json_schema_extra={"linkml_meta": {"alias": "pathway", "domain_of": ["Association"]}}
-    )
+    object_taxon: Optional[str] = Field(default=None)
+    object_taxon_label: Optional[str] = Field(default=None)
+    primary_knowledge_source: Optional[str] = Field(default=None)
+    aggregator_knowledge_source: Optional[list[str]] = Field(default=None)
+    negated: Optional[bool] = Field(default=None)
+    pathway: Optional[str] = Field(default=None)
     evidence_count: Optional[int] = Field(
-        None,
-        description="""count of supporting documents, evidence codes, and sources supplying evidence""",
-        json_schema_extra={"linkml_meta": {"alias": "evidence_count", "domain_of": ["Association"]}},
+        default=None, description="""count of supporting documents, evidence codes, and sources supplying evidence"""
     )
     knowledge_level: str = Field(
-        ...,
+        default=...,
         description="""Describes the level of knowledge expressed in a statement, based on the reasoning or analysis methods used to generate the statement, or the scope or specificity of what the statement expresses to be true.""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "knowledge_level",
-                "domain_of": ["Association"],
-                "notes": [
-                    "The range in this schema is represented as a string, but is "
-                    "constrained  to values from biolink:KnowledgeLevelEnum at ingest "
-                    "time"
-                ],
-                "slot_uri": "biolink:knowledge_level",
-            }
-        },
     )
     agent_type: str = Field(
-        ...,
+        default=...,
         description="""Describes the high-level category of agent who originally generated a  statement of knowledge or other type of information.""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "agent_type",
-                "domain_of": ["Association"],
-                "notes": [
-                    "The range in this schema is represented as a string, but is "
-                    "constrained  to values from biolink:AgentTypeEnum at ingest time"
-                ],
-                "slot_uri": "biolink:agent_type",
-            }
-        },
     )
-    has_evidence: Optional[List[str]] = Field(
-        None, json_schema_extra={"linkml_meta": {"alias": "has_evidence", "domain_of": ["Association"]}}
+    has_evidence: Optional[list[str]] = Field(default=None)
+    has_evidence_links: Optional[list[ExpandedCurie]] = Field(
+        default=None, description="""List of ExpandedCuries with id and url for evidence"""
     )
-    has_evidence_links: Optional[List[ExpandedCurie]] = Field(
-        None,
-        description="""List of ExpandedCuries with id and url for evidence""",
-        json_schema_extra={"linkml_meta": {"alias": "has_evidence_links", "domain_of": ["Association"]}},
-    )
-    has_count: Optional[int] = Field(
-        None,
-        description="""count of out of has_total representing a frequency""",
-        json_schema_extra={"linkml_meta": {"alias": "has_count", "domain_of": ["Association"]}},
-    )
+    has_count: Optional[int] = Field(default=None, description="""count of out of has_total representing a frequency""")
     has_total: Optional[int] = Field(
-        None,
-        description="""total, devided by has_count, representing a frequency""",
-        json_schema_extra={"linkml_meta": {"alias": "has_total", "domain_of": ["Association"]}},
+        default=None, description="""total, devided by has_count, representing a frequency"""
     )
     has_percentage: Optional[float] = Field(
-        None,
+        default=None,
         description="""percentage, which may be calculated from has_count and has_total, as 100 * quotient or provided directly, rounded to the integer level""",
-        json_schema_extra={"linkml_meta": {"alias": "has_percentage", "domain_of": ["Association"]}},
     )
     has_quotient: Optional[float] = Field(
-        None,
-        description="""quotient, which should be 1/100 of has_percentage""",
-        json_schema_extra={"linkml_meta": {"alias": "has_quotient", "domain_of": ["Association"]}},
+        default=None, description="""quotient, which should be 1/100 of has_percentage"""
     )
     grouping_key: Optional[str] = Field(
-        None,
+        default=None,
         description="""A concatenation of fields used to group associations with the same essential/defining properties""",
-        json_schema_extra={"linkml_meta": {"alias": "grouping_key", "domain_of": ["Association"]}},
     )
-    provided_by: Optional[str] = Field(
-        None, json_schema_extra={"linkml_meta": {"alias": "provided_by", "domain_of": ["Association", "Entity"]}}
-    )
+    provided_by: Optional[str] = Field(default=None)
     provided_by_link: Optional[ExpandedCurie] = Field(
-        None,
-        description="""A link to the docs for the knowledge source that provided the node/edge.""",
-        json_schema_extra={"linkml_meta": {"alias": "provided_by_link", "domain_of": ["Association", "Node"]}},
+        default=None, description="""A link to the docs for the knowledge source that provided the node/edge."""
     )
-    publications: Optional[List[str]] = Field(
-        None, json_schema_extra={"linkml_meta": {"alias": "publications", "domain_of": ["Association"]}}
+    publications: Optional[list[str]] = Field(default=None)
+    publications_links: Optional[list[ExpandedCurie]] = Field(
+        default=None, description="""List of ExpandedCuries with id and url for publications"""
     )
-    publications_links: Optional[List[ExpandedCurie]] = Field(
-        None,
-        description="""List of ExpandedCuries with id and url for publications""",
-        json_schema_extra={"linkml_meta": {"alias": "publications_links", "domain_of": ["Association"]}},
-    )
-    frequency_qualifier: Optional[str] = Field(
-        None, json_schema_extra={"linkml_meta": {"alias": "frequency_qualifier", "domain_of": ["Association"]}}
-    )
-    onset_qualifier: Optional[str] = Field(
-        None, json_schema_extra={"linkml_meta": {"alias": "onset_qualifier", "domain_of": ["Association"]}}
-    )
-    sex_qualifier: Optional[str] = Field(
-        None, json_schema_extra={"linkml_meta": {"alias": "sex_qualifier", "domain_of": ["Association"]}}
-    )
-    stage_qualifier: Optional[str] = Field(
-        None, json_schema_extra={"linkml_meta": {"alias": "stage_qualifier", "domain_of": ["Association"]}}
-    )
-    qualifiers: Optional[List[str]] = Field(
-        None, json_schema_extra={"linkml_meta": {"alias": "qualifiers", "domain_of": ["Association"]}}
-    )
-    qualifiers_label: Optional[str] = Field(
-        None,
-        description="""The name of the frequency_qualifier entity""",
-        json_schema_extra={"linkml_meta": {"alias": "qualifiers_label", "domain_of": ["Association"], "is_a": "name"}},
-    )
+    frequency_qualifier: Optional[str] = Field(default=None)
+    onset_qualifier: Optional[str] = Field(default=None)
+    sex_qualifier: Optional[str] = Field(default=None)
+    stage_qualifier: Optional[str] = Field(default=None)
+    qualifiers: Optional[list[str]] = Field(default=None)
+    qualifiers_label: Optional[str] = Field(default=None, description="""The name of the frequency_qualifier entity""")
     qualifiers_namespace: Optional[str] = Field(
-        None,
-        description="""The namespace/prefix of the frequency_qualifier entity""",
-        json_schema_extra={"linkml_meta": {"alias": "qualifiers_namespace", "domain_of": ["Association"]}},
+        default=None, description="""The namespace/prefix of the frequency_qualifier entity"""
     )
     qualifiers_category: Optional[str] = Field(
-        None,
-        description="""The category of the frequency_qualifier entity""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "qualifiers_category", "domain_of": ["Association"], "is_a": "category"}
-        },
+        default=None, description="""The category of the frequency_qualifier entity"""
     )
-    qualifier: Optional[List[str]] = Field(
-        None, json_schema_extra={"linkml_meta": {"alias": "qualifier", "domain_of": ["Association"]}}
-    )
-    qualifier_label: Optional[str] = Field(
-        None,
-        description="""The name of the frequency_qualifier entity""",
-        json_schema_extra={"linkml_meta": {"alias": "qualifier_label", "domain_of": ["Association"], "is_a": "name"}},
-    )
+    qualifier: Optional[list[str]] = Field(default=None)
+    qualifier_label: Optional[str] = Field(default=None, description="""The name of the frequency_qualifier entity""")
     qualifier_namespace: Optional[str] = Field(
-        None,
-        description="""The namespace/prefix of the frequency_qualifier entity""",
-        json_schema_extra={"linkml_meta": {"alias": "qualifier_namespace", "domain_of": ["Association"]}},
+        default=None, description="""The namespace/prefix of the frequency_qualifier entity"""
     )
     qualifier_category: Optional[str] = Field(
-        None,
-        description="""The category of the frequency_qualifier entity""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "qualifier_category", "domain_of": ["Association"], "is_a": "category"}
-        },
+        default=None, description="""The category of the frequency_qualifier entity"""
     )
     frequency_qualifier_label: Optional[str] = Field(
-        None,
-        description="""The name of the frequency_qualifier entity""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "frequency_qualifier_label", "domain_of": ["Association"], "is_a": "name"}
-        },
+        default=None, description="""The name of the frequency_qualifier entity"""
     )
     frequency_qualifier_namespace: Optional[str] = Field(
-        None,
-        description="""The namespace/prefix of the frequency_qualifier entity""",
-        json_schema_extra={"linkml_meta": {"alias": "frequency_qualifier_namespace", "domain_of": ["Association"]}},
+        default=None, description="""The namespace/prefix of the frequency_qualifier entity"""
     )
     frequency_qualifier_category: Optional[str] = Field(
-        None,
-        description="""The category of the frequency_qualifier entity""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "frequency_qualifier_category", "domain_of": ["Association"], "is_a": "category"}
-        },
+        default=None, description="""The category of the frequency_qualifier entity"""
     )
-    onset_qualifier_label: Optional[str] = Field(
-        None,
-        description="""The name of the onset_qualifier entity""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "onset_qualifier_label", "domain_of": ["Association"], "is_a": "name"}
-        },
-    )
+    onset_qualifier_label: Optional[str] = Field(default=None, description="""The name of the onset_qualifier entity""")
     onset_qualifier_namespace: Optional[str] = Field(
-        None,
-        description="""The namespace/prefix of the onset_qualifier entity""",
-        json_schema_extra={"linkml_meta": {"alias": "onset_qualifier_namespace", "domain_of": ["Association"]}},
+        default=None, description="""The namespace/prefix of the onset_qualifier entity"""
     )
     onset_qualifier_category: Optional[str] = Field(
-        None,
-        description="""The category of the onset_qualifier entity""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "onset_qualifier_category", "domain_of": ["Association"], "is_a": "category"}
-        },
+        default=None, description="""The category of the onset_qualifier entity"""
     )
-    sex_qualifier_label: Optional[str] = Field(
-        None,
-        description="""The name of the sex_qualifier entity""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "sex_qualifier_label", "domain_of": ["Association"], "is_a": "name"}
-        },
-    )
+    sex_qualifier_label: Optional[str] = Field(default=None, description="""The name of the sex_qualifier entity""")
     sex_qualifier_namespace: Optional[str] = Field(
-        None,
-        description="""The namespace/prefix of the sex_qualifier entity""",
-        json_schema_extra={"linkml_meta": {"alias": "sex_qualifier_namespace", "domain_of": ["Association"]}},
+        default=None, description="""The namespace/prefix of the sex_qualifier entity"""
     )
     sex_qualifier_category: Optional[str] = Field(
-        None,
-        description="""The category of the sex_qualifier entity""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "sex_qualifier_category", "domain_of": ["Association"], "is_a": "category"}
-        },
+        default=None, description="""The category of the sex_qualifier entity"""
     )
-    stage_qualifier_label: Optional[str] = Field(
-        None,
-        description="""The name of the stage_qualifier entity""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "stage_qualifier_label", "domain_of": ["Association"], "is_a": "name"}
-        },
-    )
+    stage_qualifier_label: Optional[str] = Field(default=None, description="""The name of the stage_qualifier entity""")
     stage_qualifier_namespace: Optional[str] = Field(
-        None,
-        description="""The namespace/prefix of the stage_qualifier entity""",
-        json_schema_extra={"linkml_meta": {"alias": "stage_qualifier_namespace", "domain_of": ["Association"]}},
+        default=None, description="""The namespace/prefix of the stage_qualifier entity"""
     )
     stage_qualifier_category: Optional[str] = Field(
-        None,
-        description="""The category of the stage_qualifier entity""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "stage_qualifier_category", "domain_of": ["Association"], "is_a": "category"}
-        },
+        default=None, description="""The category of the stage_qualifier entity"""
     )
     disease_context_qualifier: Optional[str] = Field(
-        None,
+        default=None,
         description="""A context qualifier representing a disease or condition in which a relationship expressed in an association took place.""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "disease_context_qualifier",
-                "domain_of": ["Association"],
-                "examples": [{"value": "MONDO:0004979"}, {"value": "MONDO:0005148"}],
-            }
-        },
     )
     disease_context_qualifier_label: Optional[str] = Field(
-        None,
-        description="""The name of the disease_context_qualifier entity""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "disease_context_qualifier_label", "domain_of": ["Association"], "is_a": "name"}
-        },
+        default=None, description="""The name of the disease_context_qualifier entity"""
     )
     disease_context_qualifier_namespace: Optional[str] = Field(
-        None,
-        description="""The namespace/prefix of the disease_context_qualifier entity""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "disease_context_qualifier_namespace", "domain_of": ["Association"]}
-        },
+        default=None, description="""The namespace/prefix of the disease_context_qualifier entity"""
     )
     disease_context_qualifier_category: Optional[str] = Field(
-        None,
-        description="""The category of the disease_context_qualifier entity""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "disease_context_qualifier_category",
-                "domain_of": ["Association"],
-                "is_a": "category",
-            }
-        },
+        default=None, description="""The category of the disease_context_qualifier entity"""
     )
-    disease_context_qualifier_closure: Optional[List[str]] = Field(
-        None,
+    disease_context_qualifier_closure: Optional[list[str]] = Field(
+        default=None,
         description="""Field containing disease_context_qualifier id and the ids of all of it's ancestors""",
-        json_schema_extra={"linkml_meta": {"alias": "disease_context_qualifier_closure", "domain_of": ["Association"]}},
     )
-    disease_context_qualifier_closure_label: Optional[List[str]] = Field(
-        None,
+    disease_context_qualifier_closure_label: Optional[list[str]] = Field(
+        default=None,
         description="""Field containing disease_context_qualifier name and the names of all of it's ancestors""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "disease_context_qualifier_closure_label", "domain_of": ["Association"]}
-        },
     )
     species_context_qualifier: Optional[str] = Field(
-        None,
+        default=None,
         description="""A context qualifier representing a species in which a relationship expressed in an association took place.""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "species_context_qualifier",
-                "domain_of": ["Association"],
-                "examples": [{"value": "NCBITaxon:9606"}],
-            }
-        },
     )
     species_context_qualifier_label: Optional[str] = Field(
-        None,
-        description="""The name of the species_context_qualifier entity""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "species_context_qualifier_label", "domain_of": ["Association"], "is_a": "name"}
-        },
+        default=None, description="""The name of the species_context_qualifier entity"""
     )
     species_context_qualifier_namespace: Optional[str] = Field(
-        None,
-        description="""The namespace/prefix of the species_context_qualifier entity""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "species_context_qualifier_namespace", "domain_of": ["Association"]}
-        },
+        default=None, description="""The namespace/prefix of the species_context_qualifier entity"""
     )
     species_context_qualifier_category: Optional[str] = Field(
-        None,
-        description="""The category of the species_context_qualifier entity""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "species_context_qualifier_category",
-                "domain_of": ["Association"],
-                "is_a": "category",
-            }
-        },
+        default=None, description="""The category of the species_context_qualifier entity"""
     )
     subject_specialization_qualifier: Optional[str] = Field(
-        None,
+        default=None,
         description="""A qualifier that composes with a core subject/object concept to define a more specific version of the subject concept, specifically using an ontology term that is not a subclass or descendant of the core concept and in the vast majority of cases, is of a different ontological namespace than the category or namespace of the subject identifier.""",
-        json_schema_extra={"linkml_meta": {"alias": "subject_specialization_qualifier", "domain_of": ["Association"]}},
     )
     subject_specialization_qualifier_label: Optional[str] = Field(
-        None,
-        description="""A label for the subject_specialization_qualifier""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "subject_specialization_qualifier_label", "domain_of": ["Association"]}
-        },
+        default=None, description="""A label for the subject_specialization_qualifier"""
     )
     subject_specialization_qualifier_namespace: Optional[str] = Field(
-        None,
-        description="""The namespace/prefix of the subject_specialization_qualifier""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "subject_specialization_qualifier_namespace", "domain_of": ["Association"]}
-        },
+        default=None, description="""The namespace/prefix of the subject_specialization_qualifier"""
     )
     subject_specialization_qualifier_category: Optional[str] = Field(
-        None,
-        description="""The category of the subject_specialization_qualifier""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "subject_specialization_qualifier_category", "domain_of": ["Association"]}
-        },
+        default=None, description="""The category of the subject_specialization_qualifier"""
     )
     subject_specialization_qualifier_closure: Optional[str] = Field(
-        None,
+        default=None,
         description="""A closure of the subject_specialization_qualifier, including the subject_specialization_qualifier itself and all of its ancestors""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "subject_specialization_qualifier_closure", "domain_of": ["Association"]}
-        },
     )
     subject_specialization_qualifier_closure_label: Optional[str] = Field(
-        None,
+        default=None,
         description="""A closure of the subject_specialization_qualifier, including the subject_specialization_qualifier itself and all of its ancestors""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "subject_specialization_qualifier_closure_label", "domain_of": ["Association"]}
-        },
     )
     object_specialization_qualifier: Optional[str] = Field(
-        None,
+        default=None,
         description="""A qualifier that composes with a core subject/object concept to define a more specific version of the object concept, specifically using an ontology term that is not a subclass or descendant of the core concept and in the vast majority of cases, is of a different ontological namespace than the category or namespace of the object identifier.""",
-        json_schema_extra={"linkml_meta": {"alias": "object_specialization_qualifier", "domain_of": ["Association"]}},
     )
     object_specialization_qualifier_label: Optional[str] = Field(
-        None,
-        description="""A label for the object_specialization_qualifier""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "object_specialization_qualifier_label", "domain_of": ["Association"]}
-        },
+        default=None, description="""A label for the object_specialization_qualifier"""
     )
     object_specialization_qualifier_namespace: Optional[str] = Field(
-        None,
-        description="""The namespace/prefix of the object_specialization_qualifier""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "object_specialization_qualifier_namespace", "domain_of": ["Association"]}
-        },
+        default=None, description="""The namespace/prefix of the object_specialization_qualifier"""
     )
     object_specialization_qualifier_category: Optional[str] = Field(
-        None,
-        description="""The category of the object_specialization_qualifier""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "object_specialization_qualifier_category", "domain_of": ["Association"]}
-        },
+        default=None, description="""The category of the object_specialization_qualifier"""
     )
     object_specialization_qualifier_closure: Optional[str] = Field(
-        None,
+        default=None,
         description="""A closure of the object_specialization_qualifier, including the object_specialization_qualifier itself and all of its ancestors""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "object_specialization_qualifier_closure", "domain_of": ["Association"]}
-        },
     )
     object_specialization_qualifier_closure_label: Optional[str] = Field(
-        None,
+        default=None,
         description="""A closure of the object_specialization_qualifier, including the object_specialization_qualifier itself and all of its ancestors""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "object_specialization_qualifier_closure_label", "domain_of": ["Association"]}
-        },
     )
 
 
@@ -1748,29 +603,8 @@ class ExpandedCurie(ConfiguredBaseModel):
     A curie bundled along with its expanded url
     """
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({"from_schema": "https://w3id.org/monarch/monarch-py"})
-
-    id: str = Field(
-        ...,
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "id",
-                "domain_of": [
-                    "TermInfo",
-                    "Association",
-                    "ExpandedCurie",
-                    "Entity",
-                    "HistoPheno",
-                    "HistoBin",
-                    "Mapping",
-                    "MultiEntityAssociationResults",
-                ],
-            }
-        },
-    )
-    url: Optional[str] = Field(
-        None, json_schema_extra={"linkml_meta": {"alias": "url", "domain_of": ["ExpandedCurie", "Release"]}}
-    )
+    id: str = Field(default=...)
+    url: Optional[str] = Field(default=None)
 
 
 class Entity(ConfiguredBaseModel):
@@ -1778,287 +612,84 @@ class Entity(ConfiguredBaseModel):
     Represents an Entity in the Monarch KG data model
     """
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({"from_schema": "https://w3id.org/monarch/monarch-py"})
-
-    id: str = Field(
-        ...,
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "id",
-                "domain_of": [
-                    "TermInfo",
-                    "Association",
-                    "ExpandedCurie",
-                    "Entity",
-                    "HistoPheno",
-                    "HistoBin",
-                    "Mapping",
-                    "MultiEntityAssociationResults",
-                ],
-            }
-        },
-    )
-    category: Optional[str] = Field(
-        None,
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "category",
-                "domain_of": [
-                    "Association",
-                    "AssociationCount",
-                    "CompactAssociation",
-                    "AssociationTypeMapping",
-                    "Entity",
-                ],
-            }
-        },
-    )
-    name: Optional[str] = Field(
-        None,
-        json_schema_extra={"linkml_meta": {"alias": "name", "domain_of": ["Entity", "MultiEntityAssociationResults"]}},
-    )
-    full_name: Optional[str] = Field(
-        None,
-        description="""The long form name of an entity""",
-        json_schema_extra={"linkml_meta": {"alias": "full_name", "domain_of": ["Entity"]}},
-    )
+    id: str = Field(default=...)
+    category: Optional[str] = Field(default=None)
+    name: Optional[str] = Field(default=None)
+    full_name: Optional[str] = Field(default=None, description="""The long form name of an entity""")
     deprecated: Optional[bool] = Field(
-        None,
+        default=None,
         description="""A boolean flag indicating that an entity is no longer considered current or valid.""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "deprecated",
-                "domain_of": ["Entity"],
-                "exact_mappings": ["oboInOwl:ObsoleteClass"],
-            }
-        },
     )
-    description: Optional[str] = Field(
-        None, json_schema_extra={"linkml_meta": {"alias": "description", "domain_of": ["Entity"]}}
-    )
-    xref: Optional[List[str]] = Field(
-        None, json_schema_extra={"linkml_meta": {"alias": "xref", "domain_of": ["Entity"]}}
-    )
-    provided_by: Optional[str] = Field(
-        None, json_schema_extra={"linkml_meta": {"alias": "provided_by", "domain_of": ["Association", "Entity"]}}
-    )
+    description: Optional[str] = Field(default=None)
+    xref: Optional[list[str]] = Field(default=None)
+    provided_by: Optional[str] = Field(default=None)
     in_taxon: Optional[str] = Field(
-        None,
-        description="""The biolink taxon that the entity is in the closure of.""",
-        json_schema_extra={"linkml_meta": {"alias": "in_taxon", "domain_of": ["Entity", "Node"]}},
+        default=None, description="""The biolink taxon that the entity is in the closure of."""
     )
     in_taxon_label: Optional[str] = Field(
-        None,
-        description="""The label of the biolink taxon that the entity is in the closure of.""",
-        json_schema_extra={"linkml_meta": {"alias": "in_taxon_label", "domain_of": ["Entity", "Node"]}},
+        default=None, description="""The label of the biolink taxon that the entity is in the closure of."""
     )
-    symbol: Optional[str] = Field(None, json_schema_extra={"linkml_meta": {"alias": "symbol", "domain_of": ["Entity"]}})
-    synonym: Optional[List[str]] = Field(
-        None, json_schema_extra={"linkml_meta": {"alias": "synonym", "domain_of": ["Entity"]}}
-    )
-    broad_synonym: Optional[List[str]] = Field(
-        None,
-        description="""A broader synonym for the entity""",
-        json_schema_extra={"linkml_meta": {"alias": "broad_synonym", "domain_of": ["Entity"]}},
-    )
-    exact_synonym: Optional[List[str]] = Field(
-        None,
-        description="""An exact synonym for the entity""",
-        json_schema_extra={"linkml_meta": {"alias": "exact_synonym", "domain_of": ["Entity"]}},
-    )
-    narrow_synonym: Optional[List[str]] = Field(
-        None,
-        description="""A narrower synonym for the entity""",
-        json_schema_extra={"linkml_meta": {"alias": "narrow_synonym", "domain_of": ["Entity"]}},
-    )
-    related_synonym: Optional[List[str]] = Field(
-        None,
-        description="""A related synonym for the entity""",
-        json_schema_extra={"linkml_meta": {"alias": "related_synonym", "domain_of": ["Entity"]}},
-    )
-    subsets: Optional[List[str]] = Field(
-        None,
-        description="""A list of subsets that the entity belongs to""",
-        json_schema_extra={"linkml_meta": {"alias": "subsets", "domain_of": ["Entity"]}},
-    )
-    uri: Optional[str] = Field(
-        None,
-        description="""The URI of the entity""",
-        json_schema_extra={"linkml_meta": {"alias": "uri", "domain_of": ["Entity"]}},
-    )
-    iri: Optional[str] = Field(None, json_schema_extra={"linkml_meta": {"alias": "iri", "domain_of": ["Entity"]}})
+    symbol: Optional[str] = Field(default=None)
+    synonym: Optional[list[str]] = Field(default=None)
+    broad_synonym: Optional[list[str]] = Field(default=None, description="""A broader synonym for the entity""")
+    exact_synonym: Optional[list[str]] = Field(default=None, description="""An exact synonym for the entity""")
+    narrow_synonym: Optional[list[str]] = Field(default=None, description="""A narrower synonym for the entity""")
+    related_synonym: Optional[list[str]] = Field(default=None, description="""A related synonym for the entity""")
+    subsets: Optional[list[str]] = Field(default=None, description="""A list of subsets that the entity belongs to""")
+    uri: Optional[str] = Field(default=None, description="""The URI of the entity""")
+    iri: Optional[str] = Field(default=None)
     namespace: Optional[str] = Field(
-        None,
-        description="""The namespace/prefix portion of this entity's identifier""",
-        json_schema_extra={"linkml_meta": {"alias": "namespace", "domain_of": ["Entity"]}},
+        default=None, description="""The namespace/prefix portion of this entity's identifier"""
     )
-    has_phenotype: Optional[List[str]] = Field(
-        None,
-        description="""A list of phenotype identifiers that are known to be associated with this entity""",
-        json_schema_extra={"linkml_meta": {"alias": "has_phenotype", "domain_of": ["Entity"]}},
+    has_phenotype: Optional[list[str]] = Field(
+        default=None, description="""A list of phenotype identifiers that are known to be associated with this entity"""
     )
-    has_phenotype_label: Optional[List[str]] = Field(
-        None,
-        description="""A list of phenotype labels that are known to be associated with this entity""",
-        json_schema_extra={"linkml_meta": {"alias": "has_phenotype_label", "domain_of": ["Entity"]}},
+    has_phenotype_label: Optional[list[str]] = Field(
+        default=None, description="""A list of phenotype labels that are known to be associated with this entity"""
     )
-    has_phenotype_closure: Optional[List[str]] = Field(
-        None,
+    has_phenotype_closure: Optional[list[str]] = Field(
+        default=None,
         description="""A list of phenotype identifiers that are known to be associated with this entity expanded to include all ancestors""",
-        json_schema_extra={"linkml_meta": {"alias": "has_phenotype_closure", "domain_of": ["Entity"]}},
     )
-    has_phenotype_closure_label: Optional[List[str]] = Field(
-        None,
+    has_phenotype_closure_label: Optional[list[str]] = Field(
+        default=None,
         description="""A list of phenotype labels that are known to be associated with this entity expanded to include all ancestors""",
-        json_schema_extra={"linkml_meta": {"alias": "has_phenotype_closure_label", "domain_of": ["Entity"]}},
     )
     has_phenotype_count: Optional[int] = Field(
-        None,
+        default=None,
         description="""A count of the number of phenotypes that are known to be associated with this entity""",
-        json_schema_extra={"linkml_meta": {"alias": "has_phenotype_count", "domain_of": ["Entity"]}},
     )
 
 
 class FacetValue(ConfiguredBaseModel):
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({"from_schema": "https://w3id.org/monarch/monarch-py"})
-
-    label: str = Field(
-        ...,
-        json_schema_extra={"linkml_meta": {"alias": "label", "domain_of": ["TermInfo", "FacetValue", "FacetField"]}},
-    )
-    count: Optional[int] = Field(
-        None,
-        description="""count of documents""",
-        json_schema_extra={"linkml_meta": {"alias": "count", "domain_of": ["FacetValue"]}},
-    )
+    label: str = Field(default=...)
+    count: Optional[int] = Field(default=None, description="""count of documents""")
 
 
 class AssociationCount(FacetValue):
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {
-            "from_schema": "https://w3id.org/monarch/monarch-py",
-            "slot_usage": {"category": {"multivalued": False, "name": "category"}},
-        }
-    )
-
-    category: Optional[str] = Field(
-        None,
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "category",
-                "domain_of": [
-                    "Association",
-                    "AssociationCount",
-                    "CompactAssociation",
-                    "AssociationTypeMapping",
-                    "Entity",
-                ],
-            }
-        },
-    )
-    label: str = Field(
-        ...,
-        json_schema_extra={"linkml_meta": {"alias": "label", "domain_of": ["TermInfo", "FacetValue", "FacetField"]}},
-    )
-    count: Optional[int] = Field(
-        None,
-        description="""count of documents""",
-        json_schema_extra={"linkml_meta": {"alias": "count", "domain_of": ["FacetValue"]}},
-    )
+    category: Optional[str] = Field(default=None)
+    label: str = Field(default=...)
+    count: Optional[int] = Field(default=None, description="""count of documents""")
 
 
 class FacetField(ConfiguredBaseModel):
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({"from_schema": "https://w3id.org/monarch/monarch-py"})
-
-    label: str = Field(
-        ...,
-        json_schema_extra={"linkml_meta": {"alias": "label", "domain_of": ["TermInfo", "FacetValue", "FacetField"]}},
-    )
-    facet_values: Optional[List[FacetValue]] = Field(
-        None,
-        description="""Collection of FacetValue label/value instances belonging to a FacetField""",
-        json_schema_extra={"linkml_meta": {"alias": "facet_values", "domain_of": ["FacetField"]}},
+    label: str = Field(default=...)
+    facet_values: Optional[list[FacetValue]] = Field(
+        default=None, description="""Collection of FacetValue label/value instances belonging to a FacetField"""
     )
 
 
 class HistoPheno(ConfiguredBaseModel):
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {
-            "from_schema": "https://w3id.org/monarch/monarch-py",
-            "slot_usage": {"items": {"name": "items", "range": "HistoBin"}},
-        }
-    )
-
-    id: str = Field(
-        ...,
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "id",
-                "domain_of": [
-                    "TermInfo",
-                    "Association",
-                    "ExpandedCurie",
-                    "Entity",
-                    "HistoPheno",
-                    "HistoBin",
-                    "Mapping",
-                    "MultiEntityAssociationResults",
-                ],
-            }
-        },
-    )
-    items: List[HistoBin] = Field(
-        ...,
-        description="""A collection of items, with the type to be overriden by slot_usage""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "items",
-                "domain_of": [
-                    "AssociationCountList",
-                    "AssociationResults",
-                    "CompactAssociationResults",
-                    "AssociationTableResults",
-                    "CategoryGroupedAssociationResults",
-                    "EntityResults",
-                    "HistoPheno",
-                    "MappingResults",
-                    "SearchResults",
-                ],
-            }
-        },
+    id: str = Field(default=...)
+    items: list[HistoBin] = Field(
+        default=..., description="""A collection of items, with the type to be overriden by slot_usage"""
     )
 
 
 class HistoBin(FacetValue):
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({"from_schema": "https://w3id.org/monarch/monarch-py"})
-
-    id: str = Field(
-        ...,
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "id",
-                "domain_of": [
-                    "TermInfo",
-                    "Association",
-                    "ExpandedCurie",
-                    "Entity",
-                    "HistoPheno",
-                    "HistoBin",
-                    "Mapping",
-                    "MultiEntityAssociationResults",
-                ],
-            }
-        },
-    )
-    label: str = Field(
-        ...,
-        json_schema_extra={"linkml_meta": {"alias": "label", "domain_of": ["TermInfo", "FacetValue", "FacetField"]}},
-    )
-    count: Optional[int] = Field(
-        None,
-        description="""count of documents""",
-        json_schema_extra={"linkml_meta": {"alias": "count", "domain_of": ["FacetValue"]}},
-    )
+    id: str = Field(default=...)
+    label: str = Field(default=...)
+    count: Optional[int] = Field(default=None, description="""count of documents""")
 
 
 class Mapping(ConfiguredBaseModel):
@@ -2066,76 +697,13 @@ class Mapping(ConfiguredBaseModel):
     A minimal class to hold a SSSOM mapping
     """
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({"from_schema": "https://w3id.org/monarch/monarch-py"})
-
-    subject_id: str = Field(
-        ...,
-        json_schema_extra={"linkml_meta": {"alias": "subject_id", "domain_of": ["TermPairwiseSimilarity", "Mapping"]}},
-    )
-    subject_label: Optional[str] = Field(
-        None,
-        description="""The name of the subject entity""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "subject_label",
-                "domain_of": [
-                    "TermPairwiseSimilarity",
-                    "Association",
-                    "CompactAssociation",
-                    "AssociationTypeMapping",
-                    "Mapping",
-                    "AssociationHighlighting",
-                ],
-                "is_a": "name",
-            }
-        },
-    )
-    predicate_id: str = Field(
-        ..., json_schema_extra={"linkml_meta": {"alias": "predicate_id", "domain_of": ["Mapping"]}}
-    )
-    object_id: str = Field(
-        ...,
-        json_schema_extra={"linkml_meta": {"alias": "object_id", "domain_of": ["TermPairwiseSimilarity", "Mapping"]}},
-    )
-    object_label: Optional[str] = Field(
-        None,
-        description="""The name of the object entity""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "object_label",
-                "domain_of": [
-                    "TermPairwiseSimilarity",
-                    "Association",
-                    "CompactAssociation",
-                    "AssociationTypeMapping",
-                    "Mapping",
-                    "AssociationHighlighting",
-                ],
-                "is_a": "name",
-            }
-        },
-    )
-    mapping_justification: Optional[str] = Field(
-        None, json_schema_extra={"linkml_meta": {"alias": "mapping_justification", "domain_of": ["Mapping"]}}
-    )
-    id: str = Field(
-        ...,
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "id",
-                "domain_of": [
-                    "TermInfo",
-                    "Association",
-                    "ExpandedCurie",
-                    "Entity",
-                    "HistoPheno",
-                    "HistoBin",
-                    "Mapping",
-                    "MultiEntityAssociationResults",
-                ],
-            }
-        },
-    )
+    subject_id: str = Field(default=...)
+    subject_label: Optional[str] = Field(default=None, description="""The name of the subject entity""")
+    predicate_id: str = Field(default=...)
+    object_id: str = Field(default=...)
+    object_label: Optional[str] = Field(default=None, description="""The name of the object entity""")
+    mapping_justification: Optional[str] = Field(default=None)
+    id: str = Field(default=...)
 
 
 class Node(Entity):
@@ -2143,190 +711,76 @@ class Node(Entity):
     UI container class extending Entity with additional information
     """
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({"from_schema": "https://w3id.org/monarch/monarch-py"})
-
     in_taxon: Optional[str] = Field(
-        None,
-        description="""The biolink taxon that the entity is in the closure of.""",
-        json_schema_extra={"linkml_meta": {"alias": "in_taxon", "domain_of": ["Entity", "Node"]}},
+        default=None, description="""The biolink taxon that the entity is in the closure of."""
     )
     in_taxon_label: Optional[str] = Field(
-        None,
-        description="""The label of the biolink taxon that the entity is in the closure of.""",
-        json_schema_extra={"linkml_meta": {"alias": "in_taxon_label", "domain_of": ["Entity", "Node"]}},
+        default=None, description="""The label of the biolink taxon that the entity is in the closure of."""
     )
-    inheritance: Optional[Entity] = Field(
-        None, json_schema_extra={"linkml_meta": {"alias": "inheritance", "domain_of": ["Node"]}}
+    inheritance: Optional[Entity] = Field(default=None)
+    causal_gene: Optional[list[Entity]] = Field(
+        default=None, description="""A list of genes that are known to be causally associated with a disease"""
     )
-    causal_gene: Optional[List[Entity]] = Field(
-        None,
-        description="""A list of genes that are known to be causally associated with a disease""",
-        json_schema_extra={"linkml_meta": {"alias": "causal_gene", "domain_of": ["Node"]}},
+    causes_disease: Optional[list[Entity]] = Field(
+        default=None, description="""A list of diseases that are known to be causally associated with a gene"""
     )
-    causes_disease: Optional[List[Entity]] = Field(
-        None,
-        description="""A list of diseases that are known to be causally associated with a gene""",
-        json_schema_extra={"linkml_meta": {"alias": "causes_disease", "domain_of": ["Node"]}},
+    mappings: Optional[list[ExpandedCurie]] = Field(
+        default=None, description="""List of ExpandedCuries with id and url for mapped entities"""
     )
-    mappings: Optional[List[ExpandedCurie]] = Field(
-        None,
-        description="""List of ExpandedCuries with id and url for mapped entities""",
-        json_schema_extra={"linkml_meta": {"alias": "mappings", "domain_of": ["Node"]}},
-    )
-    external_links: Optional[List[ExpandedCurie]] = Field(
-        None,
-        description="""ExpandedCurie with id and url for xrefs""",
-        json_schema_extra={"linkml_meta": {"alias": "external_links", "domain_of": ["Node"]}},
+    external_links: Optional[list[ExpandedCurie]] = Field(
+        default=None, description="""ExpandedCurie with id and url for xrefs"""
     )
     provided_by_link: Optional[ExpandedCurie] = Field(
-        None,
-        description="""A link to the docs for the knowledge source that provided the node/edge.""",
-        json_schema_extra={"linkml_meta": {"alias": "provided_by_link", "domain_of": ["Association", "Node"]}},
+        default=None, description="""A link to the docs for the knowledge source that provided the node/edge."""
     )
-    association_counts: List[AssociationCount] = Field(
-        ..., json_schema_extra={"linkml_meta": {"alias": "association_counts", "domain_of": ["Node"]}}
-    )
-    node_hierarchy: Optional[NodeHierarchy] = Field(
-        None, json_schema_extra={"linkml_meta": {"alias": "node_hierarchy", "domain_of": ["Node"]}}
-    )
-    id: str = Field(
-        ...,
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "id",
-                "domain_of": [
-                    "TermInfo",
-                    "Association",
-                    "ExpandedCurie",
-                    "Entity",
-                    "HistoPheno",
-                    "HistoBin",
-                    "Mapping",
-                    "MultiEntityAssociationResults",
-                ],
-            }
-        },
-    )
-    category: Optional[str] = Field(
-        None,
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "category",
-                "domain_of": [
-                    "Association",
-                    "AssociationCount",
-                    "CompactAssociation",
-                    "AssociationTypeMapping",
-                    "Entity",
-                ],
-            }
-        },
-    )
-    name: Optional[str] = Field(
-        None,
-        json_schema_extra={"linkml_meta": {"alias": "name", "domain_of": ["Entity", "MultiEntityAssociationResults"]}},
-    )
-    full_name: Optional[str] = Field(
-        None,
-        description="""The long form name of an entity""",
-        json_schema_extra={"linkml_meta": {"alias": "full_name", "domain_of": ["Entity"]}},
-    )
+    association_counts: list[AssociationCount] = Field(default=...)
+    node_hierarchy: Optional[NodeHierarchy] = Field(default=None)
+    id: str = Field(default=...)
+    category: Optional[str] = Field(default=None)
+    name: Optional[str] = Field(default=None)
+    full_name: Optional[str] = Field(default=None, description="""The long form name of an entity""")
     deprecated: Optional[bool] = Field(
-        None,
+        default=None,
         description="""A boolean flag indicating that an entity is no longer considered current or valid.""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "deprecated",
-                "domain_of": ["Entity"],
-                "exact_mappings": ["oboInOwl:ObsoleteClass"],
-            }
-        },
     )
-    description: Optional[str] = Field(
-        None, json_schema_extra={"linkml_meta": {"alias": "description", "domain_of": ["Entity"]}}
-    )
-    xref: Optional[List[str]] = Field(
-        None, json_schema_extra={"linkml_meta": {"alias": "xref", "domain_of": ["Entity"]}}
-    )
-    provided_by: Optional[str] = Field(
-        None, json_schema_extra={"linkml_meta": {"alias": "provided_by", "domain_of": ["Association", "Entity"]}}
-    )
-    symbol: Optional[str] = Field(None, json_schema_extra={"linkml_meta": {"alias": "symbol", "domain_of": ["Entity"]}})
-    synonym: Optional[List[str]] = Field(
-        None, json_schema_extra={"linkml_meta": {"alias": "synonym", "domain_of": ["Entity"]}}
-    )
-    broad_synonym: Optional[List[str]] = Field(
-        None,
-        description="""A broader synonym for the entity""",
-        json_schema_extra={"linkml_meta": {"alias": "broad_synonym", "domain_of": ["Entity"]}},
-    )
-    exact_synonym: Optional[List[str]] = Field(
-        None,
-        description="""An exact synonym for the entity""",
-        json_schema_extra={"linkml_meta": {"alias": "exact_synonym", "domain_of": ["Entity"]}},
-    )
-    narrow_synonym: Optional[List[str]] = Field(
-        None,
-        description="""A narrower synonym for the entity""",
-        json_schema_extra={"linkml_meta": {"alias": "narrow_synonym", "domain_of": ["Entity"]}},
-    )
-    related_synonym: Optional[List[str]] = Field(
-        None,
-        description="""A related synonym for the entity""",
-        json_schema_extra={"linkml_meta": {"alias": "related_synonym", "domain_of": ["Entity"]}},
-    )
-    subsets: Optional[List[str]] = Field(
-        None,
-        description="""A list of subsets that the entity belongs to""",
-        json_schema_extra={"linkml_meta": {"alias": "subsets", "domain_of": ["Entity"]}},
-    )
-    uri: Optional[str] = Field(
-        None,
-        description="""The URI of the entity""",
-        json_schema_extra={"linkml_meta": {"alias": "uri", "domain_of": ["Entity"]}},
-    )
-    iri: Optional[str] = Field(None, json_schema_extra={"linkml_meta": {"alias": "iri", "domain_of": ["Entity"]}})
+    description: Optional[str] = Field(default=None)
+    xref: Optional[list[str]] = Field(default=None)
+    provided_by: Optional[str] = Field(default=None)
+    symbol: Optional[str] = Field(default=None)
+    synonym: Optional[list[str]] = Field(default=None)
+    broad_synonym: Optional[list[str]] = Field(default=None, description="""A broader synonym for the entity""")
+    exact_synonym: Optional[list[str]] = Field(default=None, description="""An exact synonym for the entity""")
+    narrow_synonym: Optional[list[str]] = Field(default=None, description="""A narrower synonym for the entity""")
+    related_synonym: Optional[list[str]] = Field(default=None, description="""A related synonym for the entity""")
+    subsets: Optional[list[str]] = Field(default=None, description="""A list of subsets that the entity belongs to""")
+    uri: Optional[str] = Field(default=None, description="""The URI of the entity""")
+    iri: Optional[str] = Field(default=None)
     namespace: Optional[str] = Field(
-        None,
-        description="""The namespace/prefix portion of this entity's identifier""",
-        json_schema_extra={"linkml_meta": {"alias": "namespace", "domain_of": ["Entity"]}},
+        default=None, description="""The namespace/prefix portion of this entity's identifier"""
     )
-    has_phenotype: Optional[List[str]] = Field(
-        None,
-        description="""A list of phenotype identifiers that are known to be associated with this entity""",
-        json_schema_extra={"linkml_meta": {"alias": "has_phenotype", "domain_of": ["Entity"]}},
+    has_phenotype: Optional[list[str]] = Field(
+        default=None, description="""A list of phenotype identifiers that are known to be associated with this entity"""
     )
-    has_phenotype_label: Optional[List[str]] = Field(
-        None,
-        description="""A list of phenotype labels that are known to be associated with this entity""",
-        json_schema_extra={"linkml_meta": {"alias": "has_phenotype_label", "domain_of": ["Entity"]}},
+    has_phenotype_label: Optional[list[str]] = Field(
+        default=None, description="""A list of phenotype labels that are known to be associated with this entity"""
     )
-    has_phenotype_closure: Optional[List[str]] = Field(
-        None,
+    has_phenotype_closure: Optional[list[str]] = Field(
+        default=None,
         description="""A list of phenotype identifiers that are known to be associated with this entity expanded to include all ancestors""",
-        json_schema_extra={"linkml_meta": {"alias": "has_phenotype_closure", "domain_of": ["Entity"]}},
     )
-    has_phenotype_closure_label: Optional[List[str]] = Field(
-        None,
+    has_phenotype_closure_label: Optional[list[str]] = Field(
+        default=None,
         description="""A list of phenotype labels that are known to be associated with this entity expanded to include all ancestors""",
-        json_schema_extra={"linkml_meta": {"alias": "has_phenotype_closure_label", "domain_of": ["Entity"]}},
     )
     has_phenotype_count: Optional[int] = Field(
-        None,
+        default=None,
         description="""A count of the number of phenotypes that are known to be associated with this entity""",
-        json_schema_extra={"linkml_meta": {"alias": "has_phenotype_count", "domain_of": ["Entity"]}},
     )
 
 
 class NodeHierarchy(ConfiguredBaseModel):
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({"from_schema": "https://w3id.org/monarch/monarch-py"})
-
-    super_classes: List[Entity] = Field(
-        ..., json_schema_extra={"linkml_meta": {"alias": "super_classes", "domain_of": ["NodeHierarchy"]}}
-    )
-    sub_classes: List[Entity] = Field(
-        ..., json_schema_extra={"linkml_meta": {"alias": "sub_classes", "domain_of": ["NodeHierarchy"]}}
-    )
+    super_classes: list[Entity] = Field(default=...)
+    sub_classes: list[Entity] = Field(default=...)
 
 
 class Release(ConfiguredBaseModel):
@@ -2334,386 +788,88 @@ class Release(ConfiguredBaseModel):
     A class to hold information about a release of the Monarch KG
     """
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({"from_schema": "https://w3id.org/monarch/monarch-py"})
-
-    version: Optional[str] = Field(
-        None,
-        json_schema_extra={"linkml_meta": {"alias": "version", "domain_of": ["Release"], "id_prefixes": ["string"]}},
-    )
-    url: Optional[str] = Field(
-        None, json_schema_extra={"linkml_meta": {"alias": "url", "domain_of": ["ExpandedCurie", "Release"]}}
-    )
-    kg: Optional[str] = Field(
-        None, json_schema_extra={"linkml_meta": {"alias": "kg", "domain_of": ["Release"], "id_prefixes": ["string"]}}
-    )
-    sqlite: Optional[str] = Field(
-        None,
-        json_schema_extra={"linkml_meta": {"alias": "sqlite", "domain_of": ["Release"], "id_prefixes": ["string"]}},
-    )
-    solr: Optional[str] = Field(
-        None, json_schema_extra={"linkml_meta": {"alias": "solr", "domain_of": ["Release"], "id_prefixes": ["string"]}}
-    )
-    neo4j: Optional[str] = Field(
-        None, json_schema_extra={"linkml_meta": {"alias": "neo4j", "domain_of": ["Release"], "id_prefixes": ["string"]}}
-    )
-    metadata: Optional[str] = Field(
-        None,
-        json_schema_extra={"linkml_meta": {"alias": "metadata", "domain_of": ["Release"], "id_prefixes": ["string"]}},
-    )
-    graph_stats: Optional[str] = Field(
-        None,
-        json_schema_extra={
-            "linkml_meta": {"alias": "graph_stats", "domain_of": ["Release"], "id_prefixes": ["string"]}
-        },
-    )
-    qc_report: Optional[str] = Field(
-        None,
-        json_schema_extra={"linkml_meta": {"alias": "qc_report", "domain_of": ["Release"], "id_prefixes": ["string"]}},
-    )
+    version: Optional[str] = Field(default=None)
+    url: Optional[str] = Field(default=None)
+    kg: Optional[str] = Field(default=None)
+    sqlite: Optional[str] = Field(default=None)
+    solr: Optional[str] = Field(default=None)
+    neo4j: Optional[str] = Field(default=None)
+    metadata: Optional[str] = Field(default=None)
+    graph_stats: Optional[str] = Field(default=None)
+    qc_report: Optional[str] = Field(default=None)
 
 
 class Results(ConfiguredBaseModel):
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {"abstract": True, "from_schema": "https://w3id.org/monarch/monarch-py"}
-    )
-
-    limit: int = Field(
-        ...,
-        description="""number of items to return in a response""",
-        json_schema_extra={"linkml_meta": {"alias": "limit", "domain_of": ["Results"]}},
-    )
-    offset: int = Field(
-        ...,
-        description="""offset into the total number of items""",
-        json_schema_extra={"linkml_meta": {"alias": "offset", "domain_of": ["Results"]}},
-    )
-    total: int = Field(
-        ...,
-        description="""total number of items matching a query""",
-        json_schema_extra={"linkml_meta": {"alias": "total", "domain_of": ["Results"]}},
-    )
+    limit: int = Field(default=..., description="""number of items to return in a response""")
+    offset: int = Field(default=..., description="""offset into the total number of items""")
+    total: int = Field(default=..., description="""total number of items matching a query""")
 
 
 class AssociationResults(Results):
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {
-            "from_schema": "https://w3id.org/monarch/monarch-py",
-            "slot_usage": {"items": {"name": "items", "range": "Association"}},
-        }
+    items: list[Association] = Field(
+        default=..., description="""A collection of items, with the type to be overriden by slot_usage"""
     )
-
-    items: List[Association] = Field(
-        ...,
-        description="""A collection of items, with the type to be overriden by slot_usage""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "items",
-                "domain_of": [
-                    "AssociationCountList",
-                    "AssociationResults",
-                    "CompactAssociationResults",
-                    "AssociationTableResults",
-                    "CategoryGroupedAssociationResults",
-                    "EntityResults",
-                    "HistoPheno",
-                    "MappingResults",
-                    "SearchResults",
-                ],
-            }
-        },
+    facet_fields: Optional[list[FacetField]] = Field(
+        default=None, description="""Collection of facet field responses with the field values and counts"""
     )
-    facet_fields: Optional[List[FacetField]] = Field(
-        None,
-        description="""Collection of facet field responses with the field values and counts""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "facet_fields",
-                "domain_of": [
-                    "AssociationResults",
-                    "CompactAssociationResults",
-                    "AssociationTableResults",
-                    "SearchResults",
-                ],
-            }
-        },
+    facet_queries: Optional[list[FacetValue]] = Field(
+        default=None, description="""Collection of facet query responses with the query string values and counts"""
     )
-    facet_queries: Optional[List[FacetValue]] = Field(
-        None,
-        description="""Collection of facet query responses with the query string values and counts""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "facet_queries",
-                "domain_of": [
-                    "AssociationResults",
-                    "CompactAssociationResults",
-                    "AssociationTableResults",
-                    "SearchResults",
-                ],
-            }
-        },
-    )
-    limit: int = Field(
-        ...,
-        description="""number of items to return in a response""",
-        json_schema_extra={"linkml_meta": {"alias": "limit", "domain_of": ["Results"]}},
-    )
-    offset: int = Field(
-        ...,
-        description="""offset into the total number of items""",
-        json_schema_extra={"linkml_meta": {"alias": "offset", "domain_of": ["Results"]}},
-    )
-    total: int = Field(
-        ...,
-        description="""total number of items matching a query""",
-        json_schema_extra={"linkml_meta": {"alias": "total", "domain_of": ["Results"]}},
-    )
+    limit: int = Field(default=..., description="""number of items to return in a response""")
+    offset: int = Field(default=..., description="""offset into the total number of items""")
+    total: int = Field(default=..., description="""total number of items matching a query""")
 
 
 class CompactAssociationResults(Results):
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {
-            "from_schema": "https://w3id.org/monarch/monarch-py",
-            "slot_usage": {"items": {"name": "items", "range": "CompactAssociation"}},
-        }
+    items: list[CompactAssociation] = Field(
+        default=..., description="""A collection of items, with the type to be overriden by slot_usage"""
     )
-
-    items: List[CompactAssociation] = Field(
-        ...,
-        description="""A collection of items, with the type to be overriden by slot_usage""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "items",
-                "domain_of": [
-                    "AssociationCountList",
-                    "AssociationResults",
-                    "CompactAssociationResults",
-                    "AssociationTableResults",
-                    "CategoryGroupedAssociationResults",
-                    "EntityResults",
-                    "HistoPheno",
-                    "MappingResults",
-                    "SearchResults",
-                ],
-            }
-        },
+    facet_fields: Optional[list[FacetField]] = Field(
+        default=None, description="""Collection of facet field responses with the field values and counts"""
     )
-    facet_fields: Optional[List[FacetField]] = Field(
-        None,
-        description="""Collection of facet field responses with the field values and counts""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "facet_fields",
-                "domain_of": [
-                    "AssociationResults",
-                    "CompactAssociationResults",
-                    "AssociationTableResults",
-                    "SearchResults",
-                ],
-            }
-        },
+    facet_queries: Optional[list[FacetValue]] = Field(
+        default=None, description="""Collection of facet query responses with the query string values and counts"""
     )
-    facet_queries: Optional[List[FacetValue]] = Field(
-        None,
-        description="""Collection of facet query responses with the query string values and counts""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "facet_queries",
-                "domain_of": [
-                    "AssociationResults",
-                    "CompactAssociationResults",
-                    "AssociationTableResults",
-                    "SearchResults",
-                ],
-            }
-        },
-    )
-    limit: int = Field(
-        ...,
-        description="""number of items to return in a response""",
-        json_schema_extra={"linkml_meta": {"alias": "limit", "domain_of": ["Results"]}},
-    )
-    offset: int = Field(
-        ...,
-        description="""offset into the total number of items""",
-        json_schema_extra={"linkml_meta": {"alias": "offset", "domain_of": ["Results"]}},
-    )
-    total: int = Field(
-        ...,
-        description="""total number of items matching a query""",
-        json_schema_extra={"linkml_meta": {"alias": "total", "domain_of": ["Results"]}},
-    )
+    limit: int = Field(default=..., description="""number of items to return in a response""")
+    offset: int = Field(default=..., description="""offset into the total number of items""")
+    total: int = Field(default=..., description="""total number of items matching a query""")
 
 
 class AssociationTableResults(Results):
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {
-            "from_schema": "https://w3id.org/monarch/monarch-py",
-            "slot_usage": {"items": {"name": "items", "range": "DirectionalAssociation"}},
-        }
+    items: list[DirectionalAssociation] = Field(
+        default=..., description="""A collection of items, with the type to be overriden by slot_usage"""
     )
-
-    items: List[DirectionalAssociation] = Field(
-        ...,
-        description="""A collection of items, with the type to be overriden by slot_usage""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "items",
-                "domain_of": [
-                    "AssociationCountList",
-                    "AssociationResults",
-                    "CompactAssociationResults",
-                    "AssociationTableResults",
-                    "CategoryGroupedAssociationResults",
-                    "EntityResults",
-                    "HistoPheno",
-                    "MappingResults",
-                    "SearchResults",
-                ],
-            }
-        },
+    facet_fields: Optional[list[FacetField]] = Field(
+        default=None, description="""Collection of facet field responses with the field values and counts"""
     )
-    facet_fields: Optional[List[FacetField]] = Field(
-        None,
-        description="""Collection of facet field responses with the field values and counts""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "facet_fields",
-                "domain_of": [
-                    "AssociationResults",
-                    "CompactAssociationResults",
-                    "AssociationTableResults",
-                    "SearchResults",
-                ],
-            }
-        },
+    facet_queries: Optional[list[FacetValue]] = Field(
+        default=None, description="""Collection of facet query responses with the query string values and counts"""
     )
-    facet_queries: Optional[List[FacetValue]] = Field(
-        None,
-        description="""Collection of facet query responses with the query string values and counts""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "facet_queries",
-                "domain_of": [
-                    "AssociationResults",
-                    "CompactAssociationResults",
-                    "AssociationTableResults",
-                    "SearchResults",
-                ],
-            }
-        },
-    )
-    limit: int = Field(
-        ...,
-        description="""number of items to return in a response""",
-        json_schema_extra={"linkml_meta": {"alias": "limit", "domain_of": ["Results"]}},
-    )
-    offset: int = Field(
-        ...,
-        description="""offset into the total number of items""",
-        json_schema_extra={"linkml_meta": {"alias": "offset", "domain_of": ["Results"]}},
-    )
-    total: int = Field(
-        ...,
-        description="""total number of items matching a query""",
-        json_schema_extra={"linkml_meta": {"alias": "total", "domain_of": ["Results"]}},
-    )
+    limit: int = Field(default=..., description="""number of items to return in a response""")
+    offset: int = Field(default=..., description="""offset into the total number of items""")
+    total: int = Field(default=..., description="""total number of items matching a query""")
 
 
 class CategoryGroupedAssociationResults(Results):
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {
-            "from_schema": "https://w3id.org/monarch/monarch-py",
-            "slot_usage": {"items": {"name": "items", "range": "Association"}},
-        }
-    )
-
     counterpart_category: Optional[str] = Field(
-        None,
+        default=None,
         description="""The category of the counterpart entity in a given association,  eg. the category of the entity that is not the subject""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "counterpart_category", "domain_of": ["CategoryGroupedAssociationResults"]}
-        },
     )
-    items: List[Association] = Field(
-        ...,
-        description="""A collection of items, with the type to be overriden by slot_usage""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "items",
-                "domain_of": [
-                    "AssociationCountList",
-                    "AssociationResults",
-                    "CompactAssociationResults",
-                    "AssociationTableResults",
-                    "CategoryGroupedAssociationResults",
-                    "EntityResults",
-                    "HistoPheno",
-                    "MappingResults",
-                    "SearchResults",
-                ],
-            }
-        },
+    items: list[Association] = Field(
+        default=..., description="""A collection of items, with the type to be overriden by slot_usage"""
     )
-    limit: int = Field(
-        ...,
-        description="""number of items to return in a response""",
-        json_schema_extra={"linkml_meta": {"alias": "limit", "domain_of": ["Results"]}},
-    )
-    offset: int = Field(
-        ...,
-        description="""offset into the total number of items""",
-        json_schema_extra={"linkml_meta": {"alias": "offset", "domain_of": ["Results"]}},
-    )
-    total: int = Field(
-        ...,
-        description="""total number of items matching a query""",
-        json_schema_extra={"linkml_meta": {"alias": "total", "domain_of": ["Results"]}},
-    )
+    limit: int = Field(default=..., description="""number of items to return in a response""")
+    offset: int = Field(default=..., description="""offset into the total number of items""")
+    total: int = Field(default=..., description="""total number of items matching a query""")
 
 
 class EntityResults(Results):
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {
-            "from_schema": "https://w3id.org/monarch/monarch-py",
-            "slot_usage": {"items": {"name": "items", "range": "Entity"}},
-        }
+    items: list[Entity] = Field(
+        default=..., description="""A collection of items, with the type to be overriden by slot_usage"""
     )
-
-    items: List[Entity] = Field(
-        ...,
-        description="""A collection of items, with the type to be overriden by slot_usage""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "items",
-                "domain_of": [
-                    "AssociationCountList",
-                    "AssociationResults",
-                    "CompactAssociationResults",
-                    "AssociationTableResults",
-                    "CategoryGroupedAssociationResults",
-                    "EntityResults",
-                    "HistoPheno",
-                    "MappingResults",
-                    "SearchResults",
-                ],
-            }
-        },
-    )
-    limit: int = Field(
-        ...,
-        description="""number of items to return in a response""",
-        json_schema_extra={"linkml_meta": {"alias": "limit", "domain_of": ["Results"]}},
-    )
-    offset: int = Field(
-        ...,
-        description="""offset into the total number of items""",
-        json_schema_extra={"linkml_meta": {"alias": "offset", "domain_of": ["Results"]}},
-    )
-    total: int = Field(
-        ...,
-        description="""total number of items matching a query""",
-        json_schema_extra={"linkml_meta": {"alias": "total", "domain_of": ["Results"]}},
-    )
+    limit: int = Field(default=..., description="""number of items to return in a response""")
+    offset: int = Field(default=..., description="""offset into the total number of items""")
+    total: int = Field(default=..., description="""total number of items matching a query""")
 
 
 class MappingResults(Results):
@@ -2721,352 +877,94 @@ class MappingResults(Results):
     SSSOM Mappings returned as a results collection
     """
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {
-            "from_schema": "https://w3id.org/monarch/monarch-py",
-            "slot_usage": {"items": {"name": "items", "range": "Mapping"}},
-        }
+    items: list[Mapping] = Field(
+        default=..., description="""A collection of items, with the type to be overriden by slot_usage"""
     )
-
-    items: List[Mapping] = Field(
-        ...,
-        description="""A collection of items, with the type to be overriden by slot_usage""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "items",
-                "domain_of": [
-                    "AssociationCountList",
-                    "AssociationResults",
-                    "CompactAssociationResults",
-                    "AssociationTableResults",
-                    "CategoryGroupedAssociationResults",
-                    "EntityResults",
-                    "HistoPheno",
-                    "MappingResults",
-                    "SearchResults",
-                ],
-            }
-        },
-    )
-    limit: int = Field(
-        ...,
-        description="""number of items to return in a response""",
-        json_schema_extra={"linkml_meta": {"alias": "limit", "domain_of": ["Results"]}},
-    )
-    offset: int = Field(
-        ...,
-        description="""offset into the total number of items""",
-        json_schema_extra={"linkml_meta": {"alias": "offset", "domain_of": ["Results"]}},
-    )
-    total: int = Field(
-        ...,
-        description="""total number of items matching a query""",
-        json_schema_extra={"linkml_meta": {"alias": "total", "domain_of": ["Results"]}},
-    )
+    limit: int = Field(default=..., description="""number of items to return in a response""")
+    offset: int = Field(default=..., description="""offset into the total number of items""")
+    total: int = Field(default=..., description="""total number of items matching a query""")
 
 
 class MultiEntityAssociationResults(Results):
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({"from_schema": "https://w3id.org/monarch/monarch-py"})
-
-    id: str = Field(
-        ...,
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "id",
-                "domain_of": [
-                    "TermInfo",
-                    "Association",
-                    "ExpandedCurie",
-                    "Entity",
-                    "HistoPheno",
-                    "HistoBin",
-                    "Mapping",
-                    "MultiEntityAssociationResults",
-                ],
-            }
-        },
-    )
-    name: Optional[str] = Field(
-        None,
-        json_schema_extra={"linkml_meta": {"alias": "name", "domain_of": ["Entity", "MultiEntityAssociationResults"]}},
-    )
-    associated_categories: List[CategoryGroupedAssociationResults] = Field(
-        ...,
-        json_schema_extra={
-            "linkml_meta": {"alias": "associated_categories", "domain_of": ["MultiEntityAssociationResults"]}
-        },
-    )
-    limit: int = Field(
-        ...,
-        description="""number of items to return in a response""",
-        json_schema_extra={"linkml_meta": {"alias": "limit", "domain_of": ["Results"]}},
-    )
-    offset: int = Field(
-        ...,
-        description="""offset into the total number of items""",
-        json_schema_extra={"linkml_meta": {"alias": "offset", "domain_of": ["Results"]}},
-    )
-    total: int = Field(
-        ...,
-        description="""total number of items matching a query""",
-        json_schema_extra={"linkml_meta": {"alias": "total", "domain_of": ["Results"]}},
-    )
+    id: str = Field(default=...)
+    name: Optional[str] = Field(default=None)
+    associated_categories: list[CategoryGroupedAssociationResults] = Field(default=...)
+    limit: int = Field(default=..., description="""number of items to return in a response""")
+    offset: int = Field(default=..., description="""offset into the total number of items""")
+    total: int = Field(default=..., description="""total number of items matching a query""")
 
 
 class SearchResult(Entity):
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {
-            "from_schema": "https://w3id.org/monarch/monarch-py",
-            "slot_usage": {
-                "category": {"name": "category", "required": True},
-                "name": {"name": "name", "required": True},
-            },
-        }
-    )
-
-    score: Optional[float] = Field(
-        None,
-        json_schema_extra={
-            "linkml_meta": {"alias": "score", "domain_of": ["BestMatch", "SemsimSearchResult", "SearchResult"]}
-        },
-    )
-    id: str = Field(
-        ...,
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "id",
-                "domain_of": [
-                    "TermInfo",
-                    "Association",
-                    "ExpandedCurie",
-                    "Entity",
-                    "HistoPheno",
-                    "HistoBin",
-                    "Mapping",
-                    "MultiEntityAssociationResults",
-                ],
-            }
-        },
-    )
-    category: str = Field(
-        ...,
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "category",
-                "domain_of": [
-                    "Association",
-                    "AssociationCount",
-                    "CompactAssociation",
-                    "AssociationTypeMapping",
-                    "Entity",
-                ],
-            }
-        },
-    )
-    name: str = Field(
-        ...,
-        json_schema_extra={"linkml_meta": {"alias": "name", "domain_of": ["Entity", "MultiEntityAssociationResults"]}},
-    )
-    full_name: Optional[str] = Field(
-        None,
-        description="""The long form name of an entity""",
-        json_schema_extra={"linkml_meta": {"alias": "full_name", "domain_of": ["Entity"]}},
-    )
+    score: Optional[float] = Field(default=None)
+    id: str = Field(default=...)
+    category: str = Field(default=...)
+    name: str = Field(default=...)
+    full_name: Optional[str] = Field(default=None, description="""The long form name of an entity""")
     deprecated: Optional[bool] = Field(
-        None,
+        default=None,
         description="""A boolean flag indicating that an entity is no longer considered current or valid.""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "deprecated",
-                "domain_of": ["Entity"],
-                "exact_mappings": ["oboInOwl:ObsoleteClass"],
-            }
-        },
     )
-    description: Optional[str] = Field(
-        None, json_schema_extra={"linkml_meta": {"alias": "description", "domain_of": ["Entity"]}}
-    )
-    xref: Optional[List[str]] = Field(
-        None, json_schema_extra={"linkml_meta": {"alias": "xref", "domain_of": ["Entity"]}}
-    )
-    provided_by: Optional[str] = Field(
-        None, json_schema_extra={"linkml_meta": {"alias": "provided_by", "domain_of": ["Association", "Entity"]}}
-    )
+    description: Optional[str] = Field(default=None)
+    xref: Optional[list[str]] = Field(default=None)
+    provided_by: Optional[str] = Field(default=None)
     in_taxon: Optional[str] = Field(
-        None,
-        description="""The biolink taxon that the entity is in the closure of.""",
-        json_schema_extra={"linkml_meta": {"alias": "in_taxon", "domain_of": ["Entity", "Node"]}},
+        default=None, description="""The biolink taxon that the entity is in the closure of."""
     )
     in_taxon_label: Optional[str] = Field(
-        None,
-        description="""The label of the biolink taxon that the entity is in the closure of.""",
-        json_schema_extra={"linkml_meta": {"alias": "in_taxon_label", "domain_of": ["Entity", "Node"]}},
+        default=None, description="""The label of the biolink taxon that the entity is in the closure of."""
     )
-    symbol: Optional[str] = Field(None, json_schema_extra={"linkml_meta": {"alias": "symbol", "domain_of": ["Entity"]}})
-    synonym: Optional[List[str]] = Field(
-        None, json_schema_extra={"linkml_meta": {"alias": "synonym", "domain_of": ["Entity"]}}
-    )
-    broad_synonym: Optional[List[str]] = Field(
-        None,
-        description="""A broader synonym for the entity""",
-        json_schema_extra={"linkml_meta": {"alias": "broad_synonym", "domain_of": ["Entity"]}},
-    )
-    exact_synonym: Optional[List[str]] = Field(
-        None,
-        description="""An exact synonym for the entity""",
-        json_schema_extra={"linkml_meta": {"alias": "exact_synonym", "domain_of": ["Entity"]}},
-    )
-    narrow_synonym: Optional[List[str]] = Field(
-        None,
-        description="""A narrower synonym for the entity""",
-        json_schema_extra={"linkml_meta": {"alias": "narrow_synonym", "domain_of": ["Entity"]}},
-    )
-    related_synonym: Optional[List[str]] = Field(
-        None,
-        description="""A related synonym for the entity""",
-        json_schema_extra={"linkml_meta": {"alias": "related_synonym", "domain_of": ["Entity"]}},
-    )
-    subsets: Optional[List[str]] = Field(
-        None,
-        description="""A list of subsets that the entity belongs to""",
-        json_schema_extra={"linkml_meta": {"alias": "subsets", "domain_of": ["Entity"]}},
-    )
-    uri: Optional[str] = Field(
-        None,
-        description="""The URI of the entity""",
-        json_schema_extra={"linkml_meta": {"alias": "uri", "domain_of": ["Entity"]}},
-    )
-    iri: Optional[str] = Field(None, json_schema_extra={"linkml_meta": {"alias": "iri", "domain_of": ["Entity"]}})
+    symbol: Optional[str] = Field(default=None)
+    synonym: Optional[list[str]] = Field(default=None)
+    broad_synonym: Optional[list[str]] = Field(default=None, description="""A broader synonym for the entity""")
+    exact_synonym: Optional[list[str]] = Field(default=None, description="""An exact synonym for the entity""")
+    narrow_synonym: Optional[list[str]] = Field(default=None, description="""A narrower synonym for the entity""")
+    related_synonym: Optional[list[str]] = Field(default=None, description="""A related synonym for the entity""")
+    subsets: Optional[list[str]] = Field(default=None, description="""A list of subsets that the entity belongs to""")
+    uri: Optional[str] = Field(default=None, description="""The URI of the entity""")
+    iri: Optional[str] = Field(default=None)
     namespace: Optional[str] = Field(
-        None,
-        description="""The namespace/prefix portion of this entity's identifier""",
-        json_schema_extra={"linkml_meta": {"alias": "namespace", "domain_of": ["Entity"]}},
+        default=None, description="""The namespace/prefix portion of this entity's identifier"""
     )
-    has_phenotype: Optional[List[str]] = Field(
-        None,
-        description="""A list of phenotype identifiers that are known to be associated with this entity""",
-        json_schema_extra={"linkml_meta": {"alias": "has_phenotype", "domain_of": ["Entity"]}},
+    has_phenotype: Optional[list[str]] = Field(
+        default=None, description="""A list of phenotype identifiers that are known to be associated with this entity"""
     )
-    has_phenotype_label: Optional[List[str]] = Field(
-        None,
-        description="""A list of phenotype labels that are known to be associated with this entity""",
-        json_schema_extra={"linkml_meta": {"alias": "has_phenotype_label", "domain_of": ["Entity"]}},
+    has_phenotype_label: Optional[list[str]] = Field(
+        default=None, description="""A list of phenotype labels that are known to be associated with this entity"""
     )
-    has_phenotype_closure: Optional[List[str]] = Field(
-        None,
+    has_phenotype_closure: Optional[list[str]] = Field(
+        default=None,
         description="""A list of phenotype identifiers that are known to be associated with this entity expanded to include all ancestors""",
-        json_schema_extra={"linkml_meta": {"alias": "has_phenotype_closure", "domain_of": ["Entity"]}},
     )
-    has_phenotype_closure_label: Optional[List[str]] = Field(
-        None,
+    has_phenotype_closure_label: Optional[list[str]] = Field(
+        default=None,
         description="""A list of phenotype labels that are known to be associated with this entity expanded to include all ancestors""",
-        json_schema_extra={"linkml_meta": {"alias": "has_phenotype_closure_label", "domain_of": ["Entity"]}},
     )
     has_phenotype_count: Optional[int] = Field(
-        None,
+        default=None,
         description="""A count of the number of phenotypes that are known to be associated with this entity""",
-        json_schema_extra={"linkml_meta": {"alias": "has_phenotype_count", "domain_of": ["Entity"]}},
     )
 
 
 class SearchResults(Results):
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {
-            "from_schema": "https://w3id.org/monarch/monarch-py",
-            "slot_usage": {"items": {"name": "items", "range": "SearchResult"}},
-        }
+    items: list[SearchResult] = Field(
+        default=..., description="""A collection of items, with the type to be overriden by slot_usage"""
     )
-
-    items: List[SearchResult] = Field(
-        ...,
-        description="""A collection of items, with the type to be overriden by slot_usage""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "items",
-                "domain_of": [
-                    "AssociationCountList",
-                    "AssociationResults",
-                    "CompactAssociationResults",
-                    "AssociationTableResults",
-                    "CategoryGroupedAssociationResults",
-                    "EntityResults",
-                    "HistoPheno",
-                    "MappingResults",
-                    "SearchResults",
-                ],
-            }
-        },
+    facet_fields: Optional[list[FacetField]] = Field(
+        default=None, description="""Collection of facet field responses with the field values and counts"""
     )
-    facet_fields: Optional[List[FacetField]] = Field(
-        None,
-        description="""Collection of facet field responses with the field values and counts""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "facet_fields",
-                "domain_of": [
-                    "AssociationResults",
-                    "CompactAssociationResults",
-                    "AssociationTableResults",
-                    "SearchResults",
-                ],
-            }
-        },
+    facet_queries: Optional[list[FacetValue]] = Field(
+        default=None, description="""Collection of facet query responses with the query string values and counts"""
     )
-    facet_queries: Optional[List[FacetValue]] = Field(
-        None,
-        description="""Collection of facet query responses with the query string values and counts""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "facet_queries",
-                "domain_of": [
-                    "AssociationResults",
-                    "CompactAssociationResults",
-                    "AssociationTableResults",
-                    "SearchResults",
-                ],
-            }
-        },
-    )
-    limit: int = Field(
-        ...,
-        description="""number of items to return in a response""",
-        json_schema_extra={"linkml_meta": {"alias": "limit", "domain_of": ["Results"]}},
-    )
-    offset: int = Field(
-        ...,
-        description="""offset into the total number of items""",
-        json_schema_extra={"linkml_meta": {"alias": "offset", "domain_of": ["Results"]}},
-    )
-    total: int = Field(
-        ...,
-        description="""total number of items matching a query""",
-        json_schema_extra={"linkml_meta": {"alias": "total", "domain_of": ["Results"]}},
-    )
+    limit: int = Field(default=..., description="""number of items to return in a response""")
+    offset: int = Field(default=..., description="""offset into the total number of items""")
+    total: int = Field(default=..., description="""total number of items matching a query""")
 
 
 class TextAnnotationResult(ConfiguredBaseModel):
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({"from_schema": "https://w3id.org/monarch/monarch-py"})
-
-    text: Optional[str] = Field(
-        None,
-        description="""text without tokens""",
-        json_schema_extra={"linkml_meta": {"alias": "text", "domain_of": ["TextAnnotationResult"]}},
-    )
-    tokens: Optional[List[Entity]] = Field(
-        None,
-        description="""A collection of entities or concepts""",
-        json_schema_extra={"linkml_meta": {"alias": "tokens", "domain_of": ["TextAnnotationResult"]}},
-    )
-    start: Optional[int] = Field(
-        None,
-        description="""start position of the annotation""",
-        json_schema_extra={"linkml_meta": {"alias": "start", "domain_of": ["TextAnnotationResult"]}},
-    )
-    end: Optional[int] = Field(
-        None,
-        description="""end position of the annotation""",
-        json_schema_extra={"linkml_meta": {"alias": "end", "domain_of": ["TextAnnotationResult"]}},
-    )
+    text: Optional[str] = Field(default=None, description="""text without tokens""")
+    tokens: Optional[list[Entity]] = Field(default=None, description="""A collection of entities or concepts""")
+    start: Optional[int] = Field(default=None, description="""start position of the annotation""")
+    end: Optional[int] = Field(default=None, description="""end position of the annotation""")
 
 
 class AssociationHighlighting(ConfiguredBaseModel):
@@ -3074,75 +972,43 @@ class AssociationHighlighting(ConfiguredBaseModel):
     Optional highlighting information for search results
     """
 
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta(
-        {
-            "from_schema": "https://w3id.org/monarch/monarch-py",
-            "slot_usage": {
-                "object_label": {"multivalued": True, "name": "object_label", "required": False},
-                "predicate": {"multivalued": True, "name": "predicate", "required": False},
-                "subject_label": {"multivalued": True, "name": "subject_label", "required": False},
-            },
-        }
+    object_label: Optional[list[str]] = Field(default=None, description="""The name of the object entity""")
+    object_closure_label: Optional[list[str]] = Field(
+        default=None, description="""Field containing object name and the names of all of it's ancestors"""
     )
+    subject_label: Optional[list[str]] = Field(default=None, description="""The name of the subject entity""")
+    subject_closure_label: Optional[list[str]] = Field(
+        default=None, description="""Field containing subject name and the names of all of it's ancestors"""
+    )
+    predicate: Optional[list[str]] = Field(default=None)
 
-    object_label: Optional[List[str]] = Field(
-        None,
-        description="""The name of the object entity""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "object_label",
-                "domain_of": [
-                    "TermPairwiseSimilarity",
-                    "Association",
-                    "CompactAssociation",
-                    "AssociationTypeMapping",
-                    "Mapping",
-                    "AssociationHighlighting",
-                ],
-                "is_a": "name",
-            }
-        },
+
+class InformationResource(ConfiguredBaseModel):
+    """
+    A database or knowledgebase and its supporting ecosystem of interfaces and services that deliver content to consumers
+    """
+
+    id: str = Field(default=..., description="""Unique identifier (CURIE or complete URI)""")
+    name: Optional[str] = Field(default=None, description="""Human-readable name for the resource""")
+    description: Optional[str] = Field(default=None, description="""Free-text description of the resource""")
+    status: str = Field(default=..., description="""Status of the information resource identifier""")
+    knowledge_level: str = Field(
+        default=...,
+        description="""Describes the level of knowledge expressed in a statement, based on the reasoning or analysis methods used to generate the statement, or the scope or specificity of what the statement expresses to be true.""",
     )
-    object_closure_label: Optional[List[str]] = Field(
-        None,
-        description="""Field containing object name and the names of all of it's ancestors""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "object_closure_label", "domain_of": ["Association", "AssociationHighlighting"]}
-        },
+    agent_type: str = Field(
+        default=...,
+        description="""Describes the high-level category of agent who originally generated a  statement of knowledge or other type of information.""",
     )
-    subject_label: Optional[List[str]] = Field(
-        None,
-        description="""The name of the subject entity""",
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "subject_label",
-                "domain_of": [
-                    "TermPairwiseSimilarity",
-                    "Association",
-                    "CompactAssociation",
-                    "AssociationTypeMapping",
-                    "Mapping",
-                    "AssociationHighlighting",
-                ],
-                "is_a": "name",
-            }
-        },
+    xref: Optional[list[str]] = Field(
+        default=None, description="""Database cross references or alternative identifiers"""
     )
-    subject_closure_label: Optional[List[str]] = Field(
-        None,
-        description="""Field containing subject name and the names of all of it's ancestors""",
-        json_schema_extra={
-            "linkml_meta": {"alias": "subject_closure_label", "domain_of": ["Association", "AssociationHighlighting"]}
-        },
+    synonym: Optional[list[str]] = Field(default=None, description="""Alternate human-readable names""")
+    consumes: Optional[list[str]] = Field(
+        default=None, description="""Information resources consumed by this resource"""
     )
-    predicate: Optional[List[str]] = Field(
-        None,
-        json_schema_extra={
-            "linkml_meta": {
-                "alias": "predicate",
-                "domain_of": ["Association", "CompactAssociation", "AssociationHighlighting"],
-            }
-        },
+    consumed_by: Optional[list[str]] = Field(
+        default=None, description="""Information resources consuming this resource"""
     )
 
 
@@ -3182,3 +1048,4 @@ SearchResult.model_rebuild()
 SearchResults.model_rebuild()
 TextAnnotationResult.model_rebuild()
 AssociationHighlighting.model_rebuild()
+InformationResource.model_rebuild()

--- a/backend/src/monarch_py/datamodels/model.yaml
+++ b/backend/src/monarch_py/datamodels/model.yaml
@@ -367,6 +367,39 @@ classes:
         multivalued: true
         required: false
 
+  InformationResource:  # FROM INFORES REGISTRY
+    description: A database or knowledgebase and its supporting ecosystem of interfaces and services that deliver content to consumers
+    aliases: ['knowledgebase']
+    slots:
+      - id              # Core identifier
+      - name            # Human-readable name
+      - description     # Free-text description
+      - status          # Status of the resource (required)
+      - knowledge_level # Existing slot
+      - agent_type      # Existing slot
+      - xref            # Database cross references
+      - synonym         # Alternate names
+      - consumes        # Resources consumed
+      - consumed_by     # Resources that consume this
+    slot_usage:
+      id:
+        required: true
+        description: Unique identifier (CURIE or complete URI)
+      name:
+        aliases: ['label', 'display name', 'title']
+        description: Human-readable name for the resource
+      status:
+        required: true
+        description: Status of the information resource identifier
+      xref:
+        aliases: ['dbxref', 'record_url']
+        description: Database cross references or alternative identifiers
+      synonym:
+        description: Alternate human-readable names
+      description:
+        aliases: ['comment', 'note', 'definition']
+        description: Free-text description of the resource
+
 slots:
   aggregator_knowledge_source:
     multivalued: true
@@ -907,3 +940,18 @@ slots:
   highlighting:
     description: Optional highlighting information for search results
     multivalued: false
+
+  # Information Resource Registry slots - FROM INFORES REGISTRY
+  status:
+    description: Status of the information resource identifier
+    range: string
+
+  consumes:
+    description: Information resources consumed by this resource
+    range: string
+    multivalued: true
+
+  consumed_by:
+    description: Information resources consuming this resource
+    range: string
+    multivalued: true

--- a/backend/src/monarch_py/datamodels/solr.py
+++ b/backend/src/monarch_py/datamodels/solr.py
@@ -10,6 +10,7 @@ class core(Enum):
     ENTITY = "entity"
     ASSOCIATION = "association"
     SSSOM = "sssom"
+    INFORES = "infores"
 
 
 class HistoPhenoKeys(Enum):

--- a/backend/src/monarch_py/implementations/solr/solr_implementation.py
+++ b/backend/src/monarch_py/implementations/solr/solr_implementation.py
@@ -12,6 +12,7 @@ from monarch_py.datamodels.model import (
     CategoryGroupedAssociationResults,
     Entity,
     HistoPheno,
+    InformationResource,
     MappingResults,
     MultiEntityAssociationResults,
     Node,
@@ -223,31 +224,32 @@ class SolrImplementation(EntityInterface, AssociationInterface, SearchInterface,
             sub_classes=sub_classes,
         )
 
-    def get_infores(self, id: str) -> Optional[Entity]:
+    def get_infores(self, id: str) -> Optional[InformationResource]:
         """Retrieve a specific information resource by exact ID match
-        
+
         Args:
             id (str): id of the information resource to search for.
-            
+
         Returns:
-            Entity: Information resource entity or None if not found.
+            InformationResource: Information resource entity or None if not found.
         """
         solr = SolrService(base_url=self.base_url, core=core.INFORES)
         solr_document = solr.get(id)
         if solr_document is None:
             return None
-        return solr_document
+        return InformationResource(**solr_document)  # Direct unpacking!
 
-    def get_infores_catalog(self) -> List[dict]:
+    def get_infores_catalog(self) -> List[InformationResource]:
         """Retrieve all information resources from the infores catalog
-        
+
         Returns:
-            List[dict]: All information resources in the catalog as raw documents
+            List[InformationResource]: All information resources in the catalog
         """
         solr = SolrService(base_url=self.base_url, core=core.INFORES)
         response = solr.query(SolrQuery(q="*:*", limit=10000, offset=0))
-
-        return response.response.docs if response and response.response and response.response.docs else []
+        if not response or not response.response or not response.response.docs:
+            return []
+        return [InformationResource(**doc) for doc in response.response.docs]  # Direct unpacking!
 
     ####################################
     # Implements: AssociationInterface #

--- a/backend/src/monarch_py/implementations/solr/solr_implementation.py
+++ b/backend/src/monarch_py/implementations/solr/solr_implementation.py
@@ -18,7 +18,7 @@ from monarch_py.datamodels.model import (
     NodeHierarchy,
     SearchResults,
 )
-from monarch_py.datamodels.solr import core
+from monarch_py.datamodels.solr import SolrQuery, core
 from monarch_py.datamodels.category_enums import (
     AssociationCategory,
     AssociationPredicate,
@@ -222,6 +222,32 @@ class SolrImplementation(EntityInterface, AssociationInterface, SearchInterface,
             super_classes=super_classes,
             sub_classes=sub_classes,
         )
+
+    def get_infores(self, id: str) -> Optional[Entity]:
+        """Retrieve a specific information resource by exact ID match
+        
+        Args:
+            id (str): id of the information resource to search for.
+            
+        Returns:
+            Entity: Information resource entity or None if not found.
+        """
+        solr = SolrService(base_url=self.base_url, core=core.INFORES)
+        solr_document = solr.get(id)
+        if solr_document is None:
+            return None
+        return solr_document
+
+    def get_infores_catalog(self) -> List[dict]:
+        """Retrieve all information resources from the infores catalog
+        
+        Returns:
+            List[dict]: All information resources in the catalog as raw documents
+        """
+        solr = SolrService(base_url=self.base_url, core=core.INFORES)
+        response = solr.query(SolrQuery(q="*:*", limit=10000, offset=0))
+
+        return response.response.docs if response and response.response and response.response.docs else []
 
     ####################################
     # Implements: AssociationInterface #

--- a/backend/src/monarch_py/implementations/solr/solr_implementation.py
+++ b/backend/src/monarch_py/implementations/solr/solr_implementation.py
@@ -237,7 +237,7 @@ class SolrImplementation(EntityInterface, AssociationInterface, SearchInterface,
         solr_document = solr.get(id)
         if solr_document is None:
             return None
-        return InformationResource(**solr_document)  # Direct unpacking!
+        return InformationResource(**solr_document)  # Convert the Solr document into an InformationResource object by unpacking its fields.
 
     def get_infores_catalog(self) -> List[InformationResource]:
         """Retrieve all information resources from the infores catalog

--- a/backend/src/monarch_py/implementations/solr/solr_implementation.py
+++ b/backend/src/monarch_py/implementations/solr/solr_implementation.py
@@ -249,7 +249,7 @@ class SolrImplementation(EntityInterface, AssociationInterface, SearchInterface,
         response = solr.query(SolrQuery(q="*:*", limit=10000, offset=0))
         if not response or not response.response or not response.response.docs:
             return []
-        return [InformationResource(**doc) for doc in response.response.docs]  # Direct unpacking!
+        return [InformationResource(**doc) for doc in response.response.docs]  # Convert Solr documents to InformationResource objects
 
     ####################################
     # Implements: AssociationInterface #

--- a/backend/tests/api/test_infores_router.py
+++ b/backend/tests/api/test_infores_router.py
@@ -1,0 +1,129 @@
+from unittest.mock import patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from monarch_py.api.infores import router
+from monarch_py.datamodels.model import InformationResource
+
+app = FastAPI()
+app.include_router(router)
+client = TestClient(app)
+
+
+@patch("monarch_py.implementations.solr.solr_implementation.SolrImplementation.get_infores_catalog")
+def test_get_infores_catalog_json(mock_get_infores_catalog):
+    """Test infores catalog endpoint returns JSON format correctly"""
+    mock_data = [
+        InformationResource(
+            id="infores:agrkb",
+            status="released",
+            name="Alliance of Genome Resources (AGR Knowledgebase)",
+            xref=["https://github.com/NCATSTranslator/Translator-All/wiki/Alliance-of-Genome-Resources"],
+            synonym=["ALLIANCE"],
+            knowledge_level="knowledge_assertion",
+            agent_type="not_provided",
+            consumed_by=["infores:biothings-agr"],
+        ),
+        InformationResource(
+            id="infores:aact",
+            status="released",
+            name="Aggregate Analysis of ClinicalTrial.gov (AACT) database",
+            xref=["https://aact.ctti-clinicaltrials.org/"],
+            synonym=["AACT"],
+            knowledge_level="knowledge_assertion",
+            agent_type="not_provided",
+        ),
+    ]
+    mock_get_infores_catalog.return_value = mock_data
+
+    response = client.get("/?format=json")
+
+    assert response.status_code == 200
+    assert response.json() == [item.model_dump() for item in mock_data]
+    mock_get_infores_catalog.assert_called_once()
+
+
+@patch("monarch_py.implementations.solr.solr_implementation.SolrImplementation.get_infores_catalog")
+def test_get_infores_catalog_default_format(mock_get_infores_catalog):
+    """Test infores catalog endpoint defaults to JSON format"""
+    mock_data = [InformationResource(id="infores:test", status="released", knowledge_level="knowledge_assertion", agent_type="not_provided")]
+    mock_get_infores_catalog.return_value = mock_data
+
+    response = client.get("/")
+
+    assert response.status_code == 200
+    assert response.json() == [item.model_dump() for item in mock_data]
+    mock_get_infores_catalog.assert_called_once()
+
+
+@patch("monarch_py.implementations.solr.solr_implementation.SolrImplementation.get_infores_catalog")
+def test_get_infores_catalog_tsv(mock_get_infores_catalog):
+    """Test infores catalog endpoint returns TSV format correctly"""
+    mock_data = [InformationResource(id="infores:agrkb", status="released", name="Alliance of Genome Resources", knowledge_level="knowledge_assertion", agent_type="not_provided")]
+    mock_get_infores_catalog.return_value = mock_data
+
+    response = client.get("/?format=tsv")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "text/tab-separated-values; charset=utf-8"
+    assert "infores:agrkb" in response.text
+
+
+@patch("monarch_py.implementations.solr.solr_implementation.SolrImplementation.get_infores")
+def test_get_infores_by_id_json(mock_get_infores):
+    """Test individual infores endpoint returns JSON format correctly"""
+    mock_data = InformationResource(
+        id="infores:agrkb",
+        status="released",
+        name="Alliance of Genome Resources (AGR Knowledgebase)",
+        xref=["https://github.com/NCATSTranslator/Translator-All/wiki/Alliance-of-Genome-Resources"],
+        synonym=["ALLIANCE"],
+        knowledge_level="knowledge_assertion",
+        agent_type="not_provided",
+        consumed_by=["infores:biothings-agr"],
+    )
+    mock_get_infores.return_value = mock_data
+
+    response = client.get("/infores:agrkb?format=json")
+
+    assert response.status_code == 200
+    assert response.json() == mock_data.model_dump()
+    mock_get_infores.assert_called_once_with("infores:agrkb")
+
+
+@patch("monarch_py.implementations.solr.solr_implementation.SolrImplementation.get_infores")
+def test_get_infores_by_id_not_found(mock_get_infores):
+    """Test individual infores endpoint returns 404 for non-existent ID"""
+    mock_get_infores.return_value = None
+
+    response = client.get("/infores:nonexistent")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Information resource not found"
+    mock_get_infores.assert_called_once_with("infores:nonexistent")
+
+
+@patch("monarch_py.implementations.solr.solr_implementation.SolrImplementation.get_infores")
+def test_get_infores_by_id_tsv(mock_get_infores):
+    """Test individual infores endpoint returns TSV format correctly"""
+    mock_data = InformationResource(id="infores:agrkb", status="released", name="Alliance of Genome Resources", knowledge_level="knowledge_assertion", agent_type="not_provided")
+    mock_get_infores.return_value = mock_data
+
+    response = client.get("/infores:agrkb?format=tsv")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "text/tab-separated-values; charset=utf-8"
+    assert "infores:agrkb" in response.text
+
+
+@patch("monarch_py.implementations.solr.solr_implementation.SolrImplementation.get_infores_catalog")
+def test_get_infores_catalog_empty_response(mock_get_infores_catalog):
+    """Test infores catalog endpoint handles empty response correctly"""
+    mock_get_infores_catalog.return_value = []
+
+    response = client.get("/")
+
+    assert response.status_code == 200
+    assert response.json() == []
+    mock_get_infores_catalog.assert_called_once()

--- a/backend/tests/integration/test_solr_infores.py
+++ b/backend/tests/integration/test_solr_infores.py
@@ -1,0 +1,90 @@
+import pytest
+from monarch_py.implementations.solr.solr_implementation import SolrImplementation
+from monarch_py.datamodels.model import InformationResource
+
+pytestmark = pytest.mark.skipif(
+    condition=not SolrImplementation().solr_is_available(),
+    reason="Solr is not available",
+)
+
+
+def test_get_infores_catalog():
+    """Test that get_infores_catalog returns a list of information resources"""
+    si = SolrImplementation()
+    catalog = si.get_infores_catalog()
+
+    assert isinstance(catalog, list)
+    assert len(catalog) > 0
+
+    # Check that each item is an InformationResource with expected fields
+    for infores in catalog:
+        assert isinstance(infores, InformationResource)
+        assert hasattr(infores, "id")
+        assert infores.id.startswith("infores:")
+        assert hasattr(infores, "status")
+        assert hasattr(infores, "name")
+
+
+def test_get_infores_by_id():
+    """Test that get_infores returns a specific information resource by ID"""
+    si = SolrImplementation()
+
+    # First get the catalog to find a valid ID
+    catalog = si.get_infores_catalog()
+    assert len(catalog) > 0
+
+    test_id = catalog[0].id
+    infores = si.get_infores(test_id)
+
+    assert isinstance(infores, InformationResource)
+    assert infores.id == test_id
+    assert hasattr(infores, "status")
+    assert hasattr(infores, "name")
+
+
+def test_get_infores_nonexistent():
+    """Test that get_infores returns None for non-existent ID"""
+    si = SolrImplementation()
+    infores = si.get_infores("infores:nonexistent-test-id")
+
+    assert infores is None
+
+
+def test_get_infores_catalog_structure():
+    """Test that catalog entries have expected structure"""
+    si = SolrImplementation()
+    catalog = si.get_infores_catalog()
+
+    assert len(catalog) > 0
+
+    # Test first entry has basic required fields
+    first_entry = catalog[0]
+    required_fields = ["id", "status", "name"]
+    for field in required_fields:
+        assert hasattr(first_entry, field)
+
+    # Verify ID format
+    assert first_entry.id.startswith("infores:")
+
+    # Verify status is a valid value
+    valid_statuses = ["released", "deprecated", "draft"]
+    assert first_entry.status in valid_statuses
+
+
+def test_get_infores_catalog_not_empty():
+    """Test that the infores catalog is not empty"""
+    si = SolrImplementation()
+    catalog = si.get_infores_catalog()
+
+    # Should have at least some standard infores entries
+    assert len(catalog) > 10
+
+    # Check for some known infores entries
+    infores_ids = [entry.id for entry in catalog]
+
+    # These are common translator infores that should exist
+    expected_infores = ["infores:aragorn", "infores:arax"]
+    found_infores = [infores_id for infores_id in expected_infores if infores_id in infores_ids]
+
+    # At least one of the expected infores should be present
+    assert len(found_infores) > 0

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1087,30 +1087,6 @@ wheels = [
 ]
 
 [[package]]
-name = "jsonpatch"
-version = "1.33"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "jsonpointer" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/42/78/18813351fe5d63acad16aec57f94ec2b70a09e53ca98145589e185423873/jsonpatch-1.33.tar.gz", hash = "sha256:9fcd4009c41e6d12348b4a0ff2563ba56a2923a7dfee731d004e212e1ee5030c", size = 21699, upload-time = "2023-06-26T12:07:29.144Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/73/07/02e16ed01e04a374e644b575638ec7987ae846d25ad97bcc9945a3ee4b0e/jsonpatch-1.33-py2.py3-none-any.whl", hash = "sha256:0ae28c0cd062bbd8b8ecc26d7d164fbbea9652a1a3693f3b956c1eae5145dade", size = 12898, upload-time = "2023-06-16T21:01:28.466Z" },
-]
-
-[[package]]
-name = "jsonpath-ng"
-version = "1.7.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "ply" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/6d/86/08646239a313f895186ff0a4573452038eed8c86f54380b3ebac34d32fb2/jsonpath-ng-1.7.0.tar.gz", hash = "sha256:f6f5f7fd4e5ff79c785f1573b394043b39849fb2bb47bcead935d12b00beab3c", size = 37838, upload-time = "2024-10-11T15:41:42.404Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/35/5a/73ecb3d82f8615f32ccdadeb9356726d6cae3a4bbc840b437ceb95708063/jsonpath_ng-1.7.0-py3-none-any.whl", hash = "sha256:f3d7f9e848cba1b6da28c55b1c26ff915dc9e0b1ba7e752a53d6da8d5cbd00b6", size = 30105, upload-time = "2024-11-20T17:58:30.418Z" },
-]
-
-[[package]]
 name = "jsonpointer"
 version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1221,7 +1197,7 @@ wheels = [
 
 [[package]]
 name = "linkml"
-version = "1.8.3"
+version = "1.9.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "antlr4-python3-runtime" },
@@ -1232,7 +1208,6 @@ dependencies = [
     { name = "jinja2" },
     { name = "jsonasobj2" },
     { name = "jsonschema", extra = ["format"] },
-    { name = "linkml-dataops" },
     { name = "linkml-runtime" },
     { name = "openpyxl" },
     { name = "parse" },
@@ -1246,28 +1221,14 @@ dependencies = [
     { name = "pyyaml" },
     { name = "rdflib" },
     { name = "requests" },
+    { name = "sphinx-click" },
     { name = "sqlalchemy" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
     { name = "watchdog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/30/d8/03d68bd075830e39a1d065eca208a72f21fb0059ffdc60c7027376e68773/linkml-1.8.3.tar.gz", hash = "sha256:6bf65f3d6c4ce9e88af0fda71b954ae4c6f5e885f8b4d74c1090380d565e76ba", size = 245303, upload-time = "2024-08-22T21:17:01.141Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/77/e2/23136b7e063159dc25cb865ef10f1ceca5606136bbed469efe7a061cf707/linkml-1.9.2.tar.gz", hash = "sha256:2f9141d2bc8a93bfe1d4b86a015ad0acbb94c2af099177f5687a50d3331d2b34", size = 260216, upload-time = "2025-05-15T22:21:52.251Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/bf/f65fc591b95838cc2bf87404874e6eb84853d56ed21ada6dfb620bb42708/linkml-1.8.3-py3-none-any.whl", hash = "sha256:ced1af3055312d15335cfe8846847c0491519c9af28cce5ebd8e4e26e4361754", size = 305694, upload-time = "2024-08-22T21:16:59.338Z" },
-]
-
-[[package]]
-name = "linkml-dataops"
-version = "0.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "jinja2" },
-    { name = "jsonpatch" },
-    { name = "jsonpath-ng" },
-    { name = "linkml-runtime" },
-    { name = "ruamel-yaml" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/3c/60/cf6440d566738b6ab2564df0db6ce093cb79b92738b5a92e865f2df5c153/linkml_dataops-0.1.0.tar.gz", hash = "sha256:4550eab65e78b70dc3b9c651724a94ac2b1d1edb2fbe576465f1d6951a54ed04", size = 40211, upload-time = "2022-01-08T01:00:43.759Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/47/cbddeb34d1ec97844465efaa55c4031267efed28de888d5c799e5396f968/linkml_dataops-0.1.0-py3-none-any.whl", hash = "sha256:193cf7f659e5f07946d2c2761896910d5f7151d91282543b1363801f68307f4c", size = 27632, upload-time = "2022-01-08T01:00:42.558Z" },
+    { url = "https://files.pythonhosted.org/packages/33/19/430f4907cdad687af4c14e495c7027ed96d1bbb1901609838d55b2b32c4e/linkml-1.9.2-py3-none-any.whl", hash = "sha256:4c9cf217948367df8a20cdf68e8f6da24ba23ab97a551f8ae32e9d4264e702cc", size = 333519, upload-time = "2025-05-15T22:21:50.067Z" },
 ]
 
 [[package]]
@@ -1722,7 +1683,7 @@ requires-dist = [
     { name = "docker", specifier = ">=7.1.0" },
     { name = "fastapi", specifier = ">=0.115.12,<1" },
     { name = "gunicorn", specifier = ">=23.0.0" },
-    { name = "linkml", specifier = "==1.8.3" },
+    { name = "linkml", specifier = "==1.9.2" },
     { name = "loguru" },
     { name = "oaklib", specifier = ">=0.6.6" },
     { name = "prefixmaps", specifier = "==0.2.4" },
@@ -2188,15 +2149,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
-]
-
-[[package]]
-name = "ply"
-version = "3.11"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e5/69/882ee5c9d017149285cab114ebeab373308ef0f874fcdac9beb90e0ac4da/ply-3.11.tar.gz", hash = "sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3", size = 159130, upload-time = "2018-02-15T19:01:31.097Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/58/35da89ee790598a0700ea49b2a66594140f44dec458c07e8e3d4979137fc/ply-3.11-py2.py3-none-any.whl", hash = "sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce", size = 49567, upload-time = "2018-02-15T19:01:27.172Z" },
 ]
 
 [[package]]
@@ -2904,62 +2856,6 @@ wheels = [
 ]
 
 [[package]]
-name = "ruamel-yaml"
-version = "0.18.14"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "ruamel-yaml-clib", marker = "python_full_version < '3.14' and platform_python_implementation == 'CPython'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/39/87/6da0df742a4684263261c253f00edd5829e6aca970fff69e75028cccc547/ruamel.yaml-0.18.14.tar.gz", hash = "sha256:7227b76aaec364df15936730efbf7d72b30c0b79b1d578bbb8e3dcb2d81f52b7", size = 145511, upload-time = "2025-06-09T08:51:09.828Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/af/6d/6fe4805235e193aad4aaf979160dd1f3c487c57d48b810c816e6e842171b/ruamel.yaml-0.18.14-py3-none-any.whl", hash = "sha256:710ff198bb53da66718c7db27eec4fbcc9aa6ca7204e4c1df2f282b6fe5eb6b2", size = 118570, upload-time = "2025-06-09T08:51:06.348Z" },
-]
-
-[[package]]
-name = "ruamel-yaml-clib"
-version = "0.2.12"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/20/84/80203abff8ea4993a87d823a5f632e4d92831ef75d404c9fc78d0176d2b5/ruamel.yaml.clib-0.2.12.tar.gz", hash = "sha256:6c8fbb13ec503f99a91901ab46e0b07ae7941cd527393187039aec586fdfd36f", size = 225315, upload-time = "2024-10-20T10:10:56.22Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/70/57/40a958e863e299f0c74ef32a3bde9f2d1ea8d69669368c0c502a0997f57f/ruamel.yaml.clib-0.2.12-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:11f891336688faf5156a36293a9c362bdc7c88f03a8a027c2c1d8e0bcde998e5", size = 131301, upload-time = "2024-10-20T10:12:35.876Z" },
-    { url = "https://files.pythonhosted.org/packages/98/a8/29a3eb437b12b95f50a6bcc3d7d7214301c6c529d8fdc227247fa84162b5/ruamel.yaml.clib-0.2.12-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:a606ef75a60ecf3d924613892cc603b154178ee25abb3055db5062da811fd969", size = 633728, upload-time = "2024-10-20T10:12:37.858Z" },
-    { url = "https://files.pythonhosted.org/packages/35/6d/ae05a87a3ad540259c3ad88d71275cbd1c0f2d30ae04c65dcbfb6dcd4b9f/ruamel.yaml.clib-0.2.12-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd5415dded15c3822597455bc02bcd66e81ef8b7a48cb71a33628fc9fdde39df", size = 722230, upload-time = "2024-10-20T10:12:39.457Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/b7/20c6f3c0b656fe609675d69bc135c03aac9e3865912444be6339207b6648/ruamel.yaml.clib-0.2.12-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f66efbc1caa63c088dead1c4170d148eabc9b80d95fb75b6c92ac0aad2437d76", size = 686712, upload-time = "2024-10-20T10:12:41.119Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/11/d12dbf683471f888d354dac59593873c2b45feb193c5e3e0f2ebf85e68b9/ruamel.yaml.clib-0.2.12-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:22353049ba4181685023b25b5b51a574bce33e7f51c759371a7422dcae5402a6", size = 663936, upload-time = "2024-10-21T11:26:37.419Z" },
-    { url = "https://files.pythonhosted.org/packages/72/14/4c268f5077db5c83f743ee1daeb236269fa8577133a5cfa49f8b382baf13/ruamel.yaml.clib-0.2.12-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:932205970b9f9991b34f55136be327501903f7c66830e9760a8ffb15b07f05cd", size = 696580, upload-time = "2024-10-21T11:26:39.503Z" },
-    { url = "https://files.pythonhosted.org/packages/30/fc/8cd12f189c6405a4c1cf37bd633aa740a9538c8e40497c231072d0fef5cf/ruamel.yaml.clib-0.2.12-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:a52d48f4e7bf9005e8f0a89209bf9a73f7190ddf0489eee5eb51377385f59f2a", size = 663393, upload-time = "2024-12-11T19:58:13.873Z" },
-    { url = "https://files.pythonhosted.org/packages/80/29/c0a017b704aaf3cbf704989785cd9c5d5b8ccec2dae6ac0c53833c84e677/ruamel.yaml.clib-0.2.12-cp310-cp310-win32.whl", hash = "sha256:3eac5a91891ceb88138c113f9db04f3cebdae277f5d44eaa3651a4f573e6a5da", size = 100326, upload-time = "2024-10-20T10:12:42.967Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/65/fa39d74db4e2d0cd252355732d966a460a41cd01c6353b820a0952432839/ruamel.yaml.clib-0.2.12-cp310-cp310-win_amd64.whl", hash = "sha256:ab007f2f5a87bd08ab1499bdf96f3d5c6ad4dcfa364884cb4549aa0154b13a28", size = 118079, upload-time = "2024-10-20T10:12:44.117Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/8f/683c6ad562f558cbc4f7c029abcd9599148c51c54b5ef0f24f2638da9fbb/ruamel.yaml.clib-0.2.12-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:4a6679521a58256a90b0d89e03992c15144c5f3858f40d7c18886023d7943db6", size = 132224, upload-time = "2024-10-20T10:12:45.162Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/d2/b79b7d695e2f21da020bd44c782490578f300dd44f0a4c57a92575758a76/ruamel.yaml.clib-0.2.12-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:d84318609196d6bd6da0edfa25cedfbabd8dbde5140a0a23af29ad4b8f91fb1e", size = 641480, upload-time = "2024-10-20T10:12:46.758Z" },
-    { url = "https://files.pythonhosted.org/packages/68/6e/264c50ce2a31473a9fdbf4fa66ca9b2b17c7455b31ef585462343818bd6c/ruamel.yaml.clib-0.2.12-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bb43a269eb827806502c7c8efb7ae7e9e9d0573257a46e8e952f4d4caba4f31e", size = 739068, upload-time = "2024-10-20T10:12:48.605Z" },
-    { url = "https://files.pythonhosted.org/packages/86/29/88c2567bc893c84d88b4c48027367c3562ae69121d568e8a3f3a8d363f4d/ruamel.yaml.clib-0.2.12-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:811ea1594b8a0fb466172c384267a4e5e367298af6b228931f273b111f17ef52", size = 703012, upload-time = "2024-10-20T10:12:51.124Z" },
-    { url = "https://files.pythonhosted.org/packages/11/46/879763c619b5470820f0cd6ca97d134771e502776bc2b844d2adb6e37753/ruamel.yaml.clib-0.2.12-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:cf12567a7b565cbf65d438dec6cfbe2917d3c1bdddfce84a9930b7d35ea59642", size = 704352, upload-time = "2024-10-21T11:26:41.438Z" },
-    { url = "https://files.pythonhosted.org/packages/02/80/ece7e6034256a4186bbe50dee28cd032d816974941a6abf6a9d65e4228a7/ruamel.yaml.clib-0.2.12-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:7dd5adc8b930b12c8fc5b99e2d535a09889941aa0d0bd06f4749e9a9397c71d2", size = 737344, upload-time = "2024-10-21T11:26:43.62Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/ca/e4106ac7e80efbabdf4bf91d3d32fc424e41418458251712f5672eada9ce/ruamel.yaml.clib-0.2.12-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1492a6051dab8d912fc2adeef0e8c72216b24d57bd896ea607cb90bb0c4981d3", size = 714498, upload-time = "2024-12-11T19:58:15.592Z" },
-    { url = "https://files.pythonhosted.org/packages/67/58/b1f60a1d591b771298ffa0428237afb092c7f29ae23bad93420b1eb10703/ruamel.yaml.clib-0.2.12-cp311-cp311-win32.whl", hash = "sha256:bd0a08f0bab19093c54e18a14a10b4322e1eacc5217056f3c063bd2f59853ce4", size = 100205, upload-time = "2024-10-20T10:12:52.865Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/4f/b52f634c9548a9291a70dfce26ca7ebce388235c93588a1068028ea23fcc/ruamel.yaml.clib-0.2.12-cp311-cp311-win_amd64.whl", hash = "sha256:a274fb2cb086c7a3dea4322ec27f4cb5cc4b6298adb583ab0e211a4682f241eb", size = 118185, upload-time = "2024-10-20T10:12:54.652Z" },
-    { url = "https://files.pythonhosted.org/packages/48/41/e7a405afbdc26af961678474a55373e1b323605a4f5e2ddd4a80ea80f628/ruamel.yaml.clib-0.2.12-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:20b0f8dc160ba83b6dcc0e256846e1a02d044e13f7ea74a3d1d56ede4e48c632", size = 133433, upload-time = "2024-10-20T10:12:55.657Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/b0/b850385604334c2ce90e3ee1013bd911aedf058a934905863a6ea95e9eb4/ruamel.yaml.clib-0.2.12-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:943f32bc9dedb3abff9879edc134901df92cfce2c3d5c9348f172f62eb2d771d", size = 647362, upload-time = "2024-10-20T10:12:57.155Z" },
-    { url = "https://files.pythonhosted.org/packages/44/d0/3f68a86e006448fb6c005aee66565b9eb89014a70c491d70c08de597f8e4/ruamel.yaml.clib-0.2.12-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95c3829bb364fdb8e0332c9931ecf57d9be3519241323c5274bd82f709cebc0c", size = 754118, upload-time = "2024-10-20T10:12:58.501Z" },
-    { url = "https://files.pythonhosted.org/packages/52/a9/d39f3c5ada0a3bb2870d7db41901125dbe2434fa4f12ca8c5b83a42d7c53/ruamel.yaml.clib-0.2.12-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:749c16fcc4a2b09f28843cda5a193e0283e47454b63ec4b81eaa2242f50e4ccd", size = 706497, upload-time = "2024-10-20T10:13:00.211Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/fa/097e38135dadd9ac25aecf2a54be17ddf6e4c23e43d538492a90ab3d71c6/ruamel.yaml.clib-0.2.12-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:bf165fef1f223beae7333275156ab2022cffe255dcc51c27f066b4370da81e31", size = 698042, upload-time = "2024-10-21T11:26:46.038Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/d5/a659ca6f503b9379b930f13bc6b130c9f176469b73b9834296822a83a132/ruamel.yaml.clib-0.2.12-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:32621c177bbf782ca5a18ba4d7af0f1082a3f6e517ac2a18b3974d4edf349680", size = 745831, upload-time = "2024-10-21T11:26:47.487Z" },
-    { url = "https://files.pythonhosted.org/packages/db/5d/36619b61ffa2429eeaefaab4f3374666adf36ad8ac6330d855848d7d36fd/ruamel.yaml.clib-0.2.12-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b82a7c94a498853aa0b272fd5bc67f29008da798d4f93a2f9f289feb8426a58d", size = 715692, upload-time = "2024-12-11T19:58:17.252Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/82/85cb92f15a4231c89b95dfe08b09eb6adca929ef7df7e17ab59902b6f589/ruamel.yaml.clib-0.2.12-cp312-cp312-win32.whl", hash = "sha256:e8c4ebfcfd57177b572e2040777b8abc537cdef58a2120e830124946aa9b42c5", size = 98777, upload-time = "2024-10-20T10:13:01.395Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/8f/c3654f6f1ddb75daf3922c3d8fc6005b1ab56671ad56ffb874d908bfa668/ruamel.yaml.clib-0.2.12-cp312-cp312-win_amd64.whl", hash = "sha256:0467c5965282c62203273b838ae77c0d29d7638c8a4e3a1c8bdd3602c10904e4", size = 115523, upload-time = "2024-10-20T10:13:02.768Z" },
-    { url = "https://files.pythonhosted.org/packages/29/00/4864119668d71a5fa45678f380b5923ff410701565821925c69780356ffa/ruamel.yaml.clib-0.2.12-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:4c8c5d82f50bb53986a5e02d1b3092b03622c02c2eb78e29bec33fd9593bae1a", size = 132011, upload-time = "2024-10-20T10:13:04.377Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/5e/212f473a93ae78c669ffa0cb051e3fee1139cb2d385d2ae1653d64281507/ruamel.yaml.clib-0.2.12-cp313-cp313-manylinux2014_aarch64.whl", hash = "sha256:e7e3736715fbf53e9be2a79eb4db68e4ed857017344d697e8b9749444ae57475", size = 642488, upload-time = "2024-10-20T10:13:05.906Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/8f/ecfbe2123ade605c49ef769788f79c38ddb1c8fa81e01f4dbf5cf1a44b16/ruamel.yaml.clib-0.2.12-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0b7e75b4965e1d4690e93021adfcecccbca7d61c7bddd8e22406ef2ff20d74ef", size = 745066, upload-time = "2024-10-20T10:13:07.26Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/a9/28f60726d29dfc01b8decdb385de4ced2ced9faeb37a847bd5cf26836815/ruamel.yaml.clib-0.2.12-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:96777d473c05ee3e5e3c3e999f5d23c6f4ec5b0c38c098b3a5229085f74236c6", size = 701785, upload-time = "2024-10-20T10:13:08.504Z" },
-    { url = "https://files.pythonhosted.org/packages/84/7e/8e7ec45920daa7f76046578e4f677a3215fe8f18ee30a9cb7627a19d9b4c/ruamel.yaml.clib-0.2.12-cp313-cp313-musllinux_1_1_i686.whl", hash = "sha256:3bc2a80e6420ca8b7d3590791e2dfc709c88ab9152c00eeb511c9875ce5778bf", size = 693017, upload-time = "2024-10-21T11:26:48.866Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/b3/d650eaade4ca225f02a648321e1ab835b9d361c60d51150bac49063b83fa/ruamel.yaml.clib-0.2.12-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:e188d2699864c11c36cdfdada94d781fd5d6b0071cd9c427bceb08ad3d7c70e1", size = 741270, upload-time = "2024-10-21T11:26:50.213Z" },
-    { url = "https://files.pythonhosted.org/packages/87/b8/01c29b924dcbbed75cc45b30c30d565d763b9c4d540545a0eeecffb8f09c/ruamel.yaml.clib-0.2.12-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4f6f3eac23941b32afccc23081e1f50612bdbe4e982012ef4f5797986828cd01", size = 709059, upload-time = "2024-12-11T19:58:18.846Z" },
-    { url = "https://files.pythonhosted.org/packages/30/8c/ed73f047a73638257aa9377ad356bea4d96125b305c34a28766f4445cc0f/ruamel.yaml.clib-0.2.12-cp313-cp313-win32.whl", hash = "sha256:6442cb36270b3afb1b4951f060eccca1ce49f3d087ca1ca4563a6eb479cb3de6", size = 98583, upload-time = "2024-10-20T10:13:09.658Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/85/e8e751d8791564dd333d5d9a4eab0a7a115f7e349595417fd50ecae3395c/ruamel.yaml.clib-0.2.12-cp313-cp313-win_amd64.whl", hash = "sha256:e5b8daf27af0b90da7bb903a876477a9e6d7270be6146906b276605997c7e9a3", size = 115190, upload-time = "2024-10-20T10:13:10.66Z" },
-]
-
-[[package]]
 name = "ruff"
 version = "0.11.13"
 source = { registry = "https://pypi.org/simple" }
@@ -3345,6 +3241,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/38/ad/4360e50ed56cb483667b8e6dadf2d3fda62359593faabbe749a27c4eaca6/sphinx-8.2.3.tar.gz", hash = "sha256:398ad29dee7f63a75888314e9424d40f52ce5a6a87ae88e7071e80af296ec348", size = 8321876, upload-time = "2025-03-02T22:31:59.658Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/31/53/136e9eca6e0b9dc0e1962e2c908fbea2e5ac000c2a2fbd9a35797958c48b/sphinx-8.2.3-py3-none-any.whl", hash = "sha256:4405915165f13521d875a8c29c8970800a0141c14cc5416a38feca4ea5d9b9c3", size = 3589741, upload-time = "2025-03-02T22:31:56.836Z" },
+]
+
+[[package]]
+name = "sphinx-click"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "docutils" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/0a/5b1e8d0579dbb4ca8114e456ca4a68020bfe8e15c7001f3856be4929ab83/sphinx_click-6.0.0.tar.gz", hash = "sha256:f5d664321dc0c6622ff019f1e1c84e58ce0cecfddeb510e004cf60c2a3ab465b", size = 29574, upload-time = "2024-05-15T14:49:17.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/d7/8621c4726ad3f788a1db4c0c409044b16edc563f5c9542807b3724037555/sphinx_click-6.0.0-py3-none-any.whl", hash = "sha256:1e0a3c83bcb7c55497751b19d07ebe56b5d7b85eb76dd399cf9061b497adc317", size = 9922, upload-time = "2024-05-15T14:49:15.768Z" },
 ]
 
 [[package]]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1700,7 +1700,7 @@ dependencies = [
     { name = "typer" },
 ]
 
-[package.optional-dependencies]
+[package.dev-dependencies]
 dev = [
     { name = "black" },
     { name = "coverage" },
@@ -1718,32 +1718,35 @@ dev = [
 requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.13.4" },
     { name = "bioregistry", specifier = "~=0.10.57" },
-    { name = "black", marker = "extra == 'dev'", specifier = ">=24.4.2" },
-    { name = "coverage", marker = "extra == 'dev'", specifier = ">=7.5.1" },
     { name = "curies", specifier = "<1" },
     { name = "docker", specifier = ">=7.1.0" },
     { name = "fastapi", specifier = ">=0.115.12,<1" },
     { name = "gunicorn", specifier = ">=23.0.0" },
-    { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27" },
     { name = "linkml", specifier = "==1.8.3" },
     { name = "loguru" },
-    { name = "mkdocs", marker = "extra == 'dev'", specifier = ">=1.6.0" },
-    { name = "mkdocs-material", marker = "extra == 'dev'", specifier = ">=9.5.23" },
-    { name = "mkdocstrings", extras = ["python"], marker = "extra == 'dev'", specifier = ">=0.29.1" },
     { name = "oaklib", specifier = ">=0.6.6" },
     { name = "prefixmaps", specifier = "==0.2.4" },
     { name = "pydantic", specifier = ">=2,<3" },
     { name = "pystow", specifier = ">=0.5.4" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.2.0" },
     { name = "requests", specifier = ">=2.31.0" },
     { name = "rich" },
-    { name = "ruff", marker = "extra == 'dev'" },
-    { name = "scholarly", marker = "extra == 'dev'" },
     { name = "spacy", specifier = ">=3.8.7" },
     { name = "typer", specifier = ">=0.12.0" },
-    { name = "uvicorn", extras = ["standard"], marker = "extra == 'dev'", specifier = ">=0.29.0" },
 ]
-provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "black", specifier = ">=24.4.2" },
+    { name = "coverage", specifier = ">=7.5.1" },
+    { name = "httpx", specifier = ">=0.27" },
+    { name = "mkdocs", specifier = ">=1.6.0" },
+    { name = "mkdocs-material", specifier = ">=9.5.23" },
+    { name = "mkdocstrings", extras = ["python"], specifier = ">=0.29.1" },
+    { name = "pytest", specifier = ">=8.2.0" },
+    { name = "ruff" },
+    { name = "scholarly" },
+    { name = "uvicorn", extras = ["standard"], specifier = ">=0.29.0" },
+]
 
 [[package]]
 name = "more-click"

--- a/frontend/src/api/model.ts
+++ b/frontend/src/api/model.ts
@@ -10,6 +10,7 @@ export type MappingId = string;
 export type MultiEntityAssociationResultsId = string;
 export type NodeId = string;
 export type SearchResultId = string;
+export type InformationResourceId = string;
 /**
 * The directionality of an association as it relates to a specified entity, with edges being categorized as incoming or outgoing
 */
@@ -585,6 +586,33 @@ export interface AssociationHighlighting {
     /** Field containing subject name and the names of all of it's ancestors */
     subject_closure_label?: string[],
     predicate?: string[],
+}
+
+
+/**
+ * A database or knowledgebase and its supporting ecosystem of interfaces and services that deliver content to consumers
+ */
+export interface InformationResource {
+    /** Unique identifier (CURIE or complete URI) */
+    id: string,
+    /** Human-readable name for the resource */
+    name?: string,
+    /** Free-text description of the resource */
+    description?: string,
+    /** Status of the information resource identifier */
+    status: string,
+    /** Describes the level of knowledge expressed in a statement, based on the reasoning or analysis methods used to generate the statement, or the scope or specificity of what the statement expresses to be true. */
+    knowledge_level: string,
+    /** Describes the high-level category of agent who originally generated a  statement of knowledge or other type of information. */
+    agent_type: string,
+    /** Database cross references or alternative identifiers */
+    xref?: string[],
+    /** Alternate human-readable names */
+    synonym?: string[],
+    /** Information resources consumed by this resource */
+    consumes?: string[],
+    /** Information resources consuming this resource */
+    consumed_by?: string[],
 }
 
 


### PR DESCRIPTION
Fixes #1051

  🎯 Core Changes: Added proper LinkML schema support for Information Resources

  📋 Schema Changes (model.yaml & model.py)

  - Added 3 new slots: status, consumes, consumed_by for infores-specific fields
  - Added InformationResource class: Standalone class with proper slot definitions, required fields (id, status, knowledge_level,
   agent_type)
  - Regenerated Pydantic models: Complete model regeneration with updated LinkML structure

  🔧 Implementation Changes

  - SolrImplementation: Updated methods to use direct unpacking (InformationResource(**doc)) instead of raw dicts
  - API Integration: Added infores router to main FastAPI app
  - Type Safety: Changed return types from Dict/List[dict] to InformationResource/List[InformationResource]
  - Clean TSV: Replaced manual TSV generation with pydantic model property access

  🧪 Test Updates

  - API Tests: Updated mocks to use InformationResource instances with required fields
  - Integration Tests: Updated assertions to check pydantic model properties instead of dict keys
  - All 12 tests passing: 7 API tests + 5 integration tests

  ⚙️ Build/Config Changes

  - Makefile: Fixed --meta NONE parameter for gen-pydantic command
  - Dependencies: Updated LinkML version and fixed dependency groups syntax in pyproject.toml

  ✅ Benefits Achieved

  - Maximum Simplicity: Direct dictionary unpacking with **doc
  - Type Safety: Proper pydantic validation and OpenAPI spec generation
  - Schema Consistency: Aligned with Biolink Information Resource Registry standard
  - Clean Architecture: Standalone InformationResource class with explicit field definitions

  Files Modified: 6 core files + comprehensive test updates, ~200 lines of meaningful changes after model regeneration.