### PR TITLE
fix: strip bulky has_descendant lists from entity API responses

### DIFF
--- a/backend/src/monarch_py/implementations/solr/solr_implementation.py
+++ b/backend/src/monarch_py/implementations/solr/solr_implementation.py
@@ -117,6 +117,10 @@ class SolrImplementation(EntityInterface, AssociationInterface, SearchInterface,
         normalized_doc = normalize_solr_doc_for_model(solr_document, Node)
         entity = Entity(**normalized_doc)
         entity.uri = get_uri(entity.id)
+        # Strip bulky descendant lists - these can be 10+ MB for high-level ontology
+        # terms and are not used by the frontend. Keep has_descendant_count (an integer).
+        entity.has_descendant = None
+        entity.has_descendant_label = None
         if "biolink:Disease" == entity.category:
             # Get mode of inheritance
             mode_of_inheritance_associations = self.get_associations(

--- a/backend/src/monarch_py/implementations/solr/solr_parsers.py
+++ b/backend/src/monarch_py/implementations/solr/solr_parsers.py
@@ -241,6 +241,10 @@ def parse_entity(solr_document: Dict) -> Entity:
     try:
         entity = Entity(**solr_document)
         entity.uri = converter.expand(entity.id)
+        # Strip bulky descendant lists - these can be 10+ MB for high-level ontology
+        # terms and are not used by the frontend. Keep has_descendant_count (an integer).
+        entity.has_descendant = None
+        entity.has_descendant_label = None
     except ValidationError:
         logger.error(f"Validation error for {solr_document}")
         raise

--- a/backend/tests/unit/test_solr_implementation.py
+++ b/backend/tests/unit/test_solr_implementation.py
@@ -51,6 +51,40 @@ def test_get_generic_entity_grid_accepts_multiple_row_categories():
 
 
 # =====================================================================
+# Tests for get_entity descendant stripping
+# =====================================================================
+
+
+def test_get_entity_strips_descendant_lists():
+    """get_entity should strip has_descendant/has_descendant_label from the response."""
+    solr_doc = {
+        "id": "UBERON:0000061",
+        "category": "biolink:AnatomicalEntity",
+        "name": "anatomical structure",
+        "provided_by": "phenio_nodes",
+        "has_descendant": [f"UBERON:{i:07d}" for i in range(100)],
+        "has_descendant_label": [f"structure {i}" for i in range(100)],
+        "has_descendant_count": 100,
+    }
+
+    with (
+        patch("monarch_py.implementations.solr.solr_implementation.SolrService") as mock_solr_cls,
+        patch.object(SolrImplementation, "_get_cross_species_term_clique", return_value=None),
+        patch.object(SolrImplementation, "_get_node_hierarchy", return_value=None),
+        patch.object(SolrImplementation, "get_association_counts") as mock_counts,
+        patch.object(SolrImplementation, "_get_mapped_entities", return_value=[]),
+    ):
+        mock_solr_cls.return_value.get.return_value = solr_doc
+        mock_counts.return_value.items = []
+
+        node = SolrImplementation().get_entity("UBERON:0000061", extra=True)
+
+        assert node.has_descendant is None
+        assert node.has_descendant_label is None
+        assert node.has_descendant_count == 100
+
+
+# =====================================================================
 # Tests for _get_entity_name
 # =====================================================================
 

--- a/backend/tests/unit/test_solr_parsers.py
+++ b/backend/tests/unit/test_solr_parsers.py
@@ -62,6 +62,15 @@ def test_parse_entity(entity_response, node):
     assert all(parsed[k] == v for k, v in parsed.items() if k in node)
 
 
+def test_parse_entity_strips_descendant_lists(entity_response):
+    """has_descendant and has_descendant_label should be stripped to avoid multi-MB responses."""
+    assert entity_response.get("has_descendant"), "fixture should have has_descendant to test stripping"
+    entity = parse_entity(entity_response)
+    assert entity.has_descendant is None
+    assert entity.has_descendant_label is None
+    assert entity.has_descendant_count is not None  # count (integer) should be preserved
+
+
 def test_parse_histopheno(histopheno_response, histopheno, node):
     histopheno_response["response"]["numFound"] = histopheno_response["response"].pop("num_found")
     solr_response = SolrQueryResult(**histopheno_response)


### PR DESCRIPTION
These Solr-stored transitive closure lists can be 10+ MB for high-level ontology terms (e.g. UBERON:0000061 with 242K descendants) and are not used by the frontend. Keeps has_descendant_count (an integer).

Reduces UBERON:0000061 response from 24.8 MB to ~56 KB.
