### PR TITLE
Fix Claude Code workflow: Add repository checkout step

### DIFF
--- a/.github/workflows/claude-issue-handler.yml
+++ b/.github/workflows/claude-issue-handler.yml
@@ -79,6 +79,9 @@ jobs:
               content: 'eyes'
             });
 
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.CLAUDE_CODE_OATH_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds missing `actions/checkout@v4` step to the Claude Code Issue Handler workflow
- Fixes the "fatal: not a git repository" error that was preventing the workflow from running

## Problem
The Claude Code action was failing because it needs to run git commands, but the repository wasn't being checked out first. This caused the workflow to fail with:
```
fatal: not a git repository (or any of the parent directories): .git
```

## Solution
Added the checkout step before running the `claude-code-action` to ensure the repository is available.

## Test plan
- [ ] Merge this PR
- [ ] Comment `@claude` on an issue to trigger the workflow
- [ ] Verify the workflow completes successfully

Fixes https://github.com/monarch-initiative/monarch-app/actions/runs/19974390859

🤖 Generated with [Claude Code](https://claude.com/claude-code)