### PR TITLE
Update download file links to match currently generated files

### DIFF
--- a/frontend/src/data/downloads.ts
+++ b/frontend/src/data/downloads.ts
@@ -23,7 +23,7 @@ export const knowledgeGraphDownloads: DownloadItem[] = [
   },
   {
     label: "DuckDB Database",
-    url: "https://data.monarchinitiative.org/monarch-kg/latest/monarch-kg.duckdb.gz",
+    url: "https://data.monarchinitiative.org/monarch-kg/latest/monarch-kg.duckdb",
   },
 ];
 
@@ -111,10 +111,6 @@ export const derivedArtifacts: DownloadItem[] = [
   {
     label: "Phenio SQLite (semsql)",
     url: "https://data.monarchinitiative.org/monarch-kg/latest/phenio.db.gz",
-  },
-  {
-    label: "Denormalized Associations",
-    url: "https://data.monarchinitiative.org/monarch-kg/latest/monarch-kg-denormalized-edges.tsv.gz",
   },
   {
     label: "Solr Data",


### PR DESCRIPTION
Updates the downloads page to reflect current artifact generation:

- Remove `.gz` extension from DuckDB artifact link (no longer gzipped for remote access)
- Remove denormalized edges file link (no longer produced as standalone file)

Fixes #1235

---
Generated with [Claude Code](https://claude.ai/code)