### PR TITLE
Add Prettier formatting to resource data update workflow

### DIFF
--- a/.github/workflows/update-resource-data.yaml
+++ b/.github/workflows/update-resource-data.yaml
@@ -17,7 +17,18 @@ jobs:
         run: |
           wget "https://raw.githubusercontent.com/monarch-initiative/monarch-documentation/refs/heads/main/src/docs/resources/monarch-app-infopages.json" -O frontend/src/resources/monarch-app-infopages.json
 
-      - name: Update Resource Data
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install packages
+        working-directory: ./frontend
+        run: bun install
+
+      - name: Format with Prettier
+        working-directory: ./frontend
+        run: npx prettier --write src/resources/monarch-app-infopages.json
+
+      - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         if: ${{ success() }}
         with:

--- a/.github/workflows/update-resource-data.yaml
+++ b/.github/workflows/update-resource-data.yaml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        
+
       - name: Work around permission issue
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
@@ -33,7 +33,7 @@ jobs:
         if: ${{ success() }}
         with:
           commit-message: Update Resource Data from the Monarch Documentation
-          title: 'Update Resource Data'
+          title: "Update Resource Data"
           body: |
             This pull request updates the Resource Data for the Info Pages.
           assignees: varun-divya

--- a/frontend/src/resources/monarch-app-infopages.json
+++ b/frontend/src/resources/monarch-app-infopages.json
@@ -101,9 +101,7 @@
       "license": "CC-BY-4.0",
       "see_also": {
         "documentation": "https://mondo.readthedocs.io/en/latest",
-        "other": [
-          "https://monarch-initiative.github.io/mondo-ingest"
-        ],
+        "other": ["https://monarch-initiative.github.io/mondo-ingest"],
         "repository": "https://github.com/monarch-initiative/mondo",
         "website": "https://mondo.monarchinitiative.org"
       },
@@ -213,9 +211,7 @@
       "license": "CC0",
       "see_also": {
         "documentation": "https://obophenotype.github.io/upheno",
-        "other": [
-          "https://www.ebi.ac.uk/ols4/ontologies/upheno"
-        ],
+        "other": ["https://www.ebi.ac.uk/ols4/ontologies/upheno"],
         "repository": "https://github.com/obophenotype/upheno",
         "website": "https://obophenotype.github.io/upheno"
       },
@@ -237,9 +233,7 @@
       "license": "CC-BY-4.0",
       "see_also": {
         "documentation": "https://monarch-initiative.github.io/vertebrate-breed-ontology",
-        "other": [
-          "https://ols.monarchinitiative.org/ontologies/vbo"
-        ],
+        "other": ["https://ols.monarchinitiative.org/ontologies/vbo"],
         "repository": "https://github.com/monarch-initiative/vertebrate-breed-ontology",
         "website": "https://github.com/monarch-initiative/vertebrate-breed-ontology"
       },


### PR DESCRIPTION
## Summary
- Add Prettier formatting step after downloading monarch-app-infopages.json
- Prevents linting failures caused by formatting mismatches
- Serves as a safeguard for future updates

## Problem
The `update-resource-data.yaml` workflow downloads `monarch-app-infopages.json` from the monarch-documentation repo, but doesn't format it according to the frontend's Prettier configuration. This causes linting failures when the file has formatting that doesn't match our local Prettier rules.

## Solution
Add three new steps to the workflow:
1. Set up Bun
2. Install frontend dependencies
3. Run Prettier on the downloaded file

This ensures the file is always properly formatted before creating the update PR.

## Related
- monarch-initiative/monarch-documentation#140 - Fixes the source file formatting
- Fixes linting issues seen in PR #1233

## Test Plan
- [ ] Workflow runs successfully
- [ ] Downloaded file is properly formatted
- [ ] Linting passes on the updated file

🤖 Generated with [Claude Code](https://claude.com/claude-code)