### PR TITLE
Support deep linking / shareable URLs in the association browser

### DIFF
--- a/frontend/src/components/AppNodeBadge.vue
+++ b/frontend/src/components/AppNodeBadge.vue
@@ -33,11 +33,14 @@
 
 <script setup lang="ts">
 import { computed } from "vue";
+import { useRoute } from "vue-router";
 import { getCategoryIcon, getCategoryLabel } from "@/api/categories";
 import type { Node } from "@/api/model";
 import AppNodeText from "@/components/AppNodeText.vue";
 import { breadcrumbs as currentBreadcrumbs } from "@/global/breadcrumbs";
 import type { Breadcrumb } from "@/global/breadcrumbs";
+
+const route = useRoute();
 
 const { VITE_URL: baseurl } = import.meta.env;
 
@@ -94,7 +97,7 @@ const info = computed(() =>
 
 /** whether to make a link or plain text */
 const isLink = computed(() => {
-  const decodedPath = decodeURIComponent(window.location.pathname);
+  const decodedPath = decodeURIComponent(route.path);
   /** make sure we're not already on the page we'd link to */
   return (
     !decodedPath.endsWith("/" + (props.node.id || "")) &&

--- a/frontend/src/composables/use-source-dashboard.ts
+++ b/frontend/src/composables/use-source-dashboard.ts
@@ -1,7 +1,7 @@
 import { computed, reactive, type ShallowRef } from "vue";
 import { useRoute } from "vue-router";
+import { stringParam, useParam, type Param } from "@/composables/use-param";
 import { RESOURCE_NAME_MAP } from "@/config/resourceNames";
-import { useParam, stringParam, type Param } from "@/composables/use-param";
 
 /** number param that omits the default value from the URL */
 const defaultNumberParam = (defaultValue: number): Param<number> => ({
@@ -96,7 +96,7 @@ export const useAssociationFilters = () => {
       },
     });
   }
-  const filters = reactive(filtersSource) as SourceFilters;
+  const filters = reactive(filtersSource) as unknown as SourceFilters;
 
   const offset = useParam("offset", defaultNumberParam(0), 0);
   const limit = useParam("limit", defaultNumberParam(20), 20);

--- a/frontend/src/composables/use-source-dashboard.ts
+++ b/frontend/src/composables/use-source-dashboard.ts
@@ -1,6 +1,13 @@
-import { computed, reactive, ref } from "vue";
+import { computed, reactive, type ShallowRef } from "vue";
 import { useRoute } from "vue-router";
 import { RESOURCE_NAME_MAP } from "@/config/resourceNames";
+import { useParam, stringParam, type Param } from "@/composables/use-param";
+
+/** number param that omits the default value from the URL */
+const defaultNumberParam = (defaultValue: number): Param<number> => ({
+  parse: (value) => Number(value) || defaultValue,
+  stringify: (value) => (value === defaultValue ? "" : String(value)),
+});
 
 /** filter state for source dashboard */
 export interface SourceFilters {
@@ -17,6 +24,21 @@ export interface SourceFilters {
   primaryKnowledgeSource: string;
   search: string;
 }
+
+const filterKeys: (keyof SourceFilters)[] = [
+  "category",
+  "subjectCategory",
+  "objectCategory",
+  "predicate",
+  "subjectTaxonLabel",
+  "objectTaxonLabel",
+  "knowledgeLevel",
+  "agentType",
+  "providedBy",
+  "negated",
+  "primaryKnowledgeSource",
+  "search",
+];
 
 export const emptyFilters = (): SourceFilters => ({
   category: "",
@@ -56,11 +78,28 @@ const buildFilterQueries = (filters: SourceFilters): string[] => {
   return fqs;
 };
 
-/** shared filter, pagination, and filter-query state (no route dependency) */
+/** shared filter, pagination, and filter-query state synced with URL */
 export const useAssociationFilters = () => {
-  const filters = reactive<SourceFilters>(emptyFilters());
-  const offset = ref(0);
-  const limit = ref(20);
+  /** create URL-synced refs for each filter key */
+  const paramRefs = {} as Record<keyof SourceFilters, ShallowRef<string>>;
+  for (const key of filterKeys) {
+    paramRefs[key] = useParam(key, stringParam(), "");
+  }
+
+  /** reactive filters object backed by URL-synced param refs */
+  const filtersSource: Record<string, unknown> = {};
+  for (const key of filterKeys) {
+    filtersSource[key] = computed({
+      get: () => paramRefs[key].value,
+      set: (v: string) => {
+        paramRefs[key].value = v;
+      },
+    });
+  }
+  const filters = reactive(filtersSource) as SourceFilters;
+
+  const offset = useParam("offset", defaultNumberParam(0), 0);
+  const limit = useParam("limit", defaultNumberParam(20), 20);
 
   const filterQueries = computed(() => buildFilterQueries(filters));
 
@@ -75,7 +114,7 @@ export const useAssociationFilters = () => {
   };
 
   const hasActiveFilters = computed(() =>
-    Object.values(filters).some((v) => v !== ""),
+    filterKeys.some((key) => paramRefs[key].value !== ""),
   );
 
   return {

--- a/frontend/unit/useSourceDashboard.test.ts
+++ b/frontend/unit/useSourceDashboard.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it, vi } from "vitest";
+import { nextTick } from "vue";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { url } from "@/composables/use-param";
 import {
   emptyFilters,
   useAssociationFilters,
@@ -10,6 +12,13 @@ const mockRoute = { params: { infores: "monarchinitiative" } };
 vi.mock("vue-router", () => ({
   useRoute: () => mockRoute,
 }));
+
+/** clear shared URL state between tests to prevent leakage */
+beforeEach(() => {
+  for (const key of Object.keys(url.value)) {
+    delete url.value[key];
+  }
+});
 
 describe("emptyFilters", () => {
   it("returns an object with all empty string values", () => {
@@ -158,5 +167,77 @@ describe("useSourceDashboard", () => {
     clearFilters();
     expect(filters.predicate).toBe("");
     expect(hasActiveFilters.value).toBe(false);
+  });
+});
+
+describe("URL sync (deep linking)", () => {
+  it("setFilter updates URL query params", async () => {
+    const { setFilter } = useAssociationFilters();
+    setFilter("category", "biolink:GeneToPhenotypicFeatureAssociation");
+    await nextTick();
+    expect(url.value.category).toBe(
+      "biolink:GeneToPhenotypicFeatureAssociation",
+    );
+  });
+
+  it("multiple filters are reflected in URL", async () => {
+    const { setFilter } = useAssociationFilters();
+    setFilter("predicate", "biolink:has_phenotype");
+    setFilter("subjectTaxonLabel", "Homo sapiens");
+    await nextTick();
+    expect(url.value.predicate).toBe("biolink:has_phenotype");
+    expect(url.value.subjectTaxonLabel).toBe("Homo sapiens");
+  });
+
+  it("clearFilters removes filter keys from URL", async () => {
+    const { setFilter, clearFilters } = useAssociationFilters();
+    setFilter("category", "biolink:Association");
+    setFilter("predicate", "biolink:has_phenotype");
+    await nextTick();
+    clearFilters();
+    await nextTick();
+    expect(url.value.category).toBeUndefined();
+    expect(url.value.predicate).toBeUndefined();
+  });
+
+  it("initializes filters from existing URL params", async () => {
+    url.value.category = "biolink:Association";
+    url.value.predicate = "biolink:has_phenotype";
+    await nextTick();
+    const { filters } = useAssociationFilters();
+    expect(filters.category).toBe("biolink:Association");
+    expect(filters.predicate).toBe("biolink:has_phenotype");
+  });
+
+  it("offset syncs to URL when non-zero", async () => {
+    const { offset } = useAssociationFilters();
+    offset.value = 40;
+    await nextTick();
+    expect(url.value.offset).toBe("40");
+  });
+
+  it("limit syncs to URL when changed from default", async () => {
+    const { limit } = useAssociationFilters();
+    limit.value = 50;
+    await nextTick();
+    expect(url.value.limit).toBe("50");
+  });
+
+  it("default offset and limit do not appear in URL", async () => {
+    useAssociationFilters();
+    await nextTick();
+    expect(url.value.offset).toBeUndefined();
+    expect(url.value.limit).toBeUndefined();
+  });
+
+  it("setFilter resets offset in URL back to page 1", async () => {
+    const { offset, setFilter } = useAssociationFilters();
+    offset.value = 60;
+    await nextTick();
+    expect(url.value.offset).toBe("60");
+    setFilter("predicate", "biolink:has_phenotype");
+    await nextTick();
+    expect(offset.value).toBe(0);
+    expect(url.value.offset).toBeUndefined();
   });
 });


### PR DESCRIPTION
Closes #1295

## Summary

- Sync association browser filter state with URL query parameters via the existing `useParam` composable, so filtered views are bookmarkable, shareable, and survive page refresh
- Default values (offset=0, limit=20, empty filters) are omitted from the URL to keep it clean
- Changing a filter resets pagination (offset) back to 0 in both state and URL
- Fix `AppNodeBadge` using non-reactive `window.location.pathname` instead of Vue Router's `route.path`, which prevented the `isLink` computed from re-evaluating on client-side navigation

