### PR TITLE
Restructure GitHub Actions workflows for clearer Docker image management

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,54 @@
+# GitHub Actions Workflows
+
+This directory contains the GitHub Actions workflows for the Monarch App project.
+
+## Docker Image Building and Deployment
+
+The Docker image building and deployment has been restructured for clarity and to avoid confusion with release tagging:
+
+### Active Workflows
+
+1. **`build-and-deploy-main.yaml`** - Main Branch Development
+   - **Triggers**: Push to main branch, manual dispatch
+   - **Purpose**: Keeps the dev environment updated with latest main branch code
+   - **Tags**: `main-<sha>`, `latest-dev`, `<sha>`
+   - **Deployment**: Automatically deploys to dev environment
+
+2. **`build-release-images.yaml`** - Production Releases
+   - **Triggers**: Release published
+   - **Purpose**: Creates production-ready images for actual releases
+   - **Tags**: `latest`, `<release-version>`, `<sha>`
+   - **Deployment**: No automatic deployment (production images)
+
+3. **`build-images-for-branch.yaml`** - Branch Testing
+   - **Triggers**: Manual dispatch, configurable branch pushes
+   - **Purpose**: Build images for specific branches when needed for testing
+   - **Tags**: `<branch-name>-<sha>`, `<sha>`
+   - **Deployment**: No deployment (testing images only)
+
+### Deprecated Workflows
+
+- **`build-and-deploy-images.yaml.deprecated`** - Old combined workflow
+  - This workflow was causing confusion by tagging images with old release versions on every main branch push
+  - Functionality has been split into the three workflows above for better clarity
+
+## Other Workflows
+
+- **`test-backend.yaml`** - Backend testing
+- **`test-frontend.yaml`** - Frontend testing
+- **`publish-backend.yaml`** - PyPI publishing on releases
+- **`codecov_main.yaml`** - Code coverage reporting
+- **`deploy-documentation.yaml`** - Documentation deployment
+- **`update-resource-data.yaml`** - Resource data updates
+
+## Usage
+
+### For Development
+- Push to main branch → automatic dev deployment via `build-and-deploy-main.yaml`
+
+### For Releases
+- Create and publish a GitHub release → production images built via `build-release-images.yaml`
+
+### For Branch Testing
+- Use "Run workflow" button on `build-images-for-branch.yaml` to build images for any branch
+- Or add specific branch names to the workflow file for automatic builds

--- a/.github/workflows/build-and-deploy-images.yaml.deprecated
+++ b/.github/workflows/build-and-deploy-images.yaml.deprecated
@@ -1,12 +1,27 @@
-name: Build and Deploy Docker Images
+# DEPRECATED: This workflow has been replaced by separate workflows for better clarity
+# 
+# Issues with this workflow:
+# - Tagged images with old release versions on every main branch push
+# - Mixed development and release concerns in one workflow
+# - Caused confusion about when releases were actually happening
+#
+# Replaced by:
+# - build-and-deploy-main.yaml (for main branch dev deployment)
+# - build-release-images.yaml (for actual releases)
+# - build-images-for-branch.yaml (for branch testing)
+#
+# This file is kept for reference but should not be used.
+
+name: Build and Deploy Docker Images (DEPRECATED)
 
 on:
-  workflow_dispatch:
-  push:
-    branches:
-      - main
-  release:
-    types: [published]
+  # Disabled - triggers moved to separate workflows
+  # workflow_dispatch:
+  # push:
+  #   branches:
+  #     - main
+  # release:
+  #   types: [published]
 
 # This job uses RafikFarhad's GitHub action to build and
 # push a docker image to a specified GCP repository

--- a/.github/workflows/build-and-deploy-main.yaml
+++ b/.github/workflows/build-and-deploy-main.yaml
@@ -1,0 +1,105 @@
+name: Build and Deploy Main Branch to Dev
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+# This workflow builds and deploys main branch changes to the dev environment
+jobs:
+  build-and-push-api-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Build and Push Image
+        uses: RafikFarhad/push-to-gcr-github-action@v5-rc1
+        with:
+          gcloud_service_key: ${{ secrets.JSON_GCLOUD_SERVICE_ACCOUNT_JSON }}
+          registry: us-central1-docker.pkg.dev
+          project_id: monarch-initiative
+          image_name: monarch-api/monarch-api
+          image_tag: main-${{ github.sha }}, latest-dev, ${{ github.sha }}
+          dockerfile: ./backend/Dockerfile
+
+  build-and-push-frontend-image:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./frontend
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install packages
+        run: bun install
+
+      - name: Build app
+        run: bun run build
+
+      - name: Build and Push Image
+        uses: RafikFarhad/push-to-gcr-github-action@v5-rc1
+        with:
+          gcloud_service_key: ${{ secrets.JSON_GCLOUD_SERVICE_ACCOUNT_JSON }}
+          registry: us-central1-docker.pkg.dev
+          project_id: monarch-initiative
+          image_name: monarch-api/monarch-ui
+          image_tag: main-${{ github.sha }}, latest-dev, ${{ github.sha }}
+          dockerfile: ./services/nginx/Dockerfile
+          context: .
+
+  update-dev-services:
+    runs-on: ubuntu-latest
+    needs: [build-and-push-api-image, build-and-push-frontend-image]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - id: "auth"
+        uses: "google-github-actions/auth@v2"
+        with:
+          credentials_json: "${{ secrets.JSON_GCLOUD_SERVICE_ACCOUNT_JSON }}"
+
+      - name: "Set up Cloud SDK"
+        uses: "google-github-actions/setup-gcloud@v2"
+
+      - name: "Cache SSH Key"
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.ssh/google_compute_engine
+            ~/.ssh/google_compute_engine.pub
+          key: ${{ runner.os }}-ssh-key
+
+      - name: "Remove old SSH keys"
+        run: |
+          if [[ $(gcloud compute os-login ssh-keys list | grep -v FINGERPRINT) ]]; then
+            for i in $(gcloud compute os-login ssh-keys list | grep -v FINGERPRINT)
+            do 
+              echo $i
+              gcloud compute os-login ssh-keys remove --key $i
+            done
+          fi
+
+      - name: "Update API Service on Dev"
+        run: |
+          gcloud compute ssh --ssh-key-expiration 60m --zone us-central1-a monarch-v3-dev-manager -- sudo docker system prune -f
+          gcloud compute ssh --ssh-key-expiration 60m --zone us-central1-a monarch-v3-dev-manager -- sudo docker service update monarch-v3_api --with-registry-auth  --update-order=start-first --force --image us-central1-docker.pkg.dev/monarch-initiative/monarch-api/monarch-api:${{ github.sha }}
+
+      - name: "Update UI Service on Dev"
+        run: |
+          gcloud compute ssh --ssh-key-expiration 60m --zone us-central1-a monarch-v3-dev-manager -- sudo docker system prune -f
+          gcloud compute ssh --ssh-key-expiration 60m --zone us-central1-a monarch-v3-dev-manager -- sudo docker service update monarch-v3_nginx --with-registry-auth  --update-order=start-first --force --image us-central1-docker.pkg.dev/monarch-initiative/monarch-api/monarch-ui:${{ github.sha }}

--- a/.github/workflows/build-images-for-branch.yaml
+++ b/.github/workflows/build-images-for-branch.yaml
@@ -1,36 +1,49 @@
-name: Build and Push to GCR for specific branches
+name: Build Images for Specific Branches
+
 on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch name to build (leave empty to build current branch)'
+        required: false
+        type: string
   push:
     branches:
-      - issue-982-about-dropdown
+      # Add specific branch names here when needed for automatic builds
+      # Example: - feature-xyz
+      # Currently empty - use workflow_dispatch for on-demand builds
 
-# This job uses RafikFarhad's GitHub action to build and
-# push a docker image to a specified GCP repository
+# This workflow builds images for specific branches for testing purposes
+# Images are tagged with branch name and commit SHA but do not deploy anywhere
 jobs:
-  build-and-push-to-gcr:
+  build-and-push-api-image:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # to get all tags
+          ref: ${{ inputs.branch || github.ref }}
+          fetch-depth: 0
 
-      - name: Generate Image Tag
-        id: get-tag
+      - name: Get branch name
+        id: branch-name
         run: |
-          REV=$(git rev-list --tags --max-count=1)
-          IMAGE_TAG=$(git describe --tags $REV)
-          echo "IMAGE_TAG=${IMAGE_TAG//v}"
-          echo "IMAGE_TAG=${IMAGE_TAG//v}" >> $GITHUB_OUTPUT
+          if [ -n "${{ inputs.branch }}" ]; then
+            BRANCH_NAME="${{ inputs.branch }}"
+          else
+            BRANCH_NAME="${{ github.ref_name }}"
+          fi
+          echo "BRANCH_NAME=${BRANCH_NAME}" >> $GITHUB_OUTPUT
+          echo "Building branch: ${BRANCH_NAME}"
 
       - name: Build and Push Image
-        uses: RafikFarhad/push-to-gcr-github-action@v5-beta
+        uses: RafikFarhad/push-to-gcr-github-action@v5-rc1
         with:
-          gcloud_service_key: ${{ secrets.JSON_GCLOUD_SERVICE_ACCOUNT_JSON }} # not needed if you use google-github-actions/auth
+          gcloud_service_key: ${{ secrets.JSON_GCLOUD_SERVICE_ACCOUNT_JSON }}
           registry: us-central1-docker.pkg.dev
           project_id: monarch-initiative
           image_name: monarch-api/monarch-api
-          image_tag: ${{ github.sha }}, ${{ github.ref_name }}
+          image_tag: ${{ steps.branch-name.outputs.BRANCH_NAME }}-${{ github.sha }}, ${{ github.sha }}
           dockerfile: ./backend/Dockerfile
 
   build-and-push-frontend-image:
@@ -44,7 +57,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # to get all tags
+          ref: ${{ inputs.branch || github.ref }}
+          fetch-depth: 0
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
@@ -55,25 +69,26 @@ jobs:
       - name: Build app
         run: bun run build
 
-      - name: Generate Image Tag for Frontend Dir
-        id: get-tag
+      - name: Get branch name
+        id: branch-name
         run: |
-          REV=$(git rev-list --tags --max-count=1 )
-          IMAGE_TAG=$(git describe --tags $REV)
-          echo "IMAGE_TAG=${IMAGE_TAG//v}"
-          echo "IMAGE_TAG=${IMAGE_TAG//v}" >> $GITHUB_OUTPUT
-
-      # the monarch-ui Dockerfile pulls from two places:
-      # ./frontend/dist/, copied to /var/www/ in the image
-      # ./services/nginx/config/, copied to /etc/nginx/conf.d/ in the image
+          if [ -n "${{ inputs.branch }}" ]; then
+            BRANCH_NAME="${{ inputs.branch }}"
+          else
+            BRANCH_NAME="${{ github.ref_name }}"
+          fi
+          echo "BRANCH_NAME=${BRANCH_NAME}" >> $GITHUB_OUTPUT
+          echo "Building frontend for branch: ${BRANCH_NAME}"
 
       - name: Build and Push Image
-        uses: RafikFarhad/push-to-gcr-github-action@v5-beta
+        uses: RafikFarhad/push-to-gcr-github-action@v5-rc1
         with:
           gcloud_service_key: ${{ secrets.JSON_GCLOUD_SERVICE_ACCOUNT_JSON }}
           registry: us-central1-docker.pkg.dev
           project_id: monarch-initiative
           image_name: monarch-api/monarch-ui
-          image_tag: ${{ github.sha }}, ${{ github.ref_name }}
+          image_tag: ${{ steps.branch-name.outputs.BRANCH_NAME }}-${{ github.sha }}, ${{ github.sha }}
           dockerfile: ./services/nginx/Dockerfile
           context: .
+
+  # Note: This workflow does NOT deploy anywhere - it only builds images for testing

--- a/.github/workflows/build-release-images.yaml
+++ b/.github/workflows/build-release-images.yaml
@@ -1,0 +1,77 @@
+name: Build Release Images
+
+on:
+  release:
+    types: [published]
+
+# This workflow builds production-ready images when a release is published
+jobs:
+  build-and-push-api-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get Release Tag
+        id: get-tag
+        run: |
+          # Get the actual release tag from the GitHub event
+          RELEASE_TAG=${GITHUB_REF#refs/tags/}
+          echo "RELEASE_TAG=${RELEASE_TAG//v}" >> $GITHUB_OUTPUT
+          echo "Building release: ${RELEASE_TAG//v}"
+
+      - name: Build and Push Image
+        uses: RafikFarhad/push-to-gcr-github-action@v5-rc1
+        with:
+          gcloud_service_key: ${{ secrets.JSON_GCLOUD_SERVICE_ACCOUNT_JSON }}
+          registry: us-central1-docker.pkg.dev
+          project_id: monarch-initiative
+          image_name: monarch-api/monarch-api
+          image_tag: latest, ${{ steps.get-tag.outputs.RELEASE_TAG }}, ${{ github.sha }}
+          dockerfile: ./backend/Dockerfile
+
+  build-and-push-frontend-image:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./frontend
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install packages
+        run: bun install
+
+      - name: Build app
+        run: bun run build
+
+      - name: Get Release Tag
+        id: get-tag
+        run: |
+          # Get the actual release tag from the GitHub event
+          RELEASE_TAG=${GITHUB_REF#refs/tags/}
+          echo "RELEASE_TAG=${RELEASE_TAG//v}" >> $GITHUB_OUTPUT
+          echo "Building frontend release: ${RELEASE_TAG//v}"
+
+      - name: Build and Push Image
+        uses: RafikFarhad/push-to-gcr-github-action@v5-rc1
+        with:
+          gcloud_service_key: ${{ secrets.JSON_GCLOUD_SERVICE_ACCOUNT_JSON }}
+          registry: us-central1-docker.pkg.dev
+          project_id: monarch-initiative
+          image_name: monarch-api/monarch-ui
+          image_tag: latest, ${{ steps.get-tag.outputs.RELEASE_TAG }}, ${{ github.sha }}
+          dockerfile: ./services/nginx/Dockerfile
+          context: .
+
+  # Note: This workflow does NOT deploy to dev - releases are production images
+  # Dev environment continues to run the latest main branch via build-and-deploy-main.yaml


### PR DESCRIPTION
## Summary

- Split the confusing `build-and-deploy-images.yaml` into 3 focused workflows for better clarity
- Fix issue where main branch pushes were tagged with old release versions
- Improve separation between development, release, and testing image builds

## Changes

**New Workflows:**
- `build-and-deploy-main.yaml` - Main branch development deployment only
- `build-release-images.yaml` - Production releases only (no dev deployment)
- `build-images-for-branch.yaml` - Flexible branch testing with manual dispatch

**Deprecated:**
- `build-and-deploy-images.yaml` - Moved to `.deprecated` with explanation

**Documentation:**
- Added comprehensive README explaining the new workflow structure

## Benefits

- **Clear dev deployment**: Only main branch pushes update the dev environment
- **Proper release tagging**: Only actual releases create "latest" tagged images
- **Flexible branch testing**: Manual workflow dispatch allows building any branch
- **No more confusion**: Eliminates misleading old release tags on dev builds

## Testing

- Dev system will continue to be updated from main branch pushes
- Release workflow will only trigger on actual GitHub releases
- Branch workflow can be manually triggered for testing specific branches

🤖 Generated with [Claude Code](https://claude.ai/code)