### PR TITLE
Issue 1049 filter direct associations

### DIFF
--- a/frontend/src/api/associations.ts
+++ b/frontend/src/api/associations.ts
@@ -108,13 +108,12 @@ export const getDirectAssociationFacetCounts = async (nodeId = "") => {
 
   const url = `${apiUrl}/association`;
   const rawResponse = await request<any>(url, params);
-  console.log("rawResponse", rawResponse);
   // 👇 Transform the nested structure into what the UI expects
 
   const categoryFacet = rawResponse.facet_fields?.find(
     (item: any) => item.label === "category",
   );
-  console.log("categoryFacet", categoryFacet);
+
   return {
     facet_field: "category",
     facet_counts: categoryFacet?.facet_values || [],

--- a/frontend/src/api/associations.ts
+++ b/frontend/src/api/associations.ts
@@ -93,3 +93,30 @@ export const getTopAssociations = async (
   nodeId = "",
   associationCategory = "",
 ) => await getAssociations(nodeId, associationCategory, 0, 5);
+
+/** Get direct association facet counts for a node */
+export const getDirectAssociationFacetCounts = async (nodeId = "") => {
+  const params = {
+    entity: nodeId,
+    direct: true,
+    facet_fields: "category",
+    compact: false,
+    format: "json",
+    limit: 0,
+    offset: 0,
+  };
+
+  const url = `${apiUrl}/association`;
+  const rawResponse = await request<any>(url, params);
+  console.log("rawResponse", rawResponse);
+  // 👇 Transform the nested structure into what the UI expects
+
+  const categoryFacet = rawResponse.facet_fields?.find(
+    (item: any) => item.label === "category",
+  );
+  console.log("categoryFacet", categoryFacet);
+  return {
+    facet_field: "category",
+    facet_counts: categoryFacet?.facet_values || [],
+  };
+};

--- a/frontend/src/components/AppNodeBadge.vue
+++ b/frontend/src/components/AppNodeBadge.vue
@@ -62,7 +62,7 @@ type Props = {
   /** whether to show id. not shown by default, unless name/label empty. */
   showId?: boolean;
   /** boolen to use for highlighting */
-  highlight: boolean;
+  highlight?: boolean;
 };
 
 const props = withDefaults(defineProps<Props>(), {

--- a/frontend/src/components/TheTableOfContents.vue
+++ b/frontend/src/components/TheTableOfContents.vue
@@ -13,7 +13,7 @@
       aria-label="Page table of contents"
       @click.stop
     >
-      <!-- entries -->
+      <!-- entries --->
       <AppLink
         v-for="(entry, index) in entries"
         :key="index"

--- a/frontend/src/pages/knowledgeGraph/PagePhenotypeExplore.vue
+++ b/frontend/src/pages/knowledgeGraph/PagePhenotypeExplore.vue
@@ -81,7 +81,7 @@ $wrap: 1000px;
   }
   .tab-item.active {
     border: 1px solid #ccc;
-    border-bottom: 3px solid $theme; // keep consistent height
+    border-bottom: 3px solid $theme;
     background-color: $theme;
     color: $white;
 

--- a/frontend/src/pages/node/AssociationsTable.vue
+++ b/frontend/src/pages/node/AssociationsTable.vue
@@ -263,6 +263,10 @@ const start = ref(0);
 const sort = ref<Sort>();
 const perPage = ref(5);
 
+const emit = defineEmits<{
+  (e: "totalAssociations", value: number): void;
+}>();
+
 function openModal(association: DirectionalAssociation) {
   selectedAssociation.value = association;
   showModal.value = true;
@@ -517,7 +521,7 @@ const {
       props.search,
       sort.value,
     );
-
+    emit("totalAssociations", response.total);
     return response;
   },
 

--- a/frontend/src/pages/node/AssociationsTable.vue
+++ b/frontend/src/pages/node/AssociationsTable.vue
@@ -263,10 +263,6 @@ const start = ref(0);
 const sort = ref<Sort>();
 const perPage = ref(5);
 
-const emit = defineEmits<{
-  (e: "totalAssociations", value: number): void;
-}>();
-
 function openModal(association: DirectionalAssociation) {
   selectedAssociation.value = association;
   showModal.value = true;
@@ -521,7 +517,7 @@ const {
       props.search,
       sort.value,
     );
-    emit("totalAssociations", response.total);
+
     return response;
   },
 

--- a/frontend/src/pages/node/AssociationsTable.vue
+++ b/frontend/src/pages/node/AssociationsTable.vue
@@ -330,11 +330,6 @@ const medicalActionColumns = computed<Cols<Datum>>(() => {
       heading: "Extension",
     },
     {
-      slot: "maxorelation",
-      key: "original_predicate",
-      heading: "MaXO Relation",
-    },
-    {
       slot: "object",
       key: "object_label",
       heading: "Phenotype",
@@ -404,8 +399,8 @@ const cols = computed((): Cols<Datum> => {
       heading: "Taxon",
     });
   }
-
-  if (props.direct.id === "true") {
+  console.log("props.node.categor", props.node.category);
+  if (props.direct.id === "true" && props.node.category === "biolink:Disease") {
     // CorrelatedGene & Desease model: keep subject_label & predicate, only drop object_label
     if (
       props.category.id === "biolink:CorrelatedGeneToDiseaseAssociation" ||

--- a/frontend/src/pages/node/AssociationsTable.vue
+++ b/frontend/src/pages/node/AssociationsTable.vue
@@ -405,11 +405,22 @@ const cols = computed((): Cols<Datum> => {
     });
   }
 
-  // if tab is direct, take out subject label and predicate columns
   if (props.direct.id === "true") {
-    baseCols = baseCols.filter(
-      (col) => col.key !== "subject_label" && col.key !== "predicate",
-    );
+    // CorrelatedGene & Desease model: keep subject_label & predicate, only drop object_label
+    if (
+      props.category.id === "biolink:CorrelatedGeneToDiseaseAssociation" ||
+      props.category.id === "biolink:GenotypeToDiseaseAssociation"
+    ) {
+      baseCols = baseCols.filter((col) => col.key !== "object_label");
+    }
+    //  All other direct‐only cases (except Gene-Phenotype): drop subject_label & predicate
+    else if (
+      props.category.id !== "biolink:GeneToPhenotypicFeatureAssociation"
+    ) {
+      baseCols = baseCols.filter(
+        (col) => col.key !== "subject_label" && col.key !== "predicate",
+      );
+    }
   }
 
   if (

--- a/frontend/src/pages/node/AssociationsTable.vue
+++ b/frontend/src/pages/node/AssociationsTable.vue
@@ -664,4 +664,8 @@ onMounted(() => queryAssociations(true));
   color: $dark-gray;
   font-size: 0.9em;
 }
+.negated-text {
+  color: $error;
+  font-weight: bold;
+}
 </style>

--- a/frontend/src/pages/node/AssociationsTable.vue
+++ b/frontend/src/pages/node/AssociationsTable.vue
@@ -88,6 +88,9 @@
     <!-- object-->
     <template #object="{ row }">
       <div class="badgeColumn">
+        <span v-if="row?.negated === true && direct.id === 'true'">
+          Does <span class="negated-text">NOT</span> have
+        </span>
         <AppNodeBadge
           :node="{
             id: row.object,
@@ -359,7 +362,7 @@ const cols = computed((): Cols<Datum> => {
   }
 
   /** standard columns, always present */
-  const baseCols: Cols<Datum> = [
+  let baseCols: Cols<Datum> = [
     {
       slot: "subject",
       key: "subject_label",
@@ -400,6 +403,13 @@ const cols = computed((): Cols<Datum> => {
       slot: "taxon",
       heading: "Taxon",
     });
+  }
+
+  // if tab is direct, take out subject label and predicate columns
+  if (props.direct.id === "true") {
+    baseCols = baseCols.filter(
+      (col) => col.key !== "subject_label" && col.key !== "predicate",
+    );
   }
 
   if (

--- a/frontend/src/pages/node/AssociationsTable.vue
+++ b/frontend/src/pages/node/AssociationsTable.vue
@@ -249,7 +249,7 @@ type Props = {
   node: Node;
   /** selected association category */
   category: Option;
-
+  /** "true" = direct only, "false" = include subclasses */
   direct: Option;
   /** search string */
   search: string;

--- a/frontend/src/pages/node/AssociationsTable.vue
+++ b/frontend/src/pages/node/AssociationsTable.vue
@@ -246,8 +246,7 @@ type Props = {
   node: Node;
   /** selected association category */
   category: Option;
-  /** include orthologs */
-  includeOrthologs: boolean;
+
   direct: Option;
   /** search string */
   search: string;
@@ -498,13 +497,12 @@ const {
     if (fresh) {
       start.value = 0;
     }
-
     const response = await getAssociations(
       props.node.id,
       props.category.id,
       start.value,
       perPage.value,
-      props.includeOrthologs,
+      true,
       props.direct.id,
       props.search,
       sort.value,
@@ -533,7 +531,7 @@ async function download() {
   await downloadAssociations(
     props.node.id,
     props.category.id,
-    props.includeOrthologs,
+    true,
     props.direct.id,
     props.search,
     sort.value,
@@ -591,10 +589,7 @@ watch(
   () => props.category,
   async () => await queryAssociations(true),
 );
-watch(
-  () => props.includeOrthologs,
-  async () => await queryAssociations(true),
-);
+
 watch(
   () => props.direct,
   async () => await queryAssociations(true),

--- a/frontend/src/pages/node/PageNode.vue
+++ b/frontend/src/pages/node/PageNode.vue
@@ -5,7 +5,7 @@
 <template>
   <!-- status -->
   <template v-if="isLoading || isError">
-    <AppSection width="full" design="fill" class="bare node">
+    <AppSection width="full" design="fill" class="node">
       <AppHeading class="heading">
         {{ $route.params.id }}
       </AppHeading>

--- a/frontend/src/pages/node/SectionAssociations.vue
+++ b/frontend/src/pages/node/SectionAssociations.vue
@@ -19,16 +19,6 @@
         <AppButton
           :class="[
             'app-button',
-            { active: (selectedTabs[category.id] || 'all') === 'all' },
-          ]"
-          @click="setDirect(category.id, 'false')"
-          :text="`All Associations (${(totalAssociations[category.id] || 0).toLocaleString()})`"
-          color="none"
-        >
-        </AppButton>
-        <AppButton
-          :class="[
-            'app-button',
             { active: selectedTabs[category.id] === 'direct' },
           ]"
           @click="setDirect(category.id, 'true')"
@@ -37,6 +27,16 @@
             !hasDirectAssociationsForCategory(category.id)
           "
           :text="`Direct Associations (${(getDirectAssociationCount(category.id) || 0).toLocaleString()})`"
+          color="none"
+        >
+        </AppButton>
+        <AppButton
+          :class="[
+            'app-button',
+            { active: (selectedTabs[category.id] || 'all') === 'all' },
+          ]"
+          @click="setDirect(category.id, 'false')"
+          :text="`All Associations (${(totalAssociations[category.id] || 0).toLocaleString()})`"
           color="none"
         >
         </AppButton>
@@ -78,13 +78,7 @@
         <AssociationsTable
           :node="node"
           :category="category"
-          :direct="{
-            id: selectedTabs[category.id] === 'direct' ? 'true' : 'false',
-            label:
-              selectedTabs[category.id] === 'direct'
-                ? 'directly'
-                : 'including sub-classes',
-          }"
+          :direct="getDirectProps(category.id)"
           :search="debouncedSearchValues[category.id]"
           @totalAssociations="
             (total) => handleTotalAssociations(category.id, total)
@@ -130,10 +124,11 @@ const categoryOptions = computed(
     })) || [],
 );
 
-function setDirect(categoryId: string, directId: "true" | "false") {
+const setDirect = (categoryId: string, directId: "true" | "false") => {
   selectedTabs.value[categoryId] = directId === "true" ? "direct" : "all";
-}
-// // Initialize a query for fetching direct association facet counts per category for a node.
+};
+
+// Initialize a query for fetching direct association facet counts per category for a node.
 const {
   query: queryDirectFacetCount,
   data: directFacetData,
@@ -154,21 +149,30 @@ const {
 );
 
 // Helper function to check if a specific category has any direct associations
-function hasDirectAssociationsForCategory(categoryId: string): boolean {
+const hasDirectAssociationsForCategory = (categoryId: string): boolean => {
   return directFacetData.value.facet_counts.some(
     (item) => item.label === categoryId && item.count > 0,
   );
-}
-function getDirectAssociationCount(categoryId: string): number {
+};
+
+const getDirectAssociationCount = (categoryId: string): number => {
   const item = directFacetData.value.facet_counts.find(
     (c) => c.label === categoryId,
   );
   return item?.count ?? 0;
-}
+};
 
-function handleTotalAssociations(categoryId: string, total: number) {
+const handleTotalAssociations = (categoryId: string, total: number) => {
   totalAssociations.value[categoryId] = total;
-}
+};
+
+const getDirectProps = (categoryId: string) => {
+  const isDirect = selectedTabs.value[categoryId] === "direct";
+  return {
+    id: isDirect ? "true" : "false",
+    label: isDirect ? "directly" : "including sub-classes",
+  };
+};
 
 watch(
   () => props.node.id,

--- a/frontend/src/pages/node/SectionAssociations.vue
+++ b/frontend/src/pages/node/SectionAssociations.vue
@@ -44,7 +44,7 @@
           to="/search-phenotypes"
           :state="{ search: node.id }"
           text="Phenotype Explorer"
-          icon="arrow-right"
+          icon="search"
         />
 
         <div class="search-wrapper">

--- a/frontend/src/pages/node/SectionAssociations.vue
+++ b/frontend/src/pages/node/SectionAssociations.vue
@@ -56,39 +56,61 @@
 
         <!-- Disease pages: show “Direct” first, then “All” -->
         <template v-else>
-          <AppButton
-            :class="[
-              'app-button',
-              {
-                active:
-                  (selectedTabs[category.id] ?? defaultTab(category.id)) ===
-                  'direct',
-              },
-            ]"
-            @click="setDirect(category.id, 'true')"
-            :disabled="
-              isLoadingDirectCount ||
-              !hasDirectAssociationsForCategory(category.id)
-            "
-            :text="`Direct Associations`"
-            v-tooltip="'Exclude subclass associations'"
-            color="none"
-          />
-          <AppButton
-            v-if="showAllTab(category.count ?? 0, category.id)"
-            :class="[
-              'app-button',
-              {
-                active:
-                  (selectedTabs[category.id] ?? defaultTab(category.id)) ===
-                  'all',
-              },
-            ]"
-            @click="setDirect(category.id, 'false')"
-            v-tooltip="'Include subclass associations'"
-            text="All Associations"
-            color="none"
-          />
+          <div class="tab-item">
+            <AppButton
+              :class="[
+                'app-button',
+                {
+                  active:
+                    (selectedTabs[category.id] ?? defaultTab(category.id)) ===
+                    'direct',
+                },
+              ]"
+              @click="setDirect(category.id, 'true')"
+              :disabled="
+                isLoadingDirectCount ||
+                !hasDirectAssociationsForCategory(category.id)
+              "
+              :text="`Direct Associations`"
+              v-tooltip="'Exclude subclass associations'"
+              color="none"
+            />
+
+            <span
+              class="tab-count"
+              v-if="
+                category.id.includes('DiseaseToPhenotypicFeatureAssociation')
+              "
+            >
+              {{ directAssociationCount(category.id).toLocaleString() }} unique
+              across sources
+            </span>
+          </div>
+          <div class="tab-item">
+            <AppButton
+              v-if="showAllTab(category.count ?? 0, category.id)"
+              :class="[
+                'app-button',
+                {
+                  active:
+                    (selectedTabs[category.id] ?? defaultTab(category.id)) ===
+                    'all',
+                },
+              ]"
+              @click="setDirect(category.id, 'false')"
+              v-tooltip="'Include subclass associations'"
+              text="All Associations"
+              color="none"
+            />
+            <span
+              class="tab-count"
+              v-if="
+                category.id.includes('DiseaseToPhenotypicFeatureAssociation')
+              "
+            >
+              {{ (category.count ?? 0).toLocaleString() }} total associations
+            </span>
+          </div>
         </template>
       </div>
 
@@ -323,5 +345,18 @@ watch(
 .search-wrapper {
   flex: 1 1 auto;
   max-width: 500px;
+}
+
+.tab-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.tab-count {
+  color: #888; /* muted grey */
+  font-size: 0.875rem;
+  white-space: nowrap;
 }
 </style>

--- a/frontend/src/pages/node/SectionAssociations.vue
+++ b/frontend/src/pages/node/SectionAssociations.vue
@@ -237,6 +237,7 @@ const showAllTab = computed(() => {
  *  - "direct" otherwise
  * Non-disease nodes always default to "all".
  */
+
 function defaultTab(categoryId: string): "direct" | "all" {
   const directCount = directAssociationCount(categoryId);
   const isDisease = isDiseaseNode.value;
@@ -248,6 +249,12 @@ function defaultTab(categoryId: string): "direct" | "all" {
   // disease node: no direct → all, else → direct
   return directCount > 0 ? "direct" : "all";
 }
+
+/**
+ * - For non-disease pages(temperory, will change once we get the new layout):
+ * - 1. defaultTab(categoryId) → "all" when isDiseaseNode is false
+ * - 2. If hasDirectAssociationsForCategory(...) is false, omit the “Direct” tab
+ */
 
 const getDirectProps = (categoryId: string) => {
   // pick the tab (direct vs all) based on user click or our default rule

--- a/frontend/src/pages/node/SectionAssociations.vue
+++ b/frontend/src/pages/node/SectionAssociations.vue
@@ -22,7 +22,7 @@
             { active: (selectedTabs[category.id] || 'all') === 'all' },
           ]"
           @click="setDirect(category.id, 'false')"
-          text=" All Associations"
+          :text="`All Associations (${totalAssociations[category.id] || 0})`"
           color="none"
         >
         </AppButton>
@@ -36,7 +36,7 @@
             isLoadingDirectCount ||
             !hasDirectAssociationsForCategory(category.id)
           "
-          text="Direct Associations"
+          :text="`Direct Associations (${getDirectAssociationCount(category.id)})`"
           color="none"
         >
         </AppButton>
@@ -86,6 +86,9 @@
                 : 'including sub-classes',
           }"
           :search="debouncedSearchValues[category.id]"
+          @totalAssociations="
+            (total) => handleTotalAssociations(category.id, total)
+          "
         />
       </template>
     </AppSection>
@@ -94,7 +97,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from "vue";
+import { computed, ref, watch } from "vue";
 import { startCase } from "lodash";
 import { getDirectAssociationFacetCounts } from "@/api/associations";
 import type { Node } from "@/api/model";
@@ -115,6 +118,7 @@ const props = defineProps<Props>();
 const selectedTabs = ref<Record<string, "all" | "direct">>({});
 const searchValues = ref<Record<string, string>>({});
 const debouncedSearchValues = ref<Record<string, string>>({});
+const totalAssociations = ref<Record<string, number>>({});
 
 /** list of options for dropdown */
 const categoryOptions = computed(
@@ -154,6 +158,16 @@ function hasDirectAssociationsForCategory(categoryId: string): boolean {
   return directFacetData.value.facet_counts.some(
     (item) => item.label === categoryId && item.count > 0,
   );
+}
+function getDirectAssociationCount(categoryId: string): number {
+  const item = directFacetData.value.facet_counts.find(
+    (c) => c.label === categoryId,
+  );
+  return item?.count ?? 0;
+}
+
+function handleTotalAssociations(categoryId: string, total: number) {
+  totalAssociations.value[categoryId] = total;
 }
 
 watch(
@@ -212,11 +226,16 @@ watch(
     }
   }
   :deep(.app-button) {
-    &:hover {
+    border: none !important;
+    outline: none !important;
+    box-shadow: none !important;
+
+    &:focus {
       outline: none !important;
       box-shadow: none !important;
     }
-    &:focus {
+
+    &:hover {
       outline: none !important;
       box-shadow: none !important;
     }

--- a/frontend/src/pages/node/SectionAssociations.vue
+++ b/frontend/src/pages/node/SectionAssociations.vue
@@ -16,46 +16,11 @@
         Failed to load direct data.
       </p>
 
-      <div class="association-tabs">
-        <!-- Non-disease pages: show “All” first, then “Direct” -->
-        <template v-if="!isDiseaseNode">
-          <AppButton
-            v-if="showAllTab(category.count ?? 0, category.id)"
-            :class="[
-              'tab-button',
-              {
-                active:
-                  (selectedTabs[category.id] ?? defaultTab(category.id)) ===
-                  'all',
-              },
-            ]"
-            @click="setDirect(category.id, 'false')"
-            v-tooltip="'Include subclass associations'"
-            text="All Associations"
-            color="none"
-          />
-          <AppButton
-            :class="[
-              'tab-button',
-              {
-                active:
-                  (selectedTabs[category.id] ?? defaultTab(category.id)) ===
-                  'direct',
-              },
-            ]"
-            @click="setDirect(category.id, 'true')"
-            :disabled="
-              isLoadingDirectCount ||
-              !hasDirectAssociationsForCategory(category.id)
-            "
-            :text="`Direct Associations`"
-            v-tooltip="'Exclude subclass associations'"
-            color="none"
-          />
-        </template>
+      <!--tabs omly if its disease node-->
+      <template v-if="isDiseaseNode">
+        <div class="association-tabs">
+          <!-- Non-disease pages: show “All” first, then “Direct” -->
 
-        <!-- Disease pages: show “Direct” first, then “All” -->
-        <template v-else>
           <div class="tab-item">
             <AppButton
               :class="[
@@ -116,8 +81,10 @@
               {{ (category.count ?? 0).toLocaleString() }} phenotypes
             </span>
           </div>
-        </template>
-      </div>
+
+          <!-- Disease pages: show “Direct” first, then “All” -->
+        </div>
+      </template>
 
       <div class="actions-row">
         <AppButton

--- a/frontend/src/pages/node/SectionAssociations.vue
+++ b/frontend/src/pages/node/SectionAssociations.vue
@@ -27,43 +27,31 @@
         </button>
       </div>
 
-      <div class="topRow">
-        <AppFlex gap="small" class="leftColumn">
-          <AppCheckbox
-            v-if="
-              node.category === 'biolink:Gene' &&
-              category?.id.startsWith('biolink:GeneToPheno')
-            "
-            v-model="includeOrthologs"
-            v-tooltip="
-              'Include phenotypes for orthologous genes in the associations table'
-            "
-            text="Include ortholog phenotypes"
-          />
+      <div class="actions-row">
+        <AppButton
+          v-if="
+            (selectedTabs[category.id] === 'direct' &&
+              node.category === 'biolink:Disease' &&
+              category?.id.startsWith('biolink:DiseaseToPheno') &&
+              (node.has_phenotype_count ?? 0) > 0) ||
+            (node.category === 'biolink:Gene' &&
+              category?.id.startsWith('biolink:GeneToPheno') &&
+              (node.has_phenotype_count ?? 0) > 0)
+          "
+          v-tooltip="
+            'Send these phenotypes to Phenotype Explorer for comparison'
+          "
+          to="/search-phenotypes"
+          :state="{ search: node.id }"
+          text="Phenotype Explorer"
+          icon="arrow-right"
+        />
 
-          <AppButton
-            v-if="
-              (node.category === 'biolink:Disease' &&
-                category?.id.startsWith('biolink:DiseaseToPheno') &&
-                (node.has_phenotype_count ?? 0) > 0) ||
-              (node.category === 'biolink:Gene' &&
-                category?.id.startsWith('biolink:GeneToPheno') &&
-                (node.has_phenotype_count ?? 0) > 0)
-            "
-            v-tooltip="
-              'Send these phenotypes to Phenotype Explorer for comparison'
-            "
-            to="/search-phenotypes"
-            :state="{ search: node.id }"
-            text="Phenotype Explorer"
-            icon="arrow-right"
-          />
-        </AppFlex>
-
-        <div class="rightColumn">
+        <div class="search-wrapper">
           <AppTextbox
             v-model="searchValues[category.id]"
             placeholder="Search table data..."
+            class="search-box"
             @debounce="(value) => (debouncedSearchValues[category.id] = value)"
             @change="(value) => (debouncedSearchValues[category.id] = value)"
           />
@@ -75,7 +63,6 @@
         <AssociationsTable
           :node="node"
           :category="category"
-          :include-orthologs="includeOrthologs"
           :direct="{
             id: selectedTabs[category.id] === 'direct' ? 'true' : 'false',
             label:
@@ -188,5 +175,20 @@ function setDirect(categoryId: string, directId: "true" | "false") {
       font-weight: 500;
     }
   }
+}
+
+.actions-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  width: 100%;
+  margin: 1rem 0;
+  gap: 1rem;
+}
+
+.search-wrapper {
+  flex: 1 1 auto;
+  max-width: 500px;
 }
 </style>

--- a/frontend/src/pages/node/SectionAssociations.vue
+++ b/frontend/src/pages/node/SectionAssociations.vue
@@ -22,7 +22,7 @@
           <AppButton
             v-if="showAllTab(category.count ?? 0, category.id)"
             :class="[
-              'app-button',
+              'tab-button',
               {
                 active:
                   (selectedTabs[category.id] ?? defaultTab(category.id)) ===
@@ -36,7 +36,7 @@
           />
           <AppButton
             :class="[
-              'app-button',
+              'tab-button',
               {
                 active:
                   (selectedTabs[category.id] ?? defaultTab(category.id)) ===
@@ -59,7 +59,7 @@
           <div class="tab-item">
             <AppButton
               :class="[
-                'app-button',
+                'tab-button',
                 {
                   active:
                     (selectedTabs[category.id] ?? defaultTab(category.id)) ===
@@ -83,14 +83,14 @@
               "
             >
               {{ directAssociationCount(category.id).toLocaleString() }} unique
-              across sources
+              direct phenotypes across sources
             </span>
           </div>
           <div class="tab-item">
             <AppButton
               v-if="showAllTab(category.count ?? 0, category.id)"
               :class="[
-                'app-button',
+                'tab-button',
                 {
                   active:
                     (selectedTabs[category.id] ?? defaultTab(category.id)) ===
@@ -105,10 +105,11 @@
             <span
               class="tab-count"
               v-if="
+                showAllTab(category.count ?? 0, category.id) &&
                 category.id.includes('DiseaseToPhenotypicFeatureAssociation')
               "
             >
-              {{ (category.count ?? 0).toLocaleString() }} total associations
+              {{ (category.count ?? 0).toLocaleString() }} phenotypes
             </span>
           </div>
         </template>
@@ -298,16 +299,18 @@ watch(
 }
 .association-tabs {
   display: flex;
+  gap: 0.25em;
 
-  .app-button {
+  .tab-button {
     z-index: 0;
     position: relative;
-    margin-right: 0.25rem;
+
+    min-width: 22em;
+
     padding: 0.8rem 1.5rem;
     border: none;
     border-radius: 8px 8px 0 0;
     background-color: $light-gray;
-
     &.active {
       z-index: 1;
       background-color: $theme;
@@ -315,7 +318,7 @@ watch(
       color: white;
     }
   }
-  :deep(.app-button) {
+  :deep(.tab-button) {
     border: none !important;
     outline: none !important;
     box-shadow: none !important;

--- a/frontend/src/pages/node/SectionAssociations.vue
+++ b/frontend/src/pages/node/SectionAssociations.vue
@@ -6,7 +6,7 @@
   <!-- show an AppSection for each category in categoryOptions  -->
   <div v-for="category in categoryOptions" :key="category.id">
     <!-- Association table -->
-    <AppSection alignment="left" width="full" class="inset" design="bare">
+    <AppSection alignment="left" width="full" class="inset">
       <AppHeading :level="3">{{ category.label }}</AppHeading>
       <span v-if="!categoryOptions.length"
         >No associations with &nbsp;<AppNodeBadge :node="node" />

--- a/frontend/src/pages/node/SectionAssociations.vue
+++ b/frontend/src/pages/node/SectionAssociations.vue
@@ -22,7 +22,7 @@
             { active: (selectedTabs[category.id] || 'all') === 'all' },
           ]"
           @click="setDirect(category.id, 'false')"
-          :text="`All Associations (${totalAssociations[category.id] || 0})`"
+          :text="`All Associations (${(totalAssociations[category.id] || 0).toLocaleString()})`"
           color="none"
         >
         </AppButton>
@@ -36,7 +36,7 @@
             isLoadingDirectCount ||
             !hasDirectAssociationsForCategory(category.id)
           "
-          :text="`Direct Associations (${getDirectAssociationCount(category.id)})`"
+          :text="`Direct Associations (${(getDirectAssociationCount(category.id) || 0).toLocaleString()})`"
           color="none"
         >
         </AppButton>

--- a/frontend/src/pages/node/SectionAssociations.vue
+++ b/frontend/src/pages/node/SectionAssociations.vue
@@ -82,7 +82,6 @@
 import { computed, ref, watch } from "vue";
 import { startCase } from "lodash";
 import type { Node } from "@/api/model";
-import AppCheckbox from "@/components/AppCheckbox.vue";
 import AppNodeBadge from "@/components/AppNodeBadge.vue";
 import type { Option, Options } from "@/components/AppSelectSingle.vue";
 import AppTextbox from "@/components/AppTextbox.vue";
@@ -95,8 +94,6 @@ type Props = {
 
 const props = defineProps<Props>();
 
-/** include orthologous genes in association table */
-const includeOrthologs = ref(false);
 const selectedTabs = ref<Record<string, "all" | "direct">>({});
 const searchValues = ref<Record<string, string>>({});
 const debouncedSearchValues = ref<Record<string, string>>({});

--- a/frontend/src/pages/node/SectionAssociations.vue
+++ b/frontend/src/pages/node/SectionAssociations.vue
@@ -12,6 +12,21 @@
         >No associations with &nbsp;<AppNodeBadge :node="node" />
       </span>
 
+      <div class="association-tabs">
+        <button
+          :class="{ active: (selectedTabs[category.id] || 'all') === 'all' }"
+          @click="setDirect(category.id, 'false')"
+        >
+          All Associations
+        </button>
+        <button
+          :class="{ active: selectedTabs[category.id] === 'direct' }"
+          @click="setDirect(category.id, 'true')"
+        >
+          Direct Associations
+        </button>
+      </div>
+
       <div class="topRow">
         <AppFlex gap="small" class="leftColumn">
           <AppCheckbox
@@ -72,7 +87,7 @@
 
 <script setup lang="ts">
 import { computed, ref, watch } from "vue";
-import { useRoute } from "vue-router";
+import { useRoute, useRouter } from "vue-router";
 import { startCase } from "lodash";
 import type { Node } from "@/api/model";
 import AppCheckbox from "@/components/AppCheckbox.vue";
@@ -94,7 +109,7 @@ const props = defineProps<Props>();
 /** include orthologous genes in association table */
 const includeOrthologs = ref(false);
 const direct = ref<Option>();
-
+const selectedTabs = ref<Record<string, "all" | "direct">>({});
 const searchValues = ref<Record<string, string>>({});
 const debouncedSearchValues = ref<Record<string, string>>({});
 
@@ -107,6 +122,17 @@ const categoryOptions = computed(
       count: association_count.count,
     })) || [],
 );
+
+function setDirect(categoryId: string, directId: "true" | "false") {
+  // update local state
+  selectedTabs.value[categoryId] = directId === "true" ? "direct" : "all";
+  direct.value = directOptions.value.find((o) => o.id === directId)!;
+
+  //update the URL bar without navigation/scroll
+  const url = new URL(window.location.href);
+  url.searchParams.set("direct", directId);
+  window.history.replaceState({}, "", url);
+}
 
 const directOptions = computed(
   (): Options => [
@@ -156,5 +182,40 @@ watch(
 }
 .rightColumn {
   min-width: 20em;
+}
+.association-tabs {
+  display: flex;
+  border-bottom: 3px solid $theme;
+  button {
+    position: relative;
+    padding: 0.9em 1.9em;
+    border: none;
+    background: none;
+    color: #333;
+    font-weight: 500;
+    font-size: 1em;
+    cursor: pointer;
+    transition:
+      background-color 0.3s ease,
+      color 0.3s ease;
+    &:hover {
+      background-color: #f5f5f5;
+    }
+    &.active {
+      border-radius: 5px 5px 0 0;
+      background-color: $theme;
+      color: white;
+      font-weight: 600;
+      &::after {
+        display: none;
+        content: "";
+      }
+    }
+    &:not(.active) {
+      background-color: #f0f0f0;
+      color: #555;
+      font-weight: 500;
+    }
+  }
 }
 </style>

--- a/frontend/src/pages/node/SectionAssociations.vue
+++ b/frontend/src/pages/node/SectionAssociations.vue
@@ -82,8 +82,11 @@
                 category.id.includes('DiseaseToPhenotypicFeatureAssociation')
               "
             >
-              {{ directAssociationCount(category.id).toLocaleString() }} unique
-              direct phenotypes across sources
+              <template v-if="showAllTab(category.count ?? 0, category.id)">
+                {{ directAssociationCount(category.id).toLocaleString() }}
+                unique direct phenotypes across sources
+              </template>
+              <template v-else> No subclasses exist </template>
             </span>
           </div>
           <div class="tab-item">

--- a/frontend/src/pages/node/SectionBreadcrumbs.vue
+++ b/frontend/src/pages/node/SectionBreadcrumbs.vue
@@ -1,5 +1,5 @@
 <template>
-  <AppSection width="full" alignment="left" design="bare">
+  <AppSection width="full" alignment="left">
     <AppHeading icon="location-dot">Breadcrumbs</AppHeading>
 
     <template v-if="breadcrumbs.length">

--- a/frontend/src/pages/node/SectionHierarchy.vue
+++ b/frontend/src/pages/node/SectionHierarchy.vue
@@ -8,7 +8,6 @@
     width="full"
     alignment="left"
     class="inset"
-    design="bare"
   >
     <AppHeading icon="sitemap">Hierarchy</AppHeading>
 

--- a/frontend/src/pages/node/SectionTitle.vue
+++ b/frontend/src/pages/node/SectionTitle.vue
@@ -29,7 +29,7 @@
         >
           <AppNodeText :text="node.name" />
         </span>
-        <p v-if="node.id?.includes('MONDO')" class="tag">
+        <p class="tag">
           {{ node.id }}
         </p>
         <template v-if="node.deprecated"> (OBSOLETE)</template>

--- a/frontend/src/pages/node/SectionVisualization.vue
+++ b/frontend/src/pages/node/SectionVisualization.vue
@@ -10,7 +10,6 @@
     width="full"
     class="inset"
     alignment="left"
-    design="bare"
   >
     <AppHeading icon="chart-bar">HistoPheno</AppHeading>
     <HistoPheno :node="node" />


### PR DESCRIPTION
### Related issues

- Closes #1049 

### Summary

- Add “Direct” and “Indirect” association tabs
- Update node page theme styling
- Remove the “Include ortholog” checkbox and include orthologs by default
- Remove the “Subject” and “Predicate” columns in the Direct Associations view
- Prepend “Does NOT have” to the object label for any negated (“negated: true”) direct association

### Checks

- [ ] All tests have passed (or issues created for failing tests)
