### PR TITLE
Display supporting_text in association details

### DIFF
--- a/frontend/src/components/dashboard/SourceAssociationBrowser.vue
+++ b/frontend/src/components/dashboard/SourceAssociationBrowser.vue
@@ -624,6 +624,12 @@ const associationProperties = computed((): DetailProperty[] => {
   } else if (a.publications?.length) {
     details.push({ label: "Publications", value: a.publications.join(", ") });
   }
+  if (a.supporting_text?.length) {
+    details.push({
+      label: "Supporting Text",
+      value: a.supporting_text.join("\n\n"),
+    });
+  }
   if (a.frequency_qualifier_label || a.frequency_qualifier) {
     details.push({
       label: "Frequency",
@@ -997,6 +1003,7 @@ watch(
     color: $off-black;
     font-size: 0.9rem;
     word-break: break-word;
+    white-space: pre-wrap;
   }
 }
 

--- a/frontend/src/components/dashboard/SourceAssociationBrowser.vue
+++ b/frontend/src/components/dashboard/SourceAssociationBrowser.vue
@@ -265,7 +265,13 @@
                           {{ link.text }}
                         </a>
                       </template>
-                      <span v-else :class="{ 'negated-value': prop.isNegated }">
+                      <span
+                        v-else
+                        :class="{
+                          'negated-value': prop.isNegated,
+                          'pre-wrap': prop.preWrap,
+                        }"
+                      >
                         {{ prop.value }}
                       </span>
                     </td>
@@ -540,6 +546,7 @@ type DetailProperty = {
   value: string;
   isLink?: boolean;
   isNegated?: boolean;
+  preWrap?: boolean;
   links?: { text: string; url: string }[];
 };
 
@@ -625,9 +632,13 @@ const associationProperties = computed((): DetailProperty[] => {
     details.push({ label: "Publications", value: a.publications.join(", ") });
   }
   if (a.supporting_text?.length) {
+    const texts = Array.isArray(a.supporting_text)
+      ? a.supporting_text
+      : [a.supporting_text];
     details.push({
       label: "Supporting Text",
-      value: a.supporting_text.join("\n\n"),
+      value: texts.join("\n\n"),
+      preWrap: true,
     });
   }
   if (a.frequency_qualifier_label || a.frequency_qualifier) {
@@ -1003,7 +1014,6 @@ watch(
     color: $off-black;
     font-size: 0.9rem;
     word-break: break-word;
-    white-space: pre-wrap;
   }
 }
 
@@ -1046,6 +1056,10 @@ watch(
 .negated-value {
   color: $error;
   font-weight: 600;
+}
+
+.pre-wrap {
+  white-space: pre-wrap;
 }
 
 @media (max-width: 768px) {

--- a/frontend/src/pages/node/SectionAssociationDetails.vue
+++ b/frontend/src/pages/node/SectionAssociationDetails.vue
@@ -62,6 +62,23 @@
           </AppLink>
         </AppFlex>
       </AppDetail>
+
+      <AppDetail
+        v-if="association.supporting_text?.length"
+        icon="quote-left"
+        title="Supporting Text"
+        :full="true"
+      >
+        <AppFlex direction="col" gap="small" align-h="left">
+          <blockquote
+            v-for="(text, index) in association.supporting_text"
+            :key="index"
+            class="supporting-text"
+          >
+            {{ text }}
+          </blockquote>
+        </AppFlex>
+      </AppDetail>
     </AppDetails>
   </AppSection>
 </template>
@@ -109,5 +126,12 @@ onMounted(scrollIntoView);
 
 .arrow {
   color: $gray;
+}
+
+.supporting-text {
+  margin: 0;
+  padding: 0.5em 0 0.5em 1em;
+  border-left: 3px solid $light-gray;
+  font-style: italic;
 }
 </style>


### PR DESCRIPTION
## Summary
- Show the `supporting_text` field in the node page association details section as styled blockquotes (with quote-left icon, italic text, left border)
- Show `supporting_text` in the source association browser detail modal as a pre-wrapped text entry in the properties table
- Both sections are conditionally hidden when `supporting_text` is missing or empty

Closes #1292