### PR TITLE
Fix disease frequency label when subsets is pipe-delimited

### DIFF
--- a/frontend/src/pages/node/SectionOverview.vue
+++ b/frontend/src/pages/node/SectionOverview.vue
@@ -136,7 +136,7 @@
 
         <!-- disease frequecy -->
         <AppDetail v-if="node.category === 'biolink:Disease'" title="Frequency">
-          <span>{{ node?.subsets?.includes("rare") ? "Rare" : "Common" }}</span>
+          <span>{{ frequencyLabel }}</span>
         </AppDetail>
 
         <!-- mappings -->
@@ -238,7 +238,10 @@ const infoForPatients = computed(
 );
 
 const frequencyLabel = computed((): "Rare" | "Common" => {
-  return node.subsets?.includes("rare") ? "Rare" : "Common";
+  // subsets may be a true multi-valued array or a single pipe-delimited string;
+  // split on "|" to handle both
+  const allSubsets = (node.subsets ?? []).flatMap((s) => s.split("|"));
+  return allSubsets.includes("rare") ? "Rare" : "Common";
 });
 
 const { otherMappings, externalRefs } = useClinicalResources(node);


### PR DESCRIPTION
This is something of a temporary fix. It looks like subsets isn't defined in the biolink model (how did we miss that?), so it's moving through the pipeline as a single valued field by default. It's going to be handled in a couple of stages, using the monarch-app schema, closurizer will start to pick it up as a multivalued field, and that'll be enough to make the api happy, being served from denormalized_nodes -> solr nodes index. The duckdb artifact will still be wrong, and will get fixed when the subsets lands in biolink model. 

--- 
## Summary
- Disease pages were always showing **Frequency: Common** even for rare diseases (e.g. [MONDO:0006804](https://beta.monarchinitiative.org/MONDO:0006804)) because the API returns `subsets` as a single-element array containing a pipe-delimited string (e.g. `['gard_rare|ordo_disorder|orphanet_rare|otar|rare']`), so `node.subsets?.includes("rare")` never matched.
- Updated `SectionOverview.vue` to split on `|` before checking, mirroring the pattern already in `SectionCasePhenotypeGrid.vue:148-151`. The check works for both the current pipe-delimited form and a properly-multivalued array, so it will continue to work after the upstream data shape is fixed.
- Also consolidated the inline template check to use the existing `frequencyLabel` computed so there is one source of truth.

