### PR TITLE
Fix broken documentation links on KG documentation page

### DIFF
--- a/frontend/src/pages/knowledgeGraph/PageDocumentation.vue
+++ b/frontend/src/pages/knowledgeGraph/PageDocumentation.vue
@@ -20,7 +20,7 @@
       </li>
       <li>
         <AppLink
-          to="https://monarch-app.monarchinitiative.org/docs/Sources/"
+          to="https://monarch-app.monarchinitiative.org/Sources/"
           :no-icon="true"
         >
           KG Data Sources
@@ -30,7 +30,7 @@
       </li>
       <li>
         <AppLink
-          to="https://monarch-app.monarchinitiative.org/docs/KG-Build-Process/kg-build-process/"
+          to="https://monarch-app.monarchinitiative.org/KG-Build-Process/kg-build-process/"
           :no-icon="true"
         >
           KG Build Process


### PR DESCRIPTION
## Summary
- Fixed two broken links on the `/kg/documentation` page that were returning 404 errors
- The "KG Data Sources" and "KG Build Process" links had a spurious `/docs/` path segment in their URLs (e.g. `monarch-app.monarchinitiative.org/docs/Sources/` instead of `monarch-app.monarchinitiative.org/Sources/`)

## Test plan
- [ ] Visit `/kg/documentation` and verify "KG Data Sources" link opens correctly
- [ ] Verify "KG Build Process" link opens correctly