### PR TITLE
Fix Docker image tagging confusion with conditional logic

### DIFF
--- a/.github/workflows/build-and-deploy-images.yaml
+++ b/.github/workflows/build-and-deploy-images.yaml
@@ -22,10 +22,18 @@ jobs:
       - name: Generate Image Tag
         id: get-tag
         run: |
-          REV=$(git rev-list --tags --max-count=1)
-          IMAGE_TAG=$(git describe --tags $REV)
-          echo "IMAGE_TAG=${IMAGE_TAG//v}"
-          echo "IMAGE_TAG=${IMAGE_TAG//v}" >> $GITHUB_OUTPUT
+          if [ "${{ github.event_name }}" = "release" ]; then
+            # For releases, use the actual release tag
+            RELEASE_TAG=${GITHUB_REF#refs/tags/}
+            echo "IMAGE_TAG=${RELEASE_TAG//v}" >> $GITHUB_OUTPUT
+            echo "TAGS=latest,${RELEASE_TAG//v},${{ github.sha }}" >> $GITHUB_OUTPUT
+            echo "Building release: ${RELEASE_TAG//v}"
+          else
+            # For main branch pushes, use dev-specific tags (no 'latest')
+            echo "IMAGE_TAG=main-${{ github.sha }}" >> $GITHUB_OUTPUT
+            echo "TAGS=latest-dev,main-${{ github.sha }},${{ github.sha }}" >> $GITHUB_OUTPUT
+            echo "Building main branch: main-${{ github.sha }}"
+          fi
 
       - name: Build and Push Image
         uses: RafikFarhad/push-to-gcr-github-action@v5-rc1
@@ -34,7 +42,7 @@ jobs:
           registry: us-central1-docker.pkg.dev
           project_id: monarch-initiative
           image_name: monarch-api/monarch-api
-          image_tag: latest, ${{ steps.get-tag.outputs.IMAGE_TAG }}, ${{ github.sha }}
+          image_tag: ${{ steps.get-tag.outputs.TAGS }}
           dockerfile: ./backend/Dockerfile
 
   build-and-push-frontend-image:
@@ -62,10 +70,18 @@ jobs:
       - name: Generate Image Tag for Frontend Dir
         id: get-tag
         run: |
-          REV=$(git rev-list --tags --max-count=1 )
-          IMAGE_TAG=$(git describe --tags $REV)
-          echo "IMAGE_TAG=${IMAGE_TAG//v}"
-          echo "IMAGE_TAG=${IMAGE_TAG//v}" >> $GITHUB_OUTPUT
+          if [ "${{ github.event_name }}" = "release" ]; then
+            # For releases, use the actual release tag
+            RELEASE_TAG=${GITHUB_REF#refs/tags/}
+            echo "IMAGE_TAG=${RELEASE_TAG//v}" >> $GITHUB_OUTPUT
+            echo "TAGS=latest,${RELEASE_TAG//v},${{ github.sha }}" >> $GITHUB_OUTPUT
+            echo "Building frontend release: ${RELEASE_TAG//v}"
+          else
+            # For main branch pushes, use dev-specific tags (no 'latest')
+            echo "IMAGE_TAG=main-${{ github.sha }}" >> $GITHUB_OUTPUT
+            echo "TAGS=latest-dev,main-${{ github.sha }},${{ github.sha }}" >> $GITHUB_OUTPUT
+            echo "Building frontend main branch: main-${{ github.sha }}"
+          fi
 
       # the monarch-ui Dockerfile pulls from two places:
       # ./frontend/dist/, copied to /var/www/ in the image
@@ -78,7 +94,7 @@ jobs:
           registry: us-central1-docker.pkg.dev
           project_id: monarch-initiative
           image_name: monarch-api/monarch-ui
-          image_tag: latest, ${{ steps.get-tag.outputs.IMAGE_TAG }}, ${{ github.sha }}
+          image_tag: ${{ steps.get-tag.outputs.TAGS }}
           dockerfile: ./services/nginx/Dockerfile
           context: .
 


### PR DESCRIPTION
## Summary

Fixes the issue where main branch pushes were incorrectly tagged with old release versions, causing confusion about when releases were actually happening.

## Changes

**Simple conditional fix using `github.event_name`:**
- **For releases** (`github.event_name == "release"`): Tag with `latest` and actual release version
- **For main branch pushes**: Tag with `latest-dev` and branch-specific tags (no `latest` tag)

## Benefits

- ✅ **No more confusing release tags**: Main branch pushes won't create images tagged with old release versions
- ✅ **Clear separation**: `latest` tag only used for actual releases, `latest-dev` for development
- ✅ **Minimal change**: Single workflow modification instead of restructuring everything
- ✅ **Same functionality**: Dev deployment and release processes work exactly the same

## Before/After

**Before:** Main branch push → Image tagged with `latest`, `v1.2.3` (old release), and SHA
**After:** Main branch push → Image tagged with `latest-dev`, `main-<sha>`, and SHA

**Before:** Release published → Image tagged with `latest`, `v1.2.3` (old release), and SHA  
**After:** Release published → Image tagged with `latest`, `v1.4.0` (actual release), and SHA

This approach solves the core problem with the absolute minimum change required.

🤖 Generated with [Claude Code](https://claude.ai/code)