### PR TITLE
fix: update ICD10CM prefix expansion to icd10data.com

### DIFF
--- a/backend/src/monarch_py/service/curie_service.py
+++ b/backend/src/monarch_py/service/curie_service.py
@@ -12,9 +12,9 @@ converter = load_converter("merged")
 converter.add_prefix("GARD", "https://rarediseases.info.nih.gov/diseases/")
 converter.add_prefix("NORD", "https://rarediseases.org/?p=")
 converter.add_prefix("Orphanet", "https://www.orpha.net/en/disease/detail/", merge=True)
-# icd.codes is dead/returning 403s, override to use bioportal via purl.bioontology.org
+# icd.codes is dead/returning 403s, override to use icd10data.com search
 # (add_prefix merge only adds as synonym, so patch prefix_map directly)
-converter.prefix_map["ICD10CM"] = "http://purl.bioontology.org/ontology/ICD10CM/"
+converter.prefix_map["ICD10CM"] = "https://www.icd10data.com/search?s="
 converter.add_prefix(
     "phenopacket.store",
     "https://github.com/monarch-initiative/phenopacket-store/blob/main/notebooks/",


### PR DESCRIPTION
## Summary
- Switch ICD10CM URL expansion from `purl.bioontology.org` to `https://www.icd10data.com/search?s=` for more reliable and user-friendly ICD10CM code lookups

## Test plan
- [x] Verify ICD10CM links on entity pages resolve correctly (e.g. search for a disease with ICD10CM mappings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)