### PR TITLE
fix: update push-to-gcr-github-action to v5

### DIFF
--- a/.github/workflows/build-and-deploy-images.yaml
+++ b/.github/workflows/build-and-deploy-images.yaml
@@ -28,7 +28,7 @@ jobs:
           echo "IMAGE_TAG=${IMAGE_TAG//v}" >> $GITHUB_OUTPUT
 
       - name: Build and Push Image
-        uses: RafikFarhad/push-to-gcr-github-action@v5-rc1
+        uses: RafikFarhad/push-to-gcr-github-action@v5
         with:
           gcloud_service_key: ${{ secrets.JSON_GCLOUD_SERVICE_ACCOUNT_JSON }}
           registry: us-central1-docker.pkg.dev
@@ -72,7 +72,7 @@ jobs:
       # ./services/nginx/config/, copied to /etc/nginx/conf.d/ in the image
 
       - name: Build and Push Image
-        uses: RafikFarhad/push-to-gcr-github-action@v5-rc1
+        uses: RafikFarhad/push-to-gcr-github-action@v5
         with:
           gcloud_service_key: ${{ secrets.JSON_GCLOUD_SERVICE_ACCOUNT_JSON }}
           registry: us-central1-docker.pkg.dev

--- a/.github/workflows/build-images-for-branch.yaml
+++ b/.github/workflows/build-images-for-branch.yaml
@@ -24,7 +24,7 @@ jobs:
           echo "IMAGE_TAG=${IMAGE_TAG//v}" >> $GITHUB_OUTPUT
 
       - name: Build and Push Image
-        uses: RafikFarhad/push-to-gcr-github-action@v5-beta
+        uses: RafikFarhad/push-to-gcr-github-action@v5
         with:
           gcloud_service_key: ${{ secrets.JSON_GCLOUD_SERVICE_ACCOUNT_JSON }} # not needed if you use google-github-actions/auth
           registry: us-central1-docker.pkg.dev
@@ -68,7 +68,7 @@ jobs:
       # ./services/nginx/config/, copied to /etc/nginx/conf.d/ in the image
 
       - name: Build and Push Image
-        uses: RafikFarhad/push-to-gcr-github-action@v5-beta
+        uses: RafikFarhad/push-to-gcr-github-action@v5
         with:
           gcloud_service_key: ${{ secrets.JSON_GCLOUD_SERVICE_ACCOUNT_JSON }}
           registry: us-central1-docker.pkg.dev


### PR DESCRIPTION
## Summary
- Updates `RafikFarhad/push-to-gcr-github-action` from `v5-rc1`/`v5-beta` to `v5` in both Docker build workflows
- GitHub runners upgraded their Docker engine to require API version 1.44+, but the old action versions bundle Docker client API 1.41, causing all image builds to fail
- The `v5` release includes Docker CLI 29.2.1 which resolves the compatibility issue

## Test plan
- [ ] Verify the Docker image build action passes on this branch (triggered on push to main or via workflow_dispatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)