### PR TITLE
Move Trish Whetzel to Alumni Members section

### DIFF
--- a/frontend/src/data/team.json
+++ b/frontend/src/data/team.json
@@ -98,11 +98,6 @@
         "name": "Shawn O'Neil",
         "role": "DevOps, Bioinformatics, and Data Engineer",
         "link": "https://tislab.org/members/shawn-oneil.html"
-      },
-      {
-        "name": "Trish Whetzel",
-        "role": "Semantic Curation Engineer",
-        "link": "https://github.com/twhetzel"
       }
     ]
   },
@@ -343,6 +338,10 @@
   {
     "name": "Alumni Members",
     "members": [
+      {
+        "name": "Trish Whetzel",
+        "role": "Semantic Curation Engineer"
+      },
       {
         "name": "Carlo Kroll",
         "role": "Scientific Software Engineer"


### PR DESCRIPTION
Moved Trish Whetzel from University of North Carolina team to Alumni Members section as requested in issue #1244.

Generated with [Claude Code](https://claude.ai/code)