### PR TITLE
Correct label from 'Casual' to 'Causal' Genes

### DIFF
--- a/frontend/src/pages/node/SectionClinicalReources.vue
+++ b/frontend/src/pages/node/SectionClinicalReources.vue
@@ -35,7 +35,7 @@
         </div>
 
         <div v-if="node?.causal_gene?.length">
-          <span class="info-label"> Casual Genes : </span>
+          <span class="info-label"> Causal Genes : </span>
           <div class="causal-gene">
             <AppNodeBadge
               v-for="(gene, index) in node?.causal_gene"


### PR DESCRIPTION
Fixing a letter-transposition typo.

### Summary

In the spirit of casual Friday (or is that causal Friday?), fixing letter transposition that would make the related genes rather informal.

### Checks

- [x] No testing affected, this is just the change of a text label.
