### PR TITLE
Limit ontologies in cross-species visualization

### DIFF
--- a/backend/src/monarch_py/implementations/solr/solr_implementation.py
+++ b/backend/src/monarch_py/implementations/solr/solr_implementation.py
@@ -80,7 +80,32 @@ class SolrImplementation(EntityInterface, AssociationInterface, SearchInterface,
     base_url: str = os.getenv("MONARCH_SOLR_URL", "http://localhost:8983/solr")
 
     CROSS_SPECIES_PREFIXES = ["UPHENO", "UBERON"]
-    CROSS_SPECIES_CLIQUE_CATEGORIES = ["biolink:PhenotypicFeature", "biolink:AnatomicalEntity"]
+    SPECIES_SPECIFIC_PREFIXES = [
+        # Anatomy (children of UBERON)
+        "ZFA",
+        "EMAPA",
+        "FBbt",
+        "WBbt",
+        "XAO",
+        # Life stages (children of UBERON)
+        "HSAPDV",
+        "ZFS",
+        "FBdv",
+        "WBLS",
+        # Phenotypes (children of UPHENO)
+        "HP",
+        "MP",
+        "ZP",
+        "XPO",
+        "WBPhenotype",
+        "DDPHENO",
+        "FYPO",
+        "PHIPO",
+        "FBcv",
+        "PLANP",
+        "MGPO",
+        "APO",
+    ]
     SIDEWAYS_PREDICATES = [AssociationPredicate.SAME_AS, AssociationPredicate.HOMOLOGOUS_TO]
 
     def solr_is_available(self) -> bool:
@@ -267,10 +292,11 @@ class SolrImplementation(EntityInterface, AssociationInterface, SearchInterface,
         vertical (subclass_of) and horizontal (same_as, homologous_to) associations
         between clique members.
         """
-        if entity.category not in self.CROSS_SPECIES_CLIQUE_CATEGORIES:
-            return None
-
         is_root_term = any(entity.id.startswith(f"{prefix}:") for prefix in self.CROSS_SPECIES_PREFIXES)
+        is_species_specific = any(entity.id.startswith(f"{prefix}:") for prefix in self.SPECIES_SPECIFIC_PREFIXES)
+
+        if not is_root_term and not is_species_specific:
+            return None
 
         if is_root_term:
             root_term = entity
@@ -327,14 +353,16 @@ class SolrImplementation(EntityInterface, AssociationInterface, SearchInterface,
         return cross_species_parents[0] if cross_species_parents else None
 
     def _get_species_specific_children(self, root_id: str) -> list[Entity]:
-        """Get species-specific (non-UPHENO/UBERON) children of a cross-species root term."""
+        """Get species-specific children of a cross-species root term."""
         all_children = self.get_counterpart_entities(
             this_entity=Entity(id=root_id),
             object=root_id,
             predicate=[AssociationPredicate.SUBCLASS_OF],
         )
         return [
-            c for c in all_children if not any(c.id.startswith(f"{prefix}:") for prefix in self.CROSS_SPECIES_PREFIXES)
+            c
+            for c in all_children
+            if any(c.id.startswith(f"{prefix}:") for prefix in self.SPECIES_SPECIFIC_PREFIXES)
         ]
 
     @staticmethod

--- a/backend/tests/unit/test_solr_implementation.py
+++ b/backend/tests/unit/test_solr_implementation.py
@@ -427,11 +427,51 @@ def _make_assoc_results(items):
 
 
 def test_cross_species_clique_non_phenotypic_returns_none():
-    """Non-phenotypic entities should return None."""
+    """Entities with prefixes not in CROSS_SPECIES or SPECIES_SPECIFIC lists should return None."""
     entity = _make_entity("HGNC:4851", category="biolink:Gene")
     si = SolrImplementation()
     result = si._get_cross_species_term_clique(entity)
     assert result is None
+
+
+def test_cross_species_clique_species_neutral_returns_none():
+    """Species-neutral ontologies like CL and GO should not get a clique."""
+    si = SolrImplementation()
+    for id, category in [("CL:0000540", "biolink:Cell"), ("GO:0110165", "biolink:CellularComponent")]:
+        entity = _make_entity(id, category=category)
+        result = si._get_cross_species_term_clique(entity)
+        assert result is None, f"{id} should not get a cross-species clique"
+
+
+def test_cross_species_clique_filters_species_neutral_children():
+    """CL and GO children of a UBERON root should be excluded from the clique."""
+    root = _make_entity("UBERON:0000061", category="biolink:AnatomicalEntity", name="anatomical structure")
+    zfa_child = _make_entity("ZFA:0000037", name="anatomical structure")
+    cl_child = _make_entity("CL:0000000", name="cell")
+
+    vertical_assocs = [
+        _make_association("ZFA:0000037", "biolink:subclass_of", "UBERON:0000061"),
+    ]
+
+    with (
+        patch.object(
+            SolrImplementation,
+            "get_counterpart_entities",
+            return_value=[zfa_child, cl_child],
+        ),
+        patch.object(
+            SolrImplementation,
+            "get_associations",
+            side_effect=[_make_assoc_results(vertical_assocs)],
+        ),
+    ):
+        si = SolrImplementation()
+        result = si._get_cross_species_term_clique(root)
+
+        assert result is not None
+        child_ids = [c.id for c in result.clique_entities]
+        assert "ZFA:0000037" in child_ids
+        assert "CL:0000000" not in child_ids
 
 
 def test_cross_species_clique_root_term():


### PR DESCRIPTION
This limits to uberon & upheno as the cross species ontologies, and enumerates specific ontologies that are allowed to be children in the cross species viz, so that we stay within the intended goal of cross species linking down to species-specific (and not to GO or CL, which aren't species-specific)
