### PR TITLE
fix: override ICD10CM prefix expansion to use icd10data.com

### DIFF
--- a/backend/src/monarch_py/service/curie_service.py
+++ b/backend/src/monarch_py/service/curie_service.py
@@ -12,6 +12,9 @@ converter = load_converter("merged")
 converter.add_prefix("GARD", "https://rarediseases.info.nih.gov/diseases/")
 converter.add_prefix("NORD", "https://rarediseases.org/?p=")
 converter.add_prefix("Orphanet", "https://www.orpha.net/en/disease/detail/", merge=True)
+# icd.codes is dead/returning 403s, override to use bioportal via purl.bioontology.org
+# (add_prefix merge only adds as synonym, so patch prefix_map directly)
+converter.prefix_map["ICD10CM"] = "http://purl.bioontology.org/ontology/ICD10CM/"
 converter.add_prefix(
     "phenopacket.store",
     "https://github.com/monarch-initiative/phenopacket-store/blob/main/notebooks/",


### PR DESCRIPTION
## Summary
- The upstream `prefixmaps` library maps `ICD10CM` CURIEs to `https://icd.codes/icd10cm/`, but that domain is dead (returning 403s)
- Override the canonical URI prefix to use `http://purl.bioontology.org/ontology/ICD10CM/` instead, which redirects to BioPortal's ICD10CM class pages
- Uses direct `prefix_map` mutation because `add_prefix(merge=True)` only adds the new URL as a synonym rather than replacing the canonical prefix

Upstream fix should go into [linkml/prefixmaps](https://github.com/linkml/prefixmaps) and/or [biopragmatics/bioregistry](https://github.com/biopragmatics/bioregistry).