### PR TITLE
Cross-species graph: collapse by prefix and show singleton cliques

### DIFF
--- a/backend/src/monarch_py/implementations/solr/solr_query_utils.py
+++ b/backend/src/monarch_py/implementations/solr/solr_query_utils.py
@@ -111,12 +111,12 @@ def build_association_query(
     query.add_field_filter_query("primary_knowledge_source", primary_knowledge_source)
     if subject:
         if direct:
-            query.add_field_filter_query("subject", " OR ".join(subject))
+            query.add_field_filter_query("subject", subject)
         else:
             query.add_filter_query(" OR ".join([f'subject:"{s}" OR subject_closure:"{s}"' for s in subject]))
     if object:
         if direct:
-            query.add_field_filter_query("object", " OR ".join(object))
+            query.add_field_filter_query("object", object)
         else:
             query.add_filter_query(" OR ".join([f'object:"{o}" OR object_closure:"{o}"' for o in object]))
     if entity:

--- a/frontend/src/components/TheCrossSpeciesGraph.vue
+++ b/frontend/src/components/TheCrossSpeciesGraph.vue
@@ -127,16 +127,33 @@
             class="node-text node-name"
             text-anchor="middle"
           >
-            {{ truncate(child.entity.name || "", 18) }}
+            {{ truncate(child.entity.name || "", 22) }}
           </text>
         </a>
+        <!-- "+N more" badge when collapsed -->
+        <text
+          v-if="visibleChildren.groupCounts.get(child.entity.id)"
+          :x="child.x"
+          :y="child.y + child.h / 2 + 16"
+          class="more-badge"
+          text-anchor="middle"
+        >
+          +{{ visibleChildren.groupCounts.get(child.entity.id) }} more
+        </text>
       </g>
     </svg>
+    <button
+      v-if="hiddenCount > 0 || expanded"
+      class="toggle-btn"
+      @click="expanded = !expanded"
+    >
+      {{ expanded ? "Show 1 per species" : `Show all ${totalChildren} children` }}
+    </button>
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, ref } from "vue";
 import type { CrossSpeciesTermClique, Entity } from "@/api/model";
 import frogIcon from "@/assets/icons/frogIcon.svg?url";
 import humanIcon from "@/assets/icons/humanIcon.svg?url";
@@ -155,11 +172,11 @@ const ICON_MAP: Record<string, string> = {
   XPO: frogIcon,
 };
 
-const NODE_W = 140;
+const NODE_W = 170;
 const NODE_H = 60;
 const ROOT_W = 200;
 const ROOT_H = 50;
-const SPACING = 160;
+const SPACING = 190;
 const PARENT_Y = 50;
 const CHILD_Y = 180;
 
@@ -179,7 +196,38 @@ interface SidewaysEdge {
   offsetIndex: number;
 }
 
-const numChildren = computed(() => props.clique.clique_entities.length);
+/** Collapse/expand state */
+const expanded = ref(false);
+
+/** Group clique entities by ID prefix; return visible entities and per-prefix counts */
+const visibleChildren = computed(() => {
+  const all = props.clique.clique_entities;
+  const groups = new Map<string, Entity[]>();
+  for (const entity of all) {
+    const prefix = entity.id.split(":")[0];
+    if (!groups.has(prefix)) groups.set(prefix, []);
+    groups.get(prefix)!.push(entity);
+  }
+  if (expanded.value) {
+    return { entities: all, groupCounts: new Map<string, number>() };
+  }
+  const entities: Entity[] = [];
+  const groupCounts = new Map<string, number>();
+  for (const [, members] of groups) {
+    entities.push(members[0]);
+    if (members.length > 1) {
+      groupCounts.set(members[0].id, members.length - 1);
+    }
+  }
+  return { entities, groupCounts };
+});
+
+const totalChildren = computed(() => props.clique.clique_entities.length);
+const hiddenCount = computed(
+  () => totalChildren.value - visibleChildren.value.entities.length,
+);
+
+const numChildren = computed(() => visibleChildren.value.entities.length);
 
 const svgWidth = computed(
   () => Math.max(numChildren.value, 1) * SPACING + SPACING,
@@ -205,7 +253,7 @@ const childNodes = computed<LayoutNode[]>(() => {
   const n = numChildren.value;
   const totalWidth = (n - 1) * SPACING;
   const startX = svgWidth.value / 2 - totalWidth / 2;
-  return props.clique.clique_entities.map((entity, i) => ({
+  return visibleChildren.value.entities.map((entity, i) => ({
     entity,
     x: startX + i * SPACING,
     y: CHILD_Y,
@@ -373,5 +421,29 @@ svg {
 a:has(.node-current) .node-id,
 a:has(.node-current) .node-name {
   fill: #404040;
+}
+
+.more-badge {
+  fill: hsl(200, 15%, 40%);
+  font-size: 11px;
+  font-style: italic;
+  font-family: "Poppins", sans-serif;
+}
+
+.toggle-btn {
+  display: block;
+  margin: 8px auto 0;
+  padding: 4px 14px;
+  border: 1px solid hsl(200, 15%, 70%);
+  border-radius: 4px;
+  background: #fff;
+  color: hsl(200, 15%, 35%);
+  font-size: 13px;
+  cursor: pointer;
+  font-family: "Poppins", sans-serif;
+}
+
+.toggle-btn:hover {
+  background: hsl(200, 15%, 95%);
 }
 </style>

--- a/frontend/src/components/TheCrossSpeciesGraph.vue
+++ b/frontend/src/components/TheCrossSpeciesGraph.vue
@@ -13,7 +13,13 @@
       :viewBox="`0 0 ${svgWidth} ${svgHeight}`"
     >
       <!-- Vertical edges (children → root) -->
-      <g v-for="(edge, i) in verticalEdges" :key="'v-' + i">
+      <g
+        v-for="(edge, i) in verticalEdges"
+        :key="'v-' + i"
+        v-tooltip="
+          edgeTooltip(edge.predicate, edge.source, edge.subject, edge.object)
+        "
+      >
         <line
           :x1="rootNode.x"
           :y1="rootNode.y + rootNode.h / 2"
@@ -22,9 +28,6 @@
           class="edge edge-vertical"
         />
         <text
-          v-tooltip="
-            edgeTooltip(edge.predicate, edge.source, edge.subject, edge.object)
-          "
           :x="edge.child.x"
           :y="edge.child.y - edge.child.h / 2 - 14"
           class="edge-label"
@@ -35,7 +38,13 @@
       </g>
 
       <!-- Horizontal edges (same_as / homologous_to between children) -->
-      <g v-for="(edge, i) in sidewaysEdges" :key="'h-' + i">
+      <g
+        v-for="(edge, i) in sidewaysEdges"
+        :key="'h-' + i"
+        v-tooltip="
+          edgeTooltip(edge.predicate, edge.source, edge.subject, edge.object)
+        "
+      >
         <path
           :d="sidewaysPath(edge)"
           :class="[
@@ -47,9 +56,6 @@
           fill="none"
         />
         <text
-          v-tooltip="
-            edgeTooltip(edge.predicate, edge.source, edge.subject, edge.object)
-          "
           :x="(edge.sourceNode.x + edge.targetNode.x) / 2"
           :y="sidewaysLabelY(edge)"
           class="edge-label"

--- a/frontend/src/components/TheCrossSpeciesGraph.vue
+++ b/frontend/src/components/TheCrossSpeciesGraph.vue
@@ -161,7 +161,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from "vue";
+import { computed, ref, watch } from "vue";
 import type { CrossSpeciesTermClique, Entity } from "@/api/model";
 import frogIcon from "@/assets/icons/frogIcon.svg?url";
 import humanIcon from "@/assets/icons/humanIcon.svg?url";
@@ -207,8 +207,14 @@ interface SidewaysEdge {
   object: string;
 }
 
-/** Collapse/expand state */
+/** Collapse/expand state — reset when navigating to a different clique */
 const expanded = ref(false);
+watch(
+  () => props.clique,
+  () => {
+    expanded.value = false;
+  },
+);
 
 /**
  * Group clique entities by ID prefix; return visible entities and per-prefix
@@ -228,9 +234,12 @@ const visibleChildren = computed(() => {
   const entities: Entity[] = [];
   const groupCounts = new Map<string, number>();
   for (const [, members] of groups) {
-    entities.push(members[0]);
+    // Prefer the current node as the visible representative for its group
+    const current = members.find((m) => m.id === props.currentId);
+    const rep = current ?? members[0];
+    entities.push(rep);
     if (members.length > 1) {
-      groupCounts.set(members[0].id, members.length - 1);
+      groupCounts.set(rep.id, members.length - 1);
     }
   }
   return { entities, groupCounts };

--- a/frontend/src/components/TheCrossSpeciesGraph.vue
+++ b/frontend/src/components/TheCrossSpeciesGraph.vue
@@ -22,6 +22,9 @@
           class="edge edge-vertical"
         />
         <text
+          v-tooltip="
+            edgeTooltip(edge.predicate, edge.source, edge.subject, edge.object)
+          "
           :x="edge.child.x"
           :y="edge.child.y - edge.child.h / 2 - 14"
           class="edge-label"
@@ -44,6 +47,9 @@
           fill="none"
         />
         <text
+          v-tooltip="
+            edgeTooltip(edge.predicate, edge.source, edge.subject, edge.object)
+          "
           :x="(edge.sourceNode.x + edge.targetNode.x) / 2"
           :y="sidewaysLabelY(edge)"
           class="edge-label"
@@ -147,7 +153,9 @@
       class="toggle-btn"
       @click="expanded = !expanded"
     >
-      {{ expanded ? "Show 1 per species" : `Show all ${totalChildren} children` }}
+      {{
+        expanded ? "Show 1 per species" : `Show all ${totalChildren} children`
+      }}
     </button>
   </div>
 </template>
@@ -194,12 +202,18 @@ interface SidewaysEdge {
   predicate: string;
   /** Vertical offset index for stacking multiple edges between the same pair */
   offsetIndex: number;
+  source?: string;
+  subject: string;
+  object: string;
 }
 
 /** Collapse/expand state */
 const expanded = ref(false);
 
-/** Group clique entities by ID prefix; return visible entities and per-prefix counts */
+/**
+ * Group clique entities by ID prefix; return visible entities and per-prefix
+ * counts
+ */
 const visibleChildren = computed(() => {
   const all = props.clique.clique_entities;
   const groups = new Map<string, Entity[]>();
@@ -263,20 +277,32 @@ const childNodes = computed<LayoutNode[]>(() => {
 });
 
 const verticalEdges = computed(() => {
-  const assocMap = new Map<string, string>();
+  const assocMap = new Map<
+    string,
+    { predicate: string; source?: string; object: string }
+  >();
   for (const assoc of props.clique.clique_associations) {
     if (
       assoc.predicate !== "biolink:same_as" &&
       assoc.predicate !== "biolink:homologous_to"
     ) {
-      assocMap.set(assoc.subject, assoc.predicate);
+      assocMap.set(assoc.subject, {
+        predicate: assoc.predicate,
+        source: assoc.primary_knowledge_source,
+        object: assoc.object,
+      });
     }
   }
   return childNodes.value.map((child) => {
-    const predicate = assocMap.get(child.entity.id) ?? "subclass_of";
+    const info = assocMap.get(child.entity.id);
+    const predicate = info?.predicate ?? "biolink:subclass_of";
     return {
       child,
       label: predicate.replace("biolink:", "").replace(/_/g, " "),
+      predicate,
+      source: info?.source,
+      subject: child.entity.id,
+      object: info?.object ?? props.clique.root_term.id,
     };
   });
 });
@@ -303,6 +329,9 @@ const sidewaysEdges = computed<SidewaysEdge[]>(() => {
           targetNode: target,
           predicate: assoc.predicate,
           offsetIndex: idx,
+          source: assoc.primary_knowledge_source,
+          subject: assoc.subject,
+          object: assoc.object,
         });
       }
     }
@@ -341,6 +370,17 @@ function truncate(text: string, max: number): string {
 function nodeTooltip(entity: Entity): string {
   return `<strong>${entity.id}</strong><br/>${entity.name || ""}`;
 }
+
+function edgeTooltip(
+  predicate: string,
+  source: string | undefined,
+  subject: string,
+  object: string,
+): string {
+  let html = `<strong>${predicate}</strong><br/>${subject} → ${object}`;
+  if (source) html += `<br/>Source: ${source}`;
+  return html;
+}
 </script>
 
 <style scoped>
@@ -376,6 +416,7 @@ svg {
 .edge-label {
   fill: #888;
   font-size: 10px;
+  cursor: help;
 }
 
 .node {
@@ -425,8 +466,8 @@ a:has(.node-current) .node-name {
 
 .more-badge {
   fill: hsl(200, 15%, 40%);
-  font-size: 11px;
   font-style: italic;
+  font-size: 11px;
   font-family: "Poppins", sans-serif;
 }
 
@@ -439,8 +480,8 @@ a:has(.node-current) .node-name {
   background: #fff;
   color: hsl(200, 15%, 35%);
   font-size: 13px;
-  cursor: pointer;
   font-family: "Poppins", sans-serif;
+  cursor: pointer;
 }
 
 .toggle-btn:hover {

--- a/frontend/src/pages/node/SectionCrossSpecies.vue
+++ b/frontend/src/pages/node/SectionCrossSpecies.vue
@@ -2,7 +2,7 @@
   Cross-species term clique visualization section.
   Shows the cross-species parent term and its species-specific children
   with their associations (subclass_of, same_as, homologous_to).
-  Only rendered when the node has a clique with 2+ species-specific entities.
+  Only rendered when the node has a clique with 1+ species-specific entities.
 -->
 
 <template>
@@ -28,6 +28,6 @@ const props = defineProps<Props>();
 
 const showSection = computed(() => {
   const clique = props.node.cross_species_term_clique;
-  return clique && clique.clique_entities.length >= 2;
+  return clique && clique.clique_entities.length >= 1;
 });
 </script>


### PR DESCRIPTION
## Summary
- **Collapse children by prefix**: When a cross-species clique has multiple entities per species (e.g. several HP terms), the graph now shows 1 per prefix with a "+N more" badge, and a toggle button to expand/collapse all children.
- **Show singleton cliques**: Lowered the visibility threshold from 2 to 1 species-specific entity so terms like UBERON:0007132 (head kidney, which only has a ZFA descendant) still display the cross-species equivalents section.
- Minor layout tweaks: wider nodes (170px) and spacing (190px) to accommodate longer labels (truncated at 22 chars).

## Test plan
- [ ] Visit a term with many cross-species children (e.g. a UPHENO phenotype) and verify collapsed view shows 1 per prefix with "+N more" badges
- [ ] Click the expand toggle and verify all children appear; click again to re-collapse
- [ ] Visit UBERON:0007132 (head kidney) and confirm the cross-species section now appears with ZFA:0000669
- [ ] Visit a term with no cross-species clique (e.g. a gene) and confirm no section appears