### PR TITLE
Surface monarch-kg source versions in the UI

### DIFF
--- a/backend/src/monarch_py/api/config.py
+++ b/backend/src/monarch_py/api/config.py
@@ -21,6 +21,16 @@ class Settings(BaseModel):
     monarch_api_version: str = os.getenv("MONARCH_API_VERSION", "unknown")
     monarch_kg_source: str = os.getenv("MONARCH_KG_SOURCE", "unknown")
 
+    # Read the build receipt from `data.m.o/monarch-kg-dev/` instead of
+    # `monarch-kg/` when the env var is truthy. Useful while the new-shape
+    # metadata.yaml has only landed on dev. Run as e.g.:
+    #   MONARCH_KG_USE_DEV=1 make dev-api
+    monarch_kg_use_dev: bool = os.getenv("MONARCH_KG_USE_DEV", "").lower() in (
+        "1",
+        "true",
+        "yes",
+    )
+
 
 settings = Settings()
 

--- a/backend/src/monarch_py/api/main.py
+++ b/backend/src/monarch_py/api/main.py
@@ -13,6 +13,7 @@ from monarch_py.api import (
     meta,
     search,
     semsim,
+    sources_versions,
     text_annotation,
 )
 from monarch_py.api.config import semsimian, spacyner, settings
@@ -43,6 +44,7 @@ app.include_router(histopheno.router, prefix=f"{PREFIX}/histopheno")
 app.include_router(meta.router, prefix=PREFIX)
 app.include_router(search.router, prefix=PREFIX)
 app.include_router(semsim.router, prefix=f"{PREFIX}/semsim")
+app.include_router(sources_versions.router, prefix=PREFIX)
 app.include_router(text_annotation.router, prefix=PREFIX)
 
 # Allow CORS

--- a/backend/src/monarch_py/api/sources_versions.py
+++ b/backend/src/monarch_py/api/sources_versions.py
@@ -82,8 +82,6 @@ def _serialize(receipt: ResolvedReceipt) -> dict:
             for producer, entries in receipt.by_producer.items()
         },
         "canonical_producer": receipt.canonical_producer,
-        "disagreements": receipt.disagreements,
-        "version_drift": receipt.version_drift,
     }
 
 

--- a/backend/src/monarch_py/api/sources_versions.py
+++ b/backend/src/monarch_py/api/sources_versions.py
@@ -9,6 +9,7 @@ import requests
 import yaml
 from fastapi import APIRouter, HTTPException
 
+from monarch_py.api.config import settings
 from monarch_py.utils.source_versions import (
     ResolvedReceipt,
     index_receipt,
@@ -87,12 +88,14 @@ def _serialize(receipt: ResolvedReceipt) -> dict:
 
 
 @router.get("/sources/versions")
-def sources_versions(release: str = "latest", dev: bool = False) -> dict:
+def sources_versions(release: str = "latest", dev: bool | None = None) -> dict:
     """Return the resolved version index for a given monarch-kg release.
 
     Default is `latest`, which resolves to the most recent published release
     on `data.monarchinitiative.org`. Specific dates (`2026-05-07`) are also
-    accepted for retrospective lookups. Pass `dev=true` to bypass the
-    production URL entirely and only consult `monarch-kg-dev/`.
+    accepted for retrospective lookups. Pass `dev=true` to read from
+    `monarch-kg-dev/`; otherwise the deployment-wide default applies (set
+    via the `MONARCH_KG_USE_DEV` env var, default false).
     """
-    return _serialize(_fetch_receipt(release, dev=dev))
+    use_dev = settings.monarch_kg_use_dev if dev is None else dev
+    return _serialize(_fetch_receipt(release, dev=use_dev))

--- a/backend/src/monarch_py/api/sources_versions.py
+++ b/backend/src/monarch_py/api/sources_versions.py
@@ -1,0 +1,78 @@
+"""API endpoint exposing per-source version info from the build receipt."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import asdict
+
+import requests
+import yaml
+from fastapi import APIRouter, HTTPException
+
+from monarch_py.utils.source_versions import (
+    ResolvedReceipt,
+    index_receipt,
+)
+from monarch_py.utils.utils import KG_URL
+
+router = APIRouter(tags=["sources"])
+
+# 5-minute TTL on the parsed receipt — release cadence is daily-ish, but we
+# don't want a five-second window between two requests to refetch.
+_CACHE_TTL_SECONDS = 300
+
+_cache: dict[str, tuple[float, ResolvedReceipt]] = {}
+
+
+def _fetch_receipt(release: str = "latest") -> ResolvedReceipt:
+    """Fetch + parse + index `metadata.yaml` for the given release. Cached."""
+    cached = _cache.get(release)
+    if cached and (time.time() - cached[0]) < _CACHE_TTL_SECONDS:
+        return cached[1]
+
+    url = f"{KG_URL}/{release}/metadata.yaml"
+    try:
+        resp = requests.get(url, timeout=15)
+        resp.raise_for_status()
+    except requests.RequestException as e:
+        raise HTTPException(
+            status_code=502,
+            detail=f"Failed to fetch build receipt from {url}: {e}",
+        ) from e
+
+    try:
+        receipt = yaml.safe_load(resp.text)
+    except yaml.YAMLError as e:
+        raise HTTPException(
+            status_code=502,
+            detail=f"Build receipt at {url} is not valid YAML: {e}",
+        ) from e
+
+    resolved = index_receipt(receipt or {})
+    _cache[release] = (time.time(), resolved)
+    return resolved
+
+
+def _serialize(receipt: ResolvedReceipt) -> dict:
+    return {
+        "release": receipt.release,
+        "generated_at": receipt.generated_at,
+        "by_producer": {
+            producer: {infores: asdict(sv) for infores, sv in entries.items()}
+            for producer, entries in receipt.by_producer.items()
+        },
+        "canonical_producer": receipt.canonical_producer,
+        "disagreements": receipt.disagreements,
+        "version_drift": receipt.version_drift,
+    }
+
+
+@router.get("/sources/versions")
+def sources_versions(release: str = "latest") -> dict:
+    """Return the resolved version index for a given monarch-kg release.
+
+    Default is `latest`, which resolves to the most recent published release
+    on `data.monarchinitiative.org`. Specific dates (`2026-05-07`) are also
+    accepted for retrospective lookups.
+    """
+    return _serialize(_fetch_receipt(release))

--- a/backend/src/monarch_py/api/sources_versions.py
+++ b/backend/src/monarch_py/api/sources_versions.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import re
+import threading
 import time
 from dataclasses import asdict
 
@@ -22,7 +24,13 @@ router = APIRouter(tags=["sources"])
 # don't want a five-second window between two requests to refetch.
 _CACHE_TTL_SECONDS = 300
 
+# Release identifiers we accept: `latest`, dated builds (`2026-05-07`), and
+# tagged builds (`v2026-05-07`). Strict enough that the value can't break out
+# of the URL path or include unexpected characters.
+_RELEASE_PATTERN = re.compile(r"^[A-Za-z0-9._-]+$")
+
 _cache: dict[tuple[str, bool], tuple[float, ResolvedReceipt]] = {}
+_cache_lock = threading.Lock()
 
 
 def _fetch_receipt(release: str = "latest", dev: bool = False) -> ResolvedReceipt:
@@ -33,11 +41,17 @@ def _fetch_receipt(release: str = "latest", dev: bool = False) -> ResolvedReceip
     `data.m.o/monarch-kg-dev/...` mirror — handy locally while the
     new-shape receipt is still only landing on dev. Cached for
     `_CACHE_TTL_SECONDS` per (release, dev) pair.
+
+    Cache access is guarded by `_cache_lock`. Two concurrent requests for the
+    same uncached key may both issue the upstream fetch (we don't hold the
+    lock across I/O); whichever finishes second harmlessly overwrites the
+    first. This is much rarer than the in-process race on plain dict access.
     """
     key = (release, dev)
-    cached = _cache.get(key)
-    if cached and (time.time() - cached[0]) < _CACHE_TTL_SECONDS:
-        return cached[1]
+    with _cache_lock:
+        cached = _cache.get(key)
+        if cached and (time.time() - cached[0]) < _CACHE_TTL_SECONDS:
+            return cached[1]
 
     base = KG_DEV_URL if dev else KG_URL
     url = f"{base}/{release}/metadata.yaml"
@@ -69,7 +83,8 @@ def _fetch_receipt(release: str = "latest", dev: bool = False) -> ResolvedReceip
         )
 
     resolved = index_receipt(receipt)
-    _cache[key] = (time.time(), resolved)
+    with _cache_lock:
+        _cache[key] = (time.time(), resolved)
     return resolved
 
 
@@ -95,5 +110,10 @@ def sources_versions(release: str = "latest", dev: bool | None = None) -> dict:
     `monarch-kg-dev/`; otherwise the deployment-wide default applies (set
     via the `MONARCH_KG_USE_DEV` env var, default false).
     """
+    if not _RELEASE_PATTERN.match(release):
+        raise HTTPException(
+            status_code=400,
+            detail="Invalid release identifier; expected alphanumerics, `.`, `_`, or `-`.",
+        )
     use_dev = settings.monarch_kg_use_dev if dev is None else dev
     return _serialize(_fetch_receipt(release, dev=use_dev))

--- a/backend/src/monarch_py/api/sources_versions.py
+++ b/backend/src/monarch_py/api/sources_versions.py
@@ -13,7 +13,7 @@ from monarch_py.utils.source_versions import (
     ResolvedReceipt,
     index_receipt,
 )
-from monarch_py.utils.utils import KG_URL
+from monarch_py.utils.utils import KG_DEV_URL, KG_URL
 
 router = APIRouter(tags=["sources"])
 
@@ -21,35 +21,71 @@ router = APIRouter(tags=["sources"])
 # don't want a five-second window between two requests to refetch.
 _CACHE_TTL_SECONDS = 300
 
-_cache: dict[str, tuple[float, ResolvedReceipt]] = {}
+_cache: dict[tuple[str, bool], tuple[float, ResolvedReceipt]] = {}
 
 
-def _fetch_receipt(release: str = "latest") -> ResolvedReceipt:
-    """Fetch + parse + index `metadata.yaml` for the given release. Cached."""
-    cached = _cache.get(release)
+def _try_url(url: str) -> dict | None:
+    """GET the receipt; return parsed YAML on success, None on missing/legacy."""
+    try:
+        resp = requests.get(url, timeout=15)
+    except requests.RequestException:
+        return None
+    if resp.status_code != 200:
+        return None
+    try:
+        receipt = yaml.safe_load(resp.text)
+    except yaml.YAMLError:
+        return None
+    # The pre-collapse legacy `metadata.yaml` (kg-version + packages + data)
+    # has no top-level `id` — treat as missing so the caller can fall back.
+    if not isinstance(receipt, dict) or "id" not in receipt:
+        return None
+    return receipt
+
+
+def _fetch_receipt(release: str = "latest", dev: bool = False) -> ResolvedReceipt:
+    """Fetch + parse + index `metadata.yaml` for the given release.
+
+    If `dev` is False (the default), tries the production
+    (`data.m.o/monarch-kg/...`) URL first, then transparently falls back
+    to the dev mirror — useful while the new-shape receipt has only
+    landed on dev. `dev=True` skips prod entirely.
+
+    Cached for `_CACHE_TTL_SECONDS` per (release, dev) pair.
+    """
+    key = (release, dev)
+    cached = _cache.get(key)
     if cached and (time.time() - cached[0]) < _CACHE_TTL_SECONDS:
         return cached[1]
 
-    url = f"{KG_URL}/{release}/metadata.yaml"
-    try:
-        resp = requests.get(url, timeout=15)
-        resp.raise_for_status()
-    except requests.RequestException as e:
+    candidates = (
+        [f"{KG_DEV_URL}/{release}/metadata.yaml"]
+        if dev
+        else [
+            f"{KG_URL}/{release}/metadata.yaml",
+            f"{KG_DEV_URL}/{release}/metadata.yaml",
+        ]
+    )
+
+    receipt: dict | None = None
+    last_url = ""
+    for url in candidates:
+        last_url = url
+        receipt = _try_url(url)
+        if receipt is not None:
+            break
+
+    if receipt is None:
         raise HTTPException(
             status_code=502,
-            detail=f"Failed to fetch build receipt from {url}: {e}",
-        ) from e
+            detail=(
+                f"No new-shape build receipt found at any of: {', '.join(candidates)} "
+                "(production receipt may still be the pre-collapse format)."
+            ),
+        )
 
-    try:
-        receipt = yaml.safe_load(resp.text)
-    except yaml.YAMLError as e:
-        raise HTTPException(
-            status_code=502,
-            detail=f"Build receipt at {url} is not valid YAML: {e}",
-        ) from e
-
-    resolved = index_receipt(receipt or {})
-    _cache[release] = (time.time(), resolved)
+    resolved = index_receipt(receipt)
+    _cache[key] = (time.time(), resolved)
     return resolved
 
 
@@ -68,11 +104,12 @@ def _serialize(receipt: ResolvedReceipt) -> dict:
 
 
 @router.get("/sources/versions")
-def sources_versions(release: str = "latest") -> dict:
+def sources_versions(release: str = "latest", dev: bool = False) -> dict:
     """Return the resolved version index for a given monarch-kg release.
 
     Default is `latest`, which resolves to the most recent published release
     on `data.monarchinitiative.org`. Specific dates (`2026-05-07`) are also
-    accepted for retrospective lookups.
+    accepted for retrospective lookups. Pass `dev=true` to bypass the
+    production URL entirely and only consult `monarch-kg-dev/`.
     """
-    return _serialize(_fetch_receipt(release))
+    return _serialize(_fetch_receipt(release, dev=dev))

--- a/backend/src/monarch_py/api/sources_versions.py
+++ b/backend/src/monarch_py/api/sources_versions.py
@@ -24,63 +24,46 @@ _CACHE_TTL_SECONDS = 300
 _cache: dict[tuple[str, bool], tuple[float, ResolvedReceipt]] = {}
 
 
-def _try_url(url: str) -> dict | None:
-    """GET the receipt; return parsed YAML on success, None on missing/legacy."""
-    try:
-        resp = requests.get(url, timeout=15)
-    except requests.RequestException:
-        return None
-    if resp.status_code != 200:
-        return None
-    try:
-        receipt = yaml.safe_load(resp.text)
-    except yaml.YAMLError:
-        return None
-    # The pre-collapse legacy `metadata.yaml` (kg-version + packages + data)
-    # has no top-level `id` — treat as missing so the caller can fall back.
-    if not isinstance(receipt, dict) or "id" not in receipt:
-        return None
-    return receipt
-
-
 def _fetch_receipt(release: str = "latest", dev: bool = False) -> ResolvedReceipt:
     """Fetch + parse + index `metadata.yaml` for the given release.
 
-    If `dev` is False (the default), tries the production
-    (`data.m.o/monarch-kg/...`) URL first, then transparently falls back
-    to the dev mirror — useful while the new-shape receipt has only
-    landed on dev. `dev=True` skips prod entirely.
-
-    Cached for `_CACHE_TTL_SECONDS` per (release, dev) pair.
+    `dev=False` (default) reads from the production
+    `data.m.o/monarch-kg/...` mirror; `dev=True` reads from the
+    `data.m.o/monarch-kg-dev/...` mirror — handy locally while the
+    new-shape receipt is still only landing on dev. Cached for
+    `_CACHE_TTL_SECONDS` per (release, dev) pair.
     """
     key = (release, dev)
     cached = _cache.get(key)
     if cached and (time.time() - cached[0]) < _CACHE_TTL_SECONDS:
         return cached[1]
 
-    candidates = (
-        [f"{KG_DEV_URL}/{release}/metadata.yaml"]
-        if dev
-        else [
-            f"{KG_URL}/{release}/metadata.yaml",
-            f"{KG_DEV_URL}/{release}/metadata.yaml",
-        ]
-    )
+    base = KG_DEV_URL if dev else KG_URL
+    url = f"{base}/{release}/metadata.yaml"
+    try:
+        resp = requests.get(url, timeout=15)
+        resp.raise_for_status()
+    except requests.RequestException as e:
+        raise HTTPException(
+            status_code=502,
+            detail=f"Failed to fetch build receipt from {url}: {e}",
+        ) from e
 
-    receipt: dict | None = None
-    last_url = ""
-    for url in candidates:
-        last_url = url
-        receipt = _try_url(url)
-        if receipt is not None:
-            break
+    try:
+        receipt = yaml.safe_load(resp.text)
+    except yaml.YAMLError as e:
+        raise HTTPException(
+            status_code=502,
+            detail=f"Build receipt at {url} is not valid YAML: {e}",
+        ) from e
 
-    if receipt is None:
+    if not isinstance(receipt, dict) or "id" not in receipt:
         raise HTTPException(
             status_code=502,
             detail=(
-                f"No new-shape build receipt found at any of: {', '.join(candidates)} "
-                "(production receipt may still be the pre-collapse format)."
+                f"Build receipt at {url} doesn't carry a top-level `id` "
+                "(probably the pre-collapse legacy shape). Pass `?dev=true` "
+                "to read from monarch-kg-dev/ in the meantime."
             ),
         )
 

--- a/backend/src/monarch_py/utils/source_versions.py
+++ b/backend/src/monarch_py/utils/source_versions.py
@@ -49,7 +49,12 @@ class SourceVersion:
 
 @dataclass(frozen=True)
 class ResolvedReceipt:
-    """An indexed view of one `metadata.yaml` document."""
+    """An indexed view of one `metadata.yaml` document.
+
+    `frozen=True` blocks reassignment of the fields but not mutation of the
+    contained dicts — instances of this class are returned directly from the
+    receipt cache, so callers must treat the dicts as read-only.
+    """
 
     release: str
     generated_at: str

--- a/backend/src/monarch_py/utils/source_versions.py
+++ b/backend/src/monarch_py/utils/source_versions.py
@@ -138,18 +138,30 @@ def _pick_canonical_producer(
         suffix = infores.split(":", 1)[-1] if ":" in infores else infores
         producers_with = [p for p, m in by_producer.items() if infores in m]
 
-        # 1. Self-named ingest match (hgnc → hgnc-ingest).
+        # 1. Self-named ingest match. Producer ids may be `hgnc-ingest` (legacy
+        # ingests.yaml id) or `infores:hgnc` (post-collapse Release.id).
         self_named = next(
-            (p for p in producers_with if p == suffix or p == f"{suffix}-ingest"),
+            (
+                p
+                for p in producers_with
+                if p in {suffix, f"{suffix}-ingest", infores}
+            ),
             None,
         )
         if self_named:
             canonical[infores] = self_named
             continue
 
-        # 2. phenio-bearing producer for ontology-style infores.
+        # 2. phenio-bearing producer for ontology-style infores. The producer
+        # is either *named* phenio (id `kg-phenio` / `infores:phenio`) or has
+        # `infores:phenio` somewhere in its subtree.
         phenio_bearer = next(
-            (p for p in producers_with if "phenio" in by_producer[p]),
+            (
+                p
+                for p in producers_with
+                if p in {"kg-phenio", "infores:phenio"}
+                or "infores:phenio" in by_producer[p]
+            ),
             None,
         )
         if phenio_bearer:

--- a/backend/src/monarch_py/utils/source_versions.py
+++ b/backend/src/monarch_py/utils/source_versions.py
@@ -59,8 +59,6 @@ class ResolvedReceipt:
     # infores in node-level lookups). Built from the heuristic in
     # `_pick_canonical_producer`.
     canonical_producer: dict[str, str]
-    disagreements: list[dict]
-    version_drift: list[dict]
 
 
 def index_receipt(receipt: dict) -> ResolvedReceipt:
@@ -82,8 +80,6 @@ def index_receipt(receipt: dict) -> ResolvedReceipt:
         generated_at=receipt.get("generated_at") or "",
         by_producer=by_producer,
         canonical_producer=canonical_producer,
-        disagreements=list(receipt.get("disagreements") or []),
-        version_drift=list(receipt.get("version_drift") or []),
     )
 
 

--- a/backend/src/monarch_py/utils/source_versions.py
+++ b/backend/src/monarch_py/utils/source_versions.py
@@ -1,0 +1,231 @@
+"""Resolve per-source version info from the build receipt (metadata.yaml).
+
+The receipt is a recursive `Release` (kozahub-metadata-schema): each ingest
+declares the upstream sources it consumed, and aggregators (e.g. alliance-
+ingest) may further nest per-component sub-sources (e.g. infores:zfin
+inside infores:agr).
+
+Two lookup paths consumers care about:
+
+- Edge-level (aggregator-aware): given an edge's `aggregator_knowledge_source`
+  and `primary_knowledge_source`, find the producing ingest, descend into its
+  subtree, and look up the primary. Falls back to the aggregator's own
+  version when the per-component sub-sources haven't been declared yet.
+
+- Node-level (canonical): given an `infores:*`, return the version of the
+  source-as-it-appears-in-the-merged-KG. Most ontology terms come through
+  phenio (under kg-phenio); most data sources come from their self-named
+  ingest (`infores:hgnc` → `hgnc-ingest`). The resolver picks one path per
+  infores using that heuristic.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+# `infores:monarchinitiative` always shows up as an aggregator on edges (we're
+# the final aggregator). It carries no upstream-version information beyond
+# the build's own date, so consumers strip it before edge resolution.
+MONARCH_AGGREGATOR_INFORES = "infores:monarchinitiative"
+
+
+@dataclass(frozen=True)
+class SourceVersion:
+    """A resolved version record for one (producer, infores) tuple."""
+
+    infores: str
+    name: str
+    version: str
+    version_method: str
+    retrieved_at: str
+    urls: tuple[str, ...]
+    # Path of intermediate-build ids between the top-level ingest and this
+    # entry, e.g. ("infores:agr",) when this is `infores:zfin` nested under
+    # `infores:agr` in alliance-ingest's subtree. Empty tuple when this is
+    # a direct child of the producer ingest.
+    via: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ResolvedReceipt:
+    """An indexed view of one `metadata.yaml` document."""
+
+    release: str
+    generated_at: str
+    # producer-ingest id -> infores -> SourceVersion
+    by_producer: dict[str, dict[str, SourceVersion]]
+    # infores -> producer-ingest id (the producer chosen as canonical for that
+    # infores in node-level lookups). Built from the heuristic in
+    # `_pick_canonical_producer`.
+    canonical_producer: dict[str, str]
+    disagreements: list[dict]
+    version_drift: list[dict]
+
+
+def index_receipt(receipt: dict) -> ResolvedReceipt:
+    """Walk a parsed `metadata.yaml` and build the resolution index."""
+    by_producer: dict[str, dict[str, SourceVersion]] = {}
+
+    for ingest in receipt.get("sources") or []:
+        ingest_id = ingest.get("id")
+        if not ingest_id:
+            continue
+        flat: dict[str, SourceVersion] = {}
+        _flatten_ingest(ingest, flat, via=())
+        by_producer[ingest_id] = flat
+
+    canonical_producer = _pick_canonical_producer(by_producer)
+
+    return ResolvedReceipt(
+        release=receipt.get("version") or "",
+        generated_at=receipt.get("generated_at") or "",
+        by_producer=by_producer,
+        canonical_producer=canonical_producer,
+        disagreements=list(receipt.get("disagreements") or []),
+        version_drift=list(receipt.get("version_drift") or []),
+    )
+
+
+def _flatten_ingest(
+    node: dict,
+    out: dict[str, SourceVersion],
+    via: tuple[str, ...],
+) -> None:
+    """Walk a single ingest's subtree, populating `out` with one entry per
+    `infores:*` reached. The `via` chain captures intermediate-build ids
+    between the ingest root and the current entry."""
+    for child in node.get("sources") or []:
+        cid = child.get("id")
+        if not cid:
+            continue
+        # Every node with an id contributes a SourceVersion record. Even
+        # intermediate builds (e.g. `infores:agr` with nested per-MOD
+        # entries) are looked up by callers as the bundle-level fallback.
+        out[cid] = SourceVersion(
+            infores=cid,
+            name=child.get("name") or "",
+            version=child.get("version") or "",
+            version_method=child.get("version_method") or "",
+            retrieved_at=child.get("retrieved_at") or "",
+            urls=tuple(child.get("urls") or ()),
+            via=via,
+        )
+        # Recurse with this id appended to the via path so deeper entries
+        # know they're nested below it.
+        _flatten_ingest(child, out, via=(*via, cid))
+
+
+def _pick_canonical_producer(
+    by_producer: dict[str, dict[str, SourceVersion]],
+) -> dict[str, str]:
+    """For each infores, choose one producer ingest as canonical.
+
+    Heuristic, in order of preference:
+      1. An ingest whose id matches the infores' suffix (`infores:hgnc` →
+         `hgnc-ingest`). Direct authoritative provider.
+      2. Otherwise, an ingest whose subtree contains a `phenio` build
+         (typically `kg-phenio`). All ontology terms in the merged KG come
+         through phenio.
+      3. Otherwise, first-seen producer.
+    """
+    all_infores: set[str] = set()
+    for fmap in by_producer.values():
+        all_infores.update(fmap.keys())
+
+    canonical: dict[str, str] = {}
+    for infores in all_infores:
+        suffix = infores.split(":", 1)[-1] if ":" in infores else infores
+        producers_with = [p for p, m in by_producer.items() if infores in m]
+
+        # 1. Self-named ingest match (hgnc → hgnc-ingest).
+        self_named = next(
+            (p for p in producers_with if p == suffix or p == f"{suffix}-ingest"),
+            None,
+        )
+        if self_named:
+            canonical[infores] = self_named
+            continue
+
+        # 2. phenio-bearing producer for ontology-style infores.
+        phenio_bearer = next(
+            (p for p in producers_with if "phenio" in by_producer[p]),
+            None,
+        )
+        if phenio_bearer:
+            canonical[infores] = phenio_bearer
+            continue
+
+        # 3. Fallback.
+        canonical[infores] = producers_with[0]
+
+    return canonical
+
+
+def resolve_for_edge(
+    receipt: ResolvedReceipt,
+    primary_knowledge_source: str | None,
+    aggregator_knowledge_sources: Iterable[str] | None,
+) -> SourceVersion | None:
+    """Edge-level version lookup.
+
+    Walks `aggregator_knowledge_sources`, drops `infores:monarchinitiative`,
+    and uses the first remaining aggregator to identify the producing ingest.
+    Inside that ingest's subtree, looks up the primary infores; falls back to
+    the aggregator's own bundle-level entry if the primary isn't nested.
+
+    When no non-monarch aggregator is present (direct ingest), looks the
+    primary up across all producers and uses the canonical match.
+    """
+    aggregators = [
+        a
+        for a in (aggregator_knowledge_sources or ())
+        if a and a != MONARCH_AGGREGATOR_INFORES
+    ]
+
+    if aggregators:
+        # Walk aggregators in declaration order; first one whose producer we
+        # can identify wins. (Most edges have exactly one non-monarch agg.)
+        for agg in aggregators:
+            producer = _producer_with_infores(receipt, agg)
+            if producer is None:
+                continue
+            inner = receipt.by_producer.get(producer, {})
+            # Prefer the per-component version when nested.
+            if primary_knowledge_source and primary_knowledge_source in inner:
+                return inner[primary_knowledge_source]
+            # Fall back to the bundle-level aggregator entry.
+            return inner.get(agg)
+        return None
+
+    # No non-monarch aggregator: edge came from a direct ingest. Look the
+    # primary up under its canonical producer.
+    if not primary_knowledge_source:
+        return None
+    canonical = receipt.canonical_producer.get(primary_knowledge_source)
+    if canonical is None:
+        return None
+    return receipt.by_producer.get(canonical, {}).get(primary_knowledge_source)
+
+
+def resolve_for_infores(
+    receipt: ResolvedReceipt,
+    infores: str,
+) -> SourceVersion | None:
+    """Node-level version lookup. Uses the canonical-producer heuristic."""
+    canonical = receipt.canonical_producer.get(infores)
+    if canonical is None:
+        return None
+    return receipt.by_producer.get(canonical, {}).get(infores)
+
+
+def _producer_with_infores(
+    receipt: ResolvedReceipt,
+    infores: str,
+) -> str | None:
+    """Find the producer-ingest id that has this infores in its subtree.
+    First match wins; ambiguity is rare in practice (one ingest per agg)."""
+    for producer, fmap in receipt.by_producer.items():
+        if infores in fmap:
+            return producer
+    return None

--- a/backend/tests/unit/test_source_versions.py
+++ b/backend/tests/unit/test_source_versions.py
@@ -222,10 +222,3 @@ def test_resolve_for_infores_data_source():
     assert sv.via == ()
 
 
-def test_index_carries_top_level_disagreements_and_drift():
-    receipt_doc = _receipt()
-    receipt_doc["disagreements"] = [{"id": "infores:foo"}]
-    receipt_doc["version_drift"] = [{"id": "infores:bar"}]
-    receipt = index_receipt(receipt_doc)
-    assert receipt.disagreements == [{"id": "infores:foo"}]
-    assert receipt.version_drift == [{"id": "infores:bar"}]

--- a/backend/tests/unit/test_source_versions.py
+++ b/backend/tests/unit/test_source_versions.py
@@ -1,0 +1,231 @@
+"""Tests for monarch_py.utils.source_versions."""
+
+from monarch_py.utils.source_versions import (
+    MONARCH_AGGREGATOR_INFORES,
+    index_receipt,
+    resolve_for_edge,
+    resolve_for_infores,
+)
+
+
+def _receipt():
+    """Synthetic receipt covering the three resolution cases.
+
+    - alliance-ingest: aggregator (`infores:agr`) WITH per-MOD nesting (the
+      target shape after alliance-ingest#10 lands).
+    - hgnc-ingest: direct primary ingest (no aggregator chain).
+    - kg-phenio: composite ingest with phenio nested under it; phenio in
+      turn carries ontology leaves.
+    - alliance-disease-association-ingest: aggregator WITHOUT per-MOD
+      nesting (today's shape — exercises the bundle-level fallback).
+    """
+    return {
+        "id": "monarch-kg",
+        "version": "2026-05-07",
+        "generated_at": "2026-05-07T16:11:30Z",
+        "sources": [
+            {
+                "id": "alliance-ingest",
+                "version": "8.3.0",
+                "sources": [
+                    {
+                        "id": "infores:agr",
+                        "name": "Alliance of Genome Resources",
+                        "version": "8.3.0",
+                        "version_method": "alliance_fms_api",
+                        "sources": [
+                            {
+                                "id": "infores:zfin",
+                                "name": "ZFIN",
+                                "version": "2026-04-15",
+                                "version_method": "alliance_fms_submission",
+                                "urls": ["https://fms.alliancegenome.org/.../zfin"],
+                            },
+                            {
+                                "id": "infores:mgi",
+                                "name": "MGI",
+                                "version": "2026-04-08",
+                                "version_method": "alliance_fms_submission",
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                "id": "hgnc-ingest",
+                "version": "2026-05-01",
+                "sources": [
+                    {
+                        "id": "infores:hgnc",
+                        "name": "HUGO Gene Nomenclature Committee",
+                        "version": "2026-05-01",
+                        "version_method": "http_last_modified",
+                    },
+                ],
+            },
+            {
+                "id": "alliance-disease-association-ingest",
+                "version": "8.3.0",
+                "sources": [
+                    {
+                        "id": "infores:agr",
+                        "name": "Alliance of Genome Resources",
+                        "version": "8.3.0",
+                        "version_method": "alliance_fms_api",
+                        # Crucially, no per-MOD nesting yet.
+                    },
+                ],
+            },
+            {
+                "id": "kg-phenio",
+                "version": "v2026-05-06",
+                "sources": [
+                    {
+                        "id": "phenio",
+                        "name": "PHENIO",
+                        "version": "v2026-05-06",
+                        "version_method": "github_release_api",
+                        "sources": [
+                            {
+                                "id": "infores:mondo",
+                                "name": "MONDO",
+                                "version": "2026-04-01",
+                                "version_method": "owl_version_iri",
+                            },
+                            {
+                                "id": "infores:hp",
+                                "name": "HP",
+                                "version": "2026-04-15",
+                                "version_method": "owl_version_iri",
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
+        "disagreements": [],
+        "version_drift": [],
+    }
+
+
+def test_index_receipt_groups_by_producer():
+    receipt = index_receipt(_receipt())
+    assert set(receipt.by_producer) == {
+        "alliance-ingest",
+        "hgnc-ingest",
+        "alliance-disease-association-ingest",
+        "kg-phenio",
+    }
+    # alliance-ingest's flat index should include both the aggregator entry
+    # AND its per-MOD nested entries.
+    alliance = receipt.by_producer["alliance-ingest"]
+    assert "infores:agr" in alliance
+    assert "infores:zfin" in alliance
+    assert "infores:mgi" in alliance
+    # kg-phenio's index reaches the ontology leaves through phenio.
+    kgp = receipt.by_producer["kg-phenio"]
+    assert "infores:mondo" in kgp
+    assert kgp["infores:mondo"].via == ("phenio",)
+
+
+def test_canonical_producer_prefers_self_named_ingest():
+    receipt = index_receipt(_receipt())
+    assert receipt.canonical_producer["infores:hgnc"] == "hgnc-ingest"
+
+
+def test_canonical_producer_prefers_phenio_for_ontologies():
+    receipt = index_receipt(_receipt())
+    assert receipt.canonical_producer["infores:mondo"] == "kg-phenio"
+    assert receipt.canonical_producer["infores:hp"] == "kg-phenio"
+
+
+def test_resolve_for_edge_aggregator_with_nested_mod():
+    """ZFIN edge via AGR — picks the per-MOD entry from alliance-ingest."""
+    receipt = index_receipt(_receipt())
+    sv = resolve_for_edge(
+        receipt,
+        primary_knowledge_source="infores:zfin",
+        aggregator_knowledge_sources=["infores:agr", MONARCH_AGGREGATOR_INFORES],
+    )
+    assert sv is not None
+    assert sv.infores == "infores:zfin"
+    assert sv.version == "2026-04-15"
+    assert sv.version_method == "alliance_fms_submission"
+    assert sv.via == ("infores:agr",)
+
+
+def test_resolve_for_edge_aggregator_without_nesting():
+    """ZFIN edge via the alliance-disease-association-ingest path — no
+    per-MOD nesting yet, so falls back to AGR's bundle-level entry."""
+    receipt = index_receipt(_receipt())
+    # Construct a hypothetical edge that came through AGR via the
+    # disease-only ingest, where infores:zfin isn't nested.
+    receipt.by_producer["alliance-ingest"].pop("infores:zfin")
+    receipt.by_producer["alliance-ingest"].pop("infores:mgi")
+    sv = resolve_for_edge(
+        receipt,
+        primary_knowledge_source="infores:zfin",
+        aggregator_knowledge_sources=["infores:agr", MONARCH_AGGREGATOR_INFORES],
+    )
+    assert sv is not None
+    assert sv.infores == "infores:agr"  # fell through to bundle-level
+    assert sv.version == "8.3.0"
+
+
+def test_resolve_for_edge_direct_ingest_no_aggregator():
+    """HGNC gene from hgnc-ingest — only monarch is the aggregator."""
+    receipt = index_receipt(_receipt())
+    sv = resolve_for_edge(
+        receipt,
+        primary_knowledge_source="infores:hgnc",
+        aggregator_knowledge_sources=[MONARCH_AGGREGATOR_INFORES],
+    )
+    assert sv is not None
+    assert sv.infores == "infores:hgnc"
+    assert sv.version == "2026-05-01"
+
+
+def test_resolve_for_edge_no_aggregators_at_all():
+    receipt = index_receipt(_receipt())
+    sv = resolve_for_edge(
+        receipt,
+        primary_knowledge_source="infores:hgnc",
+        aggregator_knowledge_sources=None,
+    )
+    assert sv is not None
+    assert sv.infores == "infores:hgnc"
+
+
+def test_resolve_for_edge_unknown_primary_returns_none():
+    receipt = index_receipt(_receipt())
+    sv = resolve_for_edge(
+        receipt,
+        primary_knowledge_source="infores:never-heard-of",
+        aggregator_knowledge_sources=[MONARCH_AGGREGATOR_INFORES],
+    )
+    assert sv is None
+
+
+def test_resolve_for_infores_ontology():
+    receipt = index_receipt(_receipt())
+    sv = resolve_for_infores(receipt, "infores:mondo")
+    assert sv is not None
+    assert sv.version == "2026-04-01"
+    assert sv.via == ("phenio",)
+
+
+def test_resolve_for_infores_data_source():
+    receipt = index_receipt(_receipt())
+    sv = resolve_for_infores(receipt, "infores:hgnc")
+    assert sv is not None
+    assert sv.version == "2026-05-01"
+    assert sv.via == ()
+
+
+def test_index_carries_top_level_disagreements_and_drift():
+    receipt_doc = _receipt()
+    receipt_doc["disagreements"] = [{"id": "infores:foo"}]
+    receipt_doc["version_drift"] = [{"id": "infores:bar"}]
+    receipt = index_receipt(receipt_doc)
+    assert receipt.disagreements == [{"id": "infores:foo"}]
+    assert receipt.version_drift == [{"id": "infores:bar"}]

--- a/backend/tests/unit/test_source_versions.py
+++ b/backend/tests/unit/test_source_versions.py
@@ -155,13 +155,31 @@ def test_resolve_for_edge_aggregator_with_nested_mod():
 
 
 def test_resolve_for_edge_aggregator_without_nesting():
-    """ZFIN edge via the alliance-disease-association-ingest path — no
-    per-MOD nesting yet, so falls back to AGR's bundle-level entry."""
-    receipt = index_receipt(_receipt())
-    # Construct a hypothetical edge that came through AGR via the
-    # disease-only ingest, where infores:zfin isn't nested.
-    receipt.by_producer["alliance-ingest"].pop("infores:zfin")
-    receipt.by_producer["alliance-ingest"].pop("infores:mgi")
+    """ZFIN edge via an aggregator path with no per-MOD nesting — falls back
+    to AGR's bundle-level entry. Built as its own receipt rather than
+    mutating the shared fixture, so the test can't accidentally corrupt
+    cached state (`ResolvedReceipt.by_producer` is a live dict)."""
+    receipt = index_receipt(
+        {
+            "id": "monarch-kg",
+            "version": "2026-05-07",
+            "sources": [
+                {
+                    "id": "alliance-disease-association-ingest",
+                    "version": "8.3.0",
+                    "sources": [
+                        {
+                            "id": "infores:agr",
+                            "name": "Alliance of Genome Resources",
+                            "version": "8.3.0",
+                            "version_method": "alliance_fms_api",
+                            # No per-MOD nesting.
+                        },
+                    ],
+                },
+            ],
+        }
+    )
     sv = resolve_for_edge(
         receipt,
         primary_knowledge_source="infores:zfin",

--- a/backend/tests/unit/test_sources_versions_api.py
+++ b/backend/tests/unit/test_sources_versions_api.py
@@ -141,6 +141,18 @@ def test_legacy_shape_without_top_level_id_returns_502(client):
     assert "dev=true" in r.json()["detail"]
 
 
+def test_release_with_path_traversal_returns_400(client):
+    """The `release` query param is interpolated into the upstream URL —
+    reject anything that could break out of the expected path segment."""
+    with patch("monarch_py.api.sources_versions.requests.get") as g:
+        r = client.get(
+            "/v3/api/sources/versions",
+            params={"release": "../latest"},
+        )
+    assert r.status_code == 400
+    g.assert_not_called()
+
+
 def test_settings_default_drives_dev_when_flag_unset(client):
     """When the client passes no `dev` query param, the route falls back to
     the `MONARCH_KG_USE_DEV` env-var-derived setting."""

--- a/backend/tests/unit/test_sources_versions_api.py
+++ b/backend/tests/unit/test_sources_versions_api.py
@@ -1,0 +1,150 @@
+"""Unit tests for the /sources/versions FastAPI route.
+
+Covers HTTP/caching behavior in `monarch_py.api.sources_versions`. The
+underlying resolution logic is exercised in `test_source_versions.py`.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+from fastapi.testclient import TestClient
+
+from monarch_py.api import sources_versions as route
+from monarch_py.api.main import app
+
+VALID_RECEIPT_YAML = """\
+id: monarch-kg
+version: 2026-05-07
+generated_at: "2026-05-07T16:11:30Z"
+sources:
+  - id: hgnc-ingest
+    version: 2026-05-01
+    sources:
+      - id: infores:hgnc
+        name: HUGO Gene Nomenclature Committee
+        version: 2026-05-01
+        version_method: http_last_modified
+"""
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    """Reset the module-level receipt cache between tests."""
+    route._cache.clear()
+    yield
+    route._cache.clear()
+
+
+def _ok_response(text: str = VALID_RECEIPT_YAML):
+    resp = MagicMock()
+    resp.text = text
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+def test_endpoint_returns_serialized_receipt(client):
+    with patch("monarch_py.api.sources_versions.requests.get", return_value=_ok_response()) as g:
+        r = client.get("/v3/api/sources/versions")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["release"] == "2026-05-07"
+    assert body["generated_at"] == "2026-05-07T16:11:30Z"
+    assert body["by_producer"]["hgnc-ingest"]["infores:hgnc"]["version"] == "2026-05-01"
+    assert body["canonical_producer"]["infores:hgnc"] == "hgnc-ingest"
+    # Dropped from the response — confirm they don't leak back in.
+    assert "disagreements" not in body
+    assert "version_drift" not in body
+    g.assert_called_once()
+    assert "monarch-kg/latest/metadata.yaml" in g.call_args.args[0]
+
+
+def test_endpoint_caches_within_ttl(client):
+    with patch("monarch_py.api.sources_versions.requests.get", return_value=_ok_response()) as g:
+        client.get("/v3/api/sources/versions")
+        client.get("/v3/api/sources/versions")
+    # Second call should be served from the in-memory cache.
+    assert g.call_count == 1
+
+
+def test_endpoint_refetches_when_ttl_expired(client):
+    # Seed the cache with an entry older than the TTL by patching time.
+    with patch("monarch_py.api.sources_versions.requests.get", return_value=_ok_response()) as g:
+        with patch("monarch_py.api.sources_versions.time.time", return_value=0.0):
+            client.get("/v3/api/sources/versions")
+        # Jump past the TTL window.
+        with patch(
+            "monarch_py.api.sources_versions.time.time",
+            return_value=route._CACHE_TTL_SECONDS + 1,
+        ):
+            client.get("/v3/api/sources/versions")
+    assert g.call_count == 2
+
+
+def test_dev_flag_hits_dev_mirror(client):
+    with patch("monarch_py.api.sources_versions.requests.get", return_value=_ok_response()) as g:
+        r = client.get("/v3/api/sources/versions", params={"dev": "true"})
+    assert r.status_code == 200
+    assert "monarch-kg-dev/latest/metadata.yaml" in g.call_args.args[0]
+
+
+def test_dev_flag_caches_separately_from_prod(client):
+    """Dev and prod responses share the same `release` but are keyed
+    independently — flipping the flag should trigger a refetch."""
+    with patch("monarch_py.api.sources_versions.requests.get", return_value=_ok_response()) as g:
+        client.get("/v3/api/sources/versions")
+        client.get("/v3/api/sources/versions", params={"dev": "true"})
+    assert g.call_count == 2
+
+
+def test_network_error_returns_502(client):
+    err = requests.ConnectionError("network down")
+    with patch("monarch_py.api.sources_versions.requests.get", side_effect=err):
+        r = client.get("/v3/api/sources/versions")
+    assert r.status_code == 502
+    assert "Failed to fetch build receipt" in r.json()["detail"]
+
+
+def test_http_error_returns_502(client):
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock(side_effect=requests.HTTPError("404 Not Found"))
+    with patch("monarch_py.api.sources_versions.requests.get", return_value=resp):
+        r = client.get("/v3/api/sources/versions", params={"release": "1900-01-01"})
+    assert r.status_code == 502
+
+
+def test_invalid_yaml_returns_502(client):
+    with patch(
+        "monarch_py.api.sources_versions.requests.get",
+        return_value=_ok_response(text="this: is: not: valid: yaml: : :"),
+    ):
+        r = client.get("/v3/api/sources/versions")
+    assert r.status_code == 502
+    assert "not valid YAML" in r.json()["detail"]
+
+
+def test_legacy_shape_without_top_level_id_returns_502(client):
+    """Pre-collapse receipts lacked a top-level `id`; the route should reject
+    them with a 502 pointing the caller at `?dev=true`."""
+    legacy = "sources:\n  - id: hgnc-ingest\n    version: 2026-05-01\n"
+    with patch(
+        "monarch_py.api.sources_versions.requests.get",
+        return_value=_ok_response(text=legacy),
+    ):
+        r = client.get("/v3/api/sources/versions")
+    assert r.status_code == 502
+    assert "dev=true" in r.json()["detail"]
+
+
+def test_settings_default_drives_dev_when_flag_unset(client):
+    """When the client passes no `dev` query param, the route falls back to
+    the `MONARCH_KG_USE_DEV` env-var-derived setting."""
+    with patch("monarch_py.api.sources_versions.requests.get", return_value=_ok_response()) as g:
+        with patch.object(route.settings, "monarch_kg_use_dev", True):
+            client.get("/v3/api/sources/versions")
+    assert "monarch-kg-dev/" in g.call_args.args[0]

--- a/frontend/src/api/source-versions.ts
+++ b/frontend/src/api/source-versions.ts
@@ -1,0 +1,40 @@
+import { apiUrl, request } from "@/api";
+
+/** One resolved version record from the build receipt. */
+export interface SourceVersion {
+  infores: string;
+  name: string;
+  version: string;
+  version_method: string;
+  retrieved_at: string;
+  urls: string[];
+  /**
+   * Path of intermediate-build ids between the producing ingest and this
+   * entry. e.g. ["infores:agr"] when this is `infores:zfin` nested under
+   * `infores:agr` in alliance-ingest's subtree.
+   */
+  via: string[];
+}
+
+/** Response from GET /sources/versions. */
+export interface SourcesVersionsResponse {
+  release: string;
+  generated_at: string;
+  /** producer-ingest id → infores → SourceVersion */
+  by_producer: Record<string, Record<string, SourceVersion>>;
+  /** infores → producer-ingest id chosen as canonical for node-level lookup */
+  canonical_producer: Record<string, string>;
+  disagreements: Array<Record<string, unknown>>;
+  version_drift: Array<Record<string, unknown>>;
+}
+
+/** `infores:monarchinitiative` is always present as an aggregator on edges
+ * we produced; consumers strip it before edge resolution. */
+export const MONARCH_AGGREGATOR_INFORES = "infores:monarchinitiative";
+
+export const getSourcesVersions = async (
+  release = "latest",
+): Promise<SourcesVersionsResponse> => {
+  const url = `${apiUrl}/sources/versions?release=${encodeURIComponent(release)}`;
+  return await request<SourcesVersionsResponse>(url);
+};

--- a/frontend/src/api/source-versions.ts
+++ b/frontend/src/api/source-versions.ts
@@ -9,9 +9,9 @@ export interface SourceVersion {
   retrieved_at: string;
   urls: string[];
   /**
-   * Path of intermediate-build ids between the producing ingest and this
-   * entry. e.g. ["infores:agr"] when this is `infores:zfin` nested under
-   * `infores:agr` in alliance-ingest's subtree.
+   * Path of intermediate-build ids between the producing ingest and this entry.
+   * e.g. ["infores:agr"] when this is `infores:zfin` nested under `infores:agr`
+   * in alliance-ingest's subtree.
    */
   via: string[];
 }
@@ -24,12 +24,12 @@ export interface SourcesVersionsResponse {
   by_producer: Record<string, Record<string, SourceVersion>>;
   /** infores → producer-ingest id chosen as canonical for node-level lookup */
   canonical_producer: Record<string, string>;
-  disagreements: Array<Record<string, unknown>>;
-  version_drift: Array<Record<string, unknown>>;
 }
 
-/** `infores:monarchinitiative` is always present as an aggregator on edges
- * we produced; consumers strip it before edge resolution. */
+/**
+ * `infores:monarchinitiative` is always present as an aggregator on edges we
+ * produced; consumers strip it before edge resolution.
+ */
 export const MONARCH_AGGREGATOR_INFORES = "infores:monarchinitiative";
 
 export const getSourcesVersions = async (

--- a/frontend/src/api/source-versions.ts
+++ b/frontend/src/api/source-versions.ts
@@ -36,8 +36,10 @@ export const getSourcesVersions = async (
   release = "latest",
   dev = import.meta.env.DEV,
 ): Promise<SourcesVersionsResponse> => {
-  const params = new URLSearchParams({ release });
-  if (dev) params.set("dev", "true");
-  const url = `${apiUrl}/sources/versions?${params.toString()}`;
-  return await request<SourcesVersionsResponse>(url);
+  const params: Record<string, string> = { release };
+  if (dev) params.dev = "true";
+  return await request<SourcesVersionsResponse>(
+    `${apiUrl}/sources/versions`,
+    params,
+  );
 };

--- a/frontend/src/api/source-versions.ts
+++ b/frontend/src/api/source-versions.ts
@@ -34,7 +34,10 @@ export const MONARCH_AGGREGATOR_INFORES = "infores:monarchinitiative";
 
 export const getSourcesVersions = async (
   release = "latest",
+  dev = import.meta.env.DEV,
 ): Promise<SourcesVersionsResponse> => {
-  const url = `${apiUrl}/sources/versions?release=${encodeURIComponent(release)}`;
+  const params = new URLSearchParams({ release });
+  if (dev) params.set("dev", "true");
+  const url = `${apiUrl}/sources/versions?${params.toString()}`;
   return await request<SourcesVersionsResponse>(url);
 };

--- a/frontend/src/composables/use-source-versions.ts
+++ b/frontend/src/composables/use-source-versions.ts
@@ -1,0 +1,153 @@
+import { computed, ref } from "vue";
+import {
+  MONARCH_AGGREGATOR_INFORES,
+  type SourceVersion,
+  type SourcesVersionsResponse,
+  getSourcesVersions,
+} from "@/api/source-versions";
+
+/**
+ * Edge-level resolution: given an edge's primary + aggregator knowledge
+ * sources, return the most precise version we can claim about the bytes
+ * actually in the KG.
+ *
+ * Priority:
+ *   1. The first non-monarch aggregator identifies the producing ingest.
+ *      Look up the primary inside that ingest's subtree → per-component
+ *      version (the `(producer, primary)` composite key).
+ *   2. If the primary isn't nested there, fall back to the aggregator's
+ *      bundle-level entry — accurate as a date-bound on the data.
+ *   3. If only monarch is the aggregator, the edge came from a direct
+ *      ingest; look the primary up under its canonical producer.
+ */
+function lookupForEdge(
+  data: SourcesVersionsResponse | null,
+  primary: string | null | undefined,
+  aggregators: ReadonlyArray<string> | null | undefined,
+): SourceVersion | null {
+  if (!data) return null;
+
+  const realAggregators = (aggregators ?? []).filter(
+    (a) => a && a !== MONARCH_AGGREGATOR_INFORES,
+  );
+
+  if (realAggregators.length > 0) {
+    for (const agg of realAggregators) {
+      const producer = producerWith(data, agg);
+      if (!producer) continue;
+      const inner = data.by_producer[producer] ?? {};
+      if (primary && inner[primary]) return inner[primary];
+      return inner[agg] ?? null;
+    }
+    return null;
+  }
+
+  if (!primary) return null;
+  const canonical = data.canonical_producer[primary];
+  if (!canonical) return null;
+  return data.by_producer[canonical]?.[primary] ?? null;
+}
+
+/** Node-level resolution by infores using the canonical-producer heuristic. */
+function lookupForInfores(
+  data: SourcesVersionsResponse | null,
+  infores: string | null | undefined,
+): SourceVersion | null {
+  if (!data || !infores) return null;
+  const canonical = data.canonical_producer[infores];
+  if (!canonical) return null;
+  return data.by_producer[canonical]?.[infores] ?? null;
+}
+
+function producerWith(
+  data: SourcesVersionsResponse,
+  infores: string,
+): string | null {
+  for (const [producer, fmap] of Object.entries(data.by_producer)) {
+    if (fmap[infores]) return producer;
+  }
+  return null;
+}
+
+/**
+ * Module-level cache. The receipt is small and changes only between KG
+ * releases; one fetch per session is plenty.
+ */
+const cache = ref<SourcesVersionsResponse | null>(null);
+const inFlight = ref<Promise<SourcesVersionsResponse> | null>(null);
+
+async function ensureLoaded(): Promise<SourcesVersionsResponse> {
+  if (cache.value) return cache.value;
+  if (!inFlight.value) {
+    inFlight.value = getSourcesVersions().then((r) => {
+      cache.value = r;
+      return r;
+    });
+  }
+  return await inFlight.value;
+}
+
+export interface ResolvedEdgeVersion {
+  /** The thing we're claiming a version for (e.g. `infores:zfin`). */
+  primary: SourceVersion;
+  /** Filled when `primary` was reached through an aggregator; e.g. AGR. */
+  aggregator?: SourceVersion;
+}
+
+/**
+ * Composable consumed by association detail / table / node pages.
+ *
+ * Returns lazy lookup helpers; the underlying receipt is fetched once on
+ * first call and cached for the rest of the session.
+ */
+export function useSourceVersions() {
+  const data = computed(() => cache.value);
+  const isLoaded = computed(() => cache.value !== null);
+
+  // Kick off the fetch on first call; consumers can ignore the promise and
+  // just react to `data` once it populates.
+  void ensureLoaded();
+
+  function versionForEdge(
+    edge: {
+      primary_knowledge_source?: string | null;
+      aggregator_knowledge_source?: ReadonlyArray<string> | string | null;
+    },
+  ): ResolvedEdgeVersion | null {
+    const aggregators =
+      typeof edge.aggregator_knowledge_source === "string"
+        ? [edge.aggregator_knowledge_source]
+        : edge.aggregator_knowledge_source ?? [];
+    const primary = lookupForEdge(
+      cache.value,
+      edge.primary_knowledge_source,
+      aggregators,
+    );
+    if (!primary) return null;
+    // If the resolved primary came from inside an aggregator (`via` non-empty)
+    // OR the bundle-level fallback fired (resolved infores != requested
+    // primary), surface the aggregator alongside.
+    const realAggregators = aggregators.filter(
+      (a) => a && a !== MONARCH_AGGREGATOR_INFORES,
+    );
+    let aggregator: SourceVersion | undefined;
+    for (const agg of realAggregators) {
+      const producer = cache.value && producerWith(cache.value, agg);
+      if (!producer) continue;
+      aggregator = cache.value!.by_producer[producer]?.[agg];
+      if (aggregator) break;
+    }
+    return { primary, aggregator };
+  }
+
+  function versionForInfores(infores: string | null | undefined): SourceVersion | null {
+    return lookupForInfores(cache.value, infores);
+  }
+
+  return {
+    data,
+    isLoaded,
+    versionForEdge,
+    versionForInfores,
+  };
+}

--- a/frontend/src/composables/use-source-versions.ts
+++ b/frontend/src/composables/use-source-versions.ts
@@ -1,9 +1,9 @@
 import { computed, ref } from "vue";
 import {
-  MONARCH_AGGREGATOR_INFORES,
-  type SourceVersion,
-  type SourcesVersionsResponse,
   getSourcesVersions,
+  MONARCH_AGGREGATOR_INFORES,
+  type SourcesVersionsResponse,
+  type SourceVersion,
 } from "@/api/source-versions";
 
 /**
@@ -12,13 +12,14 @@ import {
  * actually in the KG.
  *
  * Priority:
- *   1. The first non-monarch aggregator identifies the producing ingest.
- *      Look up the primary inside that ingest's subtree → per-component
- *      version (the `(producer, primary)` composite key).
- *   2. If the primary isn't nested there, fall back to the aggregator's
- *      bundle-level entry — accurate as a date-bound on the data.
- *   3. If only monarch is the aggregator, the edge came from a direct
- *      ingest; look the primary up under its canonical producer.
+ *
+ * 1. The first non-monarch aggregator identifies the producing ingest. Look up the
+ *    primary inside that ingest's subtree → per-component version (the
+ *    `(producer, primary)` composite key).
+ * 2. If the primary isn't nested there, fall back to the aggregator's bundle-level
+ *    entry — accurate as a date-bound on the data.
+ * 3. If only monarch is the aggregator, the edge came from a direct ingest; look
+ *    the primary up under its canonical producer.
  */
 function lookupForEdge(
   data: SourcesVersionsResponse | null,
@@ -97,8 +98,8 @@ export interface ResolvedEdgeVersion {
 /**
  * Composable consumed by association detail / table / node pages.
  *
- * Returns lazy lookup helpers; the underlying receipt is fetched once on
- * first call and cached for the rest of the session.
+ * Returns lazy lookup helpers; the underlying receipt is fetched once on first
+ * call and cached for the rest of the session.
  */
 export function useSourceVersions() {
   const data = computed(() => cache.value);
@@ -108,16 +109,14 @@ export function useSourceVersions() {
   // just react to `data` once it populates.
   void ensureLoaded();
 
-  function versionForEdge(
-    edge: {
-      primary_knowledge_source?: string | null;
-      aggregator_knowledge_source?: ReadonlyArray<string> | string | null;
-    },
-  ): ResolvedEdgeVersion | null {
+  function versionForEdge(edge: {
+    primary_knowledge_source?: string | null;
+    aggregator_knowledge_source?: ReadonlyArray<string> | string | null;
+  }): ResolvedEdgeVersion | null {
     const aggregators =
       typeof edge.aggregator_knowledge_source === "string"
         ? [edge.aggregator_knowledge_source]
-        : edge.aggregator_knowledge_source ?? [];
+        : (edge.aggregator_knowledge_source ?? []);
     const primary = lookupForEdge(
       cache.value,
       edge.primary_knowledge_source,
@@ -140,7 +139,9 @@ export function useSourceVersions() {
     return { primary, aggregator };
   }
 
-  function versionForInfores(infores: string | null | undefined): SourceVersion | null {
+  function versionForInfores(
+    infores: string | null | undefined,
+  ): SourceVersion | null {
     return lookupForInfores(cache.value, infores);
   }
 

--- a/frontend/src/composables/use-source-versions.ts
+++ b/frontend/src/composables/use-source-versions.ts
@@ -80,10 +80,18 @@ const inFlight = ref<Promise<SourcesVersionsResponse> | null>(null);
 async function ensureLoaded(): Promise<SourcesVersionsResponse> {
   if (cache.value) return cache.value;
   if (!inFlight.value) {
-    inFlight.value = getSourcesVersions().then((r) => {
-      cache.value = r;
-      return r;
-    });
+    // Clear `inFlight` on rejection so a subsequent caller can retry —
+    // otherwise every consumer this session keeps awaiting the original
+    // settled-rejected promise.
+    inFlight.value = getSourcesVersions()
+      .then((r) => {
+        cache.value = r;
+        return r;
+      })
+      .catch((e) => {
+        inFlight.value = null;
+        throw e;
+      });
   }
   return await inFlight.value;
 }
@@ -106,8 +114,9 @@ export function useSourceVersions() {
   const isLoaded = computed(() => cache.value !== null);
 
   // Kick off the fetch on first call; consumers can ignore the promise and
-  // just react to `data` once it populates.
-  void ensureLoaded();
+  // just react to `data` once it populates. Swallow rejection here — the
+  // next `useSourceVersions()` call retries (see `ensureLoaded`).
+  ensureLoaded().catch(() => undefined);
 
   function versionForEdge(edge: {
     primary_knowledge_source?: string | null;

--- a/frontend/src/pages/knowledgeGraph/PageSourceDashboard.vue
+++ b/frontend/src/pages/knowledgeGraph/PageSourceDashboard.vue
@@ -99,6 +99,7 @@
 </template>
 
 <script setup lang="ts">
+import { computed, ref } from "vue";
 import AppBreadcrumb from "@/components/AppBreadcrumb.vue";
 import AppSection from "@/components/AppSection.vue";
 import DataSource from "@/components/dashboard/DataSource.vue";
@@ -106,7 +107,6 @@ import KGDashboard from "@/components/dashboard/KGDashboard.vue";
 import SourceAssociationBrowser from "@/components/dashboard/SourceAssociationBrowser.vue";
 import SourceCharts from "@/components/dashboard/SourceCharts.vue";
 import PageTitle from "@/components/ThePageTitle.vue";
-import { computed, ref } from "vue";
 import { useSourceDashboard } from "@/composables/use-source-dashboard";
 import { useSourceVersions } from "@/composables/use-source-versions";
 
@@ -146,8 +146,8 @@ const onFilterCategory = (
 
 .source-header {
   display: flex;
-  align-self: stretch;
   flex-direction: column;
+  align-self: stretch;
   margin-bottom: 0.5rem;
   gap: 0.75rem;
   text-align: left;
@@ -176,12 +176,12 @@ const onFilterCategory = (
   display: inline-flex;
   align-items: center;
   padding: 0.25rem 0.7rem;
+  gap: 0.4rem;
   border: 1px solid $light-gray;
   border-radius: $rounded;
   background: $white;
   color: $dark-gray;
   font: inherit;
-  gap: 0.4rem;
   cursor: pointer;
 
   &:hover {
@@ -210,10 +210,10 @@ const onFilterCategory = (
   align-self: stretch;
   margin: 0 0 1rem;
   padding: 0.5rem 0.75rem;
+  gap: 0.4rem 0.6rem;
   border: 1px solid $light-gray;
   border-radius: $rounded;
   background: $off-white;
-  gap: 0.4rem 0.6rem;
 }
 
 .url-chip {

--- a/frontend/src/pages/knowledgeGraph/PageSourceDashboard.vue
+++ b/frontend/src/pages/knowledgeGraph/PageSourceDashboard.vue
@@ -6,16 +6,53 @@
     <AppSection width="big">
       <!-- Source header info -->
       <div class="source-header">
-        <p class="source-id">
-          <strong>Infores ID:</strong>
-          <a
-            :href="`https://w3id.org/information-resource-registry/${inforesId.replace('infores:', '')}`"
-            target="_blank"
-            rel="noopener"
+        <p class="source-line">
+          <span>
+            <strong>Infores:</strong>
+            <a
+              :href="`https://w3id.org/information-resource-registry/${inforesId.replace('infores:', '')}`"
+              target="_blank"
+              rel="noopener"
+              >{{ inforesId }}</a
+            >
+          </span>
+          <span v-if="version">
+            <strong>Version:</strong>
+            {{ version.version || "unknown" }}
+          </span>
+          <span v-if="version?.version_method">
+            <strong>Version method:</strong>
+            {{ version.version_method }}
+          </span>
+          <span v-if="version?.retrieved_at">
+            <strong>Retrieved:</strong>
+            {{ version.retrieved_at }}
+          </span>
+          <button
+            v-if="version?.urls.length"
+            type="button"
+            class="source-urls-toggle"
+            :aria-expanded="urlsExpanded"
+            @click="urlsExpanded = !urlsExpanded"
           >
-            {{ inforesId }}
-          </a>
+            <strong>Source URLs:</strong>
+            {{ version.urls.length }}
+            <span class="caret" :class="{ open: urlsExpanded }">▾</span>
+          </button>
         </p>
+      </div>
+
+      <div v-if="version?.urls.length && urlsExpanded" class="url-panel">
+        <a
+          v-for="url in version.urls"
+          :key="url"
+          class="url-chip"
+          :href="url"
+          target="_blank"
+          rel="noopener"
+        >
+          {{ url }}
+        </a>
       </div>
 
       <!-- Dashboard charts section (DuckDB-WASM powered) -->
@@ -69,7 +106,9 @@ import KGDashboard from "@/components/dashboard/KGDashboard.vue";
 import SourceAssociationBrowser from "@/components/dashboard/SourceAssociationBrowser.vue";
 import SourceCharts from "@/components/dashboard/SourceCharts.vue";
 import PageTitle from "@/components/ThePageTitle.vue";
+import { computed, ref } from "vue";
 import { useSourceDashboard } from "@/composables/use-source-dashboard";
+import { useSourceVersions } from "@/composables/use-source-versions";
 
 const {
   inforesId,
@@ -82,6 +121,10 @@ const {
   clearFilters,
   hasActiveFilters,
 } = useSourceDashboard();
+
+const { versionForInfores } = useSourceVersions();
+const version = computed(() => versionForInfores(inforesId.value));
+const urlsExpanded = ref(false);
 
 /** Handle chart click events to filter the association browser */
 const onFilterPredicate = (predicate: string) => {
@@ -102,24 +145,90 @@ const onFilterCategory = (
 }
 
 .source-header {
-  margin-bottom: 2rem;
-  padding: 1rem 1.5rem;
-  border-left: 4px solid $theme;
-  border-radius: 0 $rounded $rounded 0;
-  background: $theme-light;
+  display: flex;
+  align-self: stretch;
+  flex-direction: column;
+  margin-bottom: 0.5rem;
+  gap: 0.75rem;
+  text-align: left;
 
-  .source-id {
-    margin: 0;
-    color: $off-black;
-    font-size: 0.95rem;
+  a {
+    color: $theme;
 
-    a {
-      color: $theme;
-
-      &:hover {
-        text-decoration: underline;
-      }
+    &:hover {
+      text-decoration: underline;
     }
+  }
+}
+
+.source-line {
+  display: flex;
+  flex: 1 1 auto;
+  flex-wrap: wrap;
+  align-items: center;
+  margin: 0;
+  gap: 0.5rem 1.5rem;
+  color: $off-black;
+  font-size: 0.95rem;
+}
+
+.source-urls-toggle {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.7rem;
+  border: 1px solid $light-gray;
+  border-radius: $rounded;
+  background: $white;
+  color: $dark-gray;
+  font: inherit;
+  gap: 0.4rem;
+  cursor: pointer;
+
+  &:hover {
+    border-color: $gray;
+    color: $off-black;
+  }
+
+  strong {
+    color: $off-black;
+  }
+
+  .caret {
+    color: $gray;
+    font-size: 0.85em;
+    transition: transform 0.15s ease;
+
+    &.open {
+      transform: rotate(180deg);
+    }
+  }
+}
+
+.url-panel {
+  display: flex;
+  flex-wrap: wrap;
+  align-self: stretch;
+  margin: 0 0 1rem;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid $light-gray;
+  border-radius: $rounded;
+  background: $off-white;
+  gap: 0.4rem 0.6rem;
+}
+
+.url-chip {
+  padding: 0.25rem 0.6rem;
+  border: 1px solid $light-gray;
+  border-radius: 999px;
+  background: $white;
+  color: $theme;
+  font-size: 0.85rem;
+  text-decoration: none;
+  word-break: break-all;
+
+  &:hover {
+    border-color: $theme;
+    text-decoration: underline;
   }
 }
 

--- a/frontend/src/pages/knowledgeGraph/PageSources.vue
+++ b/frontend/src/pages/knowledgeGraph/PageSources.vue
@@ -54,16 +54,10 @@
             </td>
             <td class="version-cell">
               <template v-if="versionsById[source.id]">
-                <code v-if="versionsById[source.id].version">{{
+                <span v-if="versionsById[source.id].version">{{
                   versionsById[source.id].version
-                }}</code>
+                }}</span>
                 <span v-else class="muted">unknown</span>
-                <span
-                  v-if="versionsById[source.id].version_method"
-                  class="version-method"
-                >
-                  · {{ versionsById[source.id].version_method }}
-                </span>
               </template>
               <span v-else class="muted">—</span>
             </td>
@@ -172,17 +166,6 @@ const versionsRelease = computed(() => versionsData.value?.release ?? "");
 .sources-table th {
   background-color: $off-white;
   font-weight: bold;
-}
-
-.version-cell code {
-  white-space: nowrap;
-  font-size: 0.95em;
-}
-
-.version-method {
-  margin-left: 0.4em;
-  color: $gray;
-  font-size: 0.85em;
 }
 
 .muted {

--- a/frontend/src/pages/knowledgeGraph/PageSources.vue
+++ b/frontend/src/pages/knowledgeGraph/PageSources.vue
@@ -8,6 +8,11 @@
     >
 
     <div v-else class="tab-container">
+      <p v-if="versionsRelease" class="receipt-subtitle">
+        Versions as of monarch-kg release
+        <strong>{{ versionsRelease }}</strong>
+      </p>
+
       <div class="tabs">
         <div class="tab-item" :class="{ active: activeTab === 'primary' }">
           <AppButton
@@ -34,6 +39,7 @@
           <tr>
             <th>Resource</th>
             <th>Link</th>
+            <th>Version</th>
             <th>Associations</th>
             <th v-if="activeTab === 'primary'">Dashboard</th>
           </tr>
@@ -45,6 +51,21 @@
               <a :href="generateInforesLink(source.id)" target="_blank">{{
                 source.id
               }}</a>
+            </td>
+            <td class="version-cell">
+              <template v-if="versionsById[source.id]">
+                <code v-if="versionsById[source.id].version">{{
+                  versionsById[source.id].version
+                }}</code>
+                <span v-else class="muted">unknown</span>
+                <span
+                  v-if="versionsById[source.id].version_method"
+                  class="version-method"
+                >
+                  · {{ versionsById[source.id].version_method }}
+                </span>
+              </template>
+              <span v-else class="muted">—</span>
             </td>
             <td>{{ source.count.toLocaleString() }}</td>
             <td v-if="activeTab === 'primary'">
@@ -64,10 +85,12 @@
 
 <script setup lang="ts">
 import { computed, onMounted, ref } from "vue";
+import type { SourceVersion } from "@/api/source-versions";
 import AppBreadcrumb from "@/components/AppBreadcrumb.vue";
 import AppSection from "@/components/AppSection.vue";
 import PageTitle from "@/components/ThePageTitle.vue";
 import { useKnowledgeSources } from "@/composables/use-knowledge-sources";
+import { useSourceVersions } from "@/composables/use-source-versions";
 import { RESOURCE_NAME_MAP } from "@/config/resourceNames";
 
 const activeTab = ref<"primary" | "aggregator">("primary");
@@ -81,6 +104,11 @@ const {
   isErrorAggregator,
   fetchAll,
 } = useKnowledgeSources();
+
+const {
+  data: versionsData,
+  versionForInfores,
+} = useSourceVersions();
 
 onMounted(() => fetchAll());
 
@@ -98,6 +126,21 @@ const isLoading = computed(
   () => isLoadingPrimary.value || isLoadingAggregator.value,
 );
 const isError = computed(() => isErrorPrimary.value || isErrorAggregator.value);
+
+/** Resolve every visible source to a version once per render, keyed by id, so
+ * the template can reference values without calling the lookup repeatedly. */
+const versionsById = computed<Record<string, SourceVersion>>(() => {
+  const out: Record<string, SourceVersion> = {};
+  for (const list of [primarySources.value, aggregatorSources.value]) {
+    for (const source of list) {
+      const v = versionForInfores(source.id);
+      if (v) out[source.id] = v;
+    }
+  }
+  return out;
+});
+
+const versionsRelease = computed(() => versionsData.value?.release ?? "");
 </script>
 
 <style lang="scss" scoped>
@@ -129,6 +172,28 @@ const isError = computed(() => isErrorPrimary.value || isErrorAggregator.value);
 .sources-table th {
   background-color: $off-white;
   font-weight: bold;
+}
+
+.version-cell code {
+  white-space: nowrap;
+  font-size: 0.95em;
+}
+
+.version-method {
+  margin-left: 0.4em;
+  color: $gray;
+  font-size: 0.85em;
+}
+
+.muted {
+  color: $gray;
+}
+
+.receipt-subtitle {
+  width: 100%;
+  margin: 0 0 0.75rem;
+  color: $gray;
+  font-size: 0.95em;
 }
 
 .explore-link {

--- a/frontend/src/pages/knowledgeGraph/PageSources.vue
+++ b/frontend/src/pages/knowledgeGraph/PageSources.vue
@@ -99,10 +99,7 @@ const {
   fetchAll,
 } = useKnowledgeSources();
 
-const {
-  data: versionsData,
-  versionForInfores,
-} = useSourceVersions();
+const { data: versionsData, versionForInfores } = useSourceVersions();
 
 onMounted(() => fetchAll());
 
@@ -121,8 +118,10 @@ const isLoading = computed(
 );
 const isError = computed(() => isErrorPrimary.value || isErrorAggregator.value);
 
-/** Resolve every visible source to a version once per render, keyed by id, so
- * the template can reference values without calling the lookup repeatedly. */
+/**
+ * Resolve every visible source to a version once per render, keyed by id, so
+ * the template can reference values without calling the lookup repeatedly.
+ */
 const versionsById = computed<Record<string, SourceVersion>>(() => {
   const out: Record<string, SourceVersion> = {};
   for (const list of [primarySources.value, aggregatorSources.value]) {

--- a/frontend/src/pages/node/SectionAssociationDetails.vue
+++ b/frontend/src/pages/node/SectionAssociationDetails.vue
@@ -72,8 +72,9 @@
             (via
             {{
               sourceVersion.aggregator.name || sourceVersion.aggregator.infores
-            }}
-            v{{ sourceVersion.aggregator.version }})
+            }}<template v-if="sourceVersion.aggregator.version">
+              v{{ sourceVersion.aggregator.version }}</template
+            >)
           </span>
         </span>
       </AppDetail>

--- a/frontend/src/pages/node/SectionAssociationDetails.vue
+++ b/frontend/src/pages/node/SectionAssociationDetails.vue
@@ -54,16 +54,25 @@
 
       <AppDetail v-if="sourceVersion" title="Source Version" icon="clock">
         <span>
-          <span v-if="sourceVersion.primary.name">{{ sourceVersion.primary.name }}</span>
-          <span v-else><code>{{ sourceVersion.primary.infores }}</code></span>
-          <span v-if="sourceVersion.primary.version"> v{{ sourceVersion.primary.version }}</span>
+          <span v-if="sourceVersion.primary.name">{{
+            sourceVersion.primary.name
+          }}</span>
+          <span v-else
+            ><code>{{ sourceVersion.primary.infores }}</code></span
+          >
+          <span v-if="sourceVersion.primary.version">
+            v{{ sourceVersion.primary.version }}</span
+          >
           <span
             v-if="
               sourceVersion.aggregator &&
               sourceVersion.aggregator.infores !== sourceVersion.primary.infores
             "
           >
-            (via {{ sourceVersion.aggregator.name || sourceVersion.aggregator.infores }}
+            (via
+            {{
+              sourceVersion.aggregator.name || sourceVersion.aggregator.infores
+            }}
             v{{ sourceVersion.aggregator.version }})
           </span>
         </span>

--- a/frontend/src/pages/node/SectionAssociationDetails.vue
+++ b/frontend/src/pages/node/SectionAssociationDetails.vue
@@ -52,6 +52,26 @@
         <span>{{ association.primary_knowledge_source }}</span>
       </AppDetail>
 
+      <AppDetail v-if="sourceVersion" title="Source Version" icon="clock">
+        <span>
+          <span v-if="sourceVersion.primary.name">{{ sourceVersion.primary.name }}</span>
+          <span v-else><code>{{ sourceVersion.primary.infores }}</code></span>
+          <span v-if="sourceVersion.primary.version"> v{{ sourceVersion.primary.version }}</span>
+          <span
+            v-if="
+              sourceVersion.aggregator &&
+              sourceVersion.aggregator.infores !== sourceVersion.primary.infores
+            "
+          >
+            (via {{ sourceVersion.aggregator.name || sourceVersion.aggregator.infores }}
+            v{{ sourceVersion.aggregator.version }})
+          </span>
+          <span v-if="sourceVersion.primary.version_method" class="version-method">
+            · {{ sourceVersion.primary.version_method }}
+          </span>
+        </span>
+      </AppDetail>
+
       <AppDetail title="Provided By" icon="notes-medical">
         <AppLink :to="association.provided_by_link?.url || ''" :replace="true">
           {{ association.provided_by_link?.id || association.provided_by }}
@@ -97,6 +117,7 @@ import AppDetail from "@/components/AppDetail.vue";
 import AppDetails from "@/components/AppDetails.vue";
 import AppNodeBadge from "@/components/AppNodeBadge.vue";
 import AppPredicateBadge from "@/components/AppPredicateBadge.vue";
+import { useSourceVersions } from "@/composables/use-source-versions";
 import { scrollTo } from "@/router";
 import { getAgentTypeMeta } from "@/util/agentType";
 
@@ -113,6 +134,11 @@ const agentMeta = computed(() =>
   props.association?.agent_type
     ? getAgentTypeMeta(props.association.agent_type)
     : null,
+);
+
+const { versionForEdge } = useSourceVersions();
+const sourceVersion = computed(() =>
+  props.association ? versionForEdge(props.association) : null,
 );
 
 /** scroll details section into view */
@@ -140,6 +166,11 @@ onMounted(scrollIntoView);
 
 .arrow {
   color: $gray;
+}
+
+.version-method {
+  color: $gray;
+  font-size: 0.9em;
 }
 
 .supporting-text {

--- a/frontend/src/pages/node/SectionAssociationDetails.vue
+++ b/frontend/src/pages/node/SectionAssociationDetails.vue
@@ -66,9 +66,6 @@
             (via {{ sourceVersion.aggregator.name || sourceVersion.aggregator.infores }}
             v{{ sourceVersion.aggregator.version }})
           </span>
-          <span v-if="sourceVersion.primary.version_method" class="version-method">
-            · {{ sourceVersion.primary.version_method }}
-          </span>
         </span>
       </AppDetail>
 
@@ -166,11 +163,6 @@ onMounted(scrollIntoView);
 
 .arrow {
   color: $gray;
-}
-
-.version-method {
-  color: $gray;
-  font-size: 0.9em;
 }
 
 .supporting-text {

--- a/frontend/src/pages/node/SectionOverview.vue
+++ b/frontend/src/pages/node/SectionOverview.vue
@@ -255,18 +255,22 @@ const frequencyLabel = computed((): "Rare" | "Common" => {
 
 const { otherMappings, externalRefs } = useClinicalResources(node);
 
-/** Derive the infores from a node's curie prefix (e.g. MONDO:0007947 →
- * infores:mondo). Lossy for sources whose infores name doesn't match the
- * curie prefix lowercased — those silently fall through to no version. */
+/**
+ * Derive the infores from a node's curie prefix (e.g. MONDO:0007947 →
+ * infores:mondo). Lossy for sources whose infores name doesn't match the curie
+ * prefix lowercased — those silently fall through to no version.
+ */
 const { versionForInfores } = useSourceVersions();
 const nodeVersion = computed(() => {
-  const prefix = node.id?.split(":", 1)[0];
+  const prefix = node.id?.split(":")[0];
   if (!prefix) return null;
   return versionForInfores(`infores:${prefix.toLowerCase()}`);
 });
 
-/** Use the source's own name in the field title (e.g. "Mondo Version") so
- * disease/gene/etc. pages don't say a generic "Source Version". */
+/**
+ * Use the source's own name in the field title (e.g. "Mondo Version") so
+ * disease/gene/etc. pages don't say a generic "Source Version".
+ */
 const nodeVersionTitle = computed(() => {
   const v = nodeVersion.value;
   if (!v) return "Source Version";
@@ -285,5 +289,4 @@ const nodeVersionTitle = computed(() => {
   overflow-x: auto;
   white-space: pre-line;
 }
-
 </style>

--- a/frontend/src/pages/node/SectionOverview.vue
+++ b/frontend/src/pages/node/SectionOverview.vue
@@ -94,6 +94,10 @@
             {{ node.provided_by_link?.id || node.provided_by }}
           </AppLink>
         </AppDetail>
+
+        <AppDetail v-if="nodeVersion" :title="nodeVersionTitle">
+          <span>{{ nodeVersion.version || "unknown" }}</span>
+        </AppDetail>
       </AppDetails>
 
       <!--For all other nodes other than diesease nodes-->
@@ -172,6 +176,10 @@
           </AppLink>
         </AppDetail>
 
+        <AppDetail v-if="nodeVersion" :title="nodeVersionTitle">
+          <span>{{ nodeVersion.version || "unknown" }}</span>
+        </AppDetail>
+
         <AppDetail
           :blank="!otherMappings.length"
           title="Other Mappings"
@@ -217,6 +225,7 @@ import AppNodeBadge from "@/components/AppNodeBadge.vue";
 import AppNodeText from "@/components/AppNodeText.vue";
 import AppTagList from "@/components/AppTagList.vue";
 import { useClinicalResources } from "@/composables/use-clinical-resources";
+import { useSourceVersions } from "@/composables/use-source-versions";
 import SectionClinicalReources from "./SectionClinicalReources.vue";
 
 type Props = { node: Node };
@@ -245,6 +254,25 @@ const frequencyLabel = computed((): "Rare" | "Common" => {
 });
 
 const { otherMappings, externalRefs } = useClinicalResources(node);
+
+/** Derive the infores from a node's curie prefix (e.g. MONDO:0007947 →
+ * infores:mondo). Lossy for sources whose infores name doesn't match the
+ * curie prefix lowercased — those silently fall through to no version. */
+const { versionForInfores } = useSourceVersions();
+const nodeVersion = computed(() => {
+  const prefix = node.id?.split(":", 1)[0];
+  if (!prefix) return null;
+  return versionForInfores(`infores:${prefix.toLowerCase()}`);
+});
+
+/** Use the source's own name in the field title (e.g. "Mondo Version") so
+ * disease/gene/etc. pages don't say a generic "Source Version". */
+const nodeVersionTitle = computed(() => {
+  const v = nodeVersion.value;
+  if (!v) return "Source Version";
+  const label = v.name?.trim() || v.infores.replace(/^infores:/, "");
+  return `${label} Version`;
+});
 // async function scrollToAssociations() {
 //   await sleep(100);
 //   scrollTo("#associations");
@@ -257,4 +285,5 @@ const { otherMappings, externalRefs } = useClinicalResources(node);
   overflow-x: auto;
   white-space: pre-line;
 }
+
 </style>

--- a/frontend/unit/useSourceVersions.test.ts
+++ b/frontend/unit/useSourceVersions.test.ts
@@ -185,4 +185,28 @@ describe("useSourceVersions", () => {
     expect(versionForInfores(null)).toBeNull();
     expect(versionForInfores(undefined)).toBeNull();
   });
+
+  it("allows a retry after a rejected fetch (inFlight is cleared)", async () => {
+    vi.resetModules();
+    const api = await import("@/api/source-versions");
+    const fetchMock = api.getSourcesVersions as unknown as ReturnType<
+      typeof vi.fn
+    >;
+    fetchMock.mockRejectedValueOnce(new Error("network"));
+    fetchMock.mockResolvedValueOnce(receipt());
+
+    const { useSourceVersions } =
+      await import("@/composables/use-source-versions");
+
+    // First consumer triggers the failing fetch.
+    const first = useSourceVersions();
+    await flushPromises().catch(() => {});
+    expect(first.isLoaded.value).toBe(false);
+
+    // Second consumer should kick off a fresh fetch, which succeeds.
+    const second = useSourceVersions();
+    await flushPromises();
+    expect(second.isLoaded.value).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
 });

--- a/frontend/unit/useSourceVersions.test.ts
+++ b/frontend/unit/useSourceVersions.test.ts
@@ -1,0 +1,188 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { flushPromises } from "@vue/test-utils";
+import {
+  MONARCH_AGGREGATOR_INFORES,
+  type SourcesVersionsResponse,
+} from "@/api/source-versions";
+
+/**
+ * Synthetic receipt mirroring the backend test fixture: covers the three
+ * resolution cases this composable has to handle.
+ *
+ * - alliance-ingest: aggregator (`infores:agr`) WITH per-MOD nesting.
+ * - alliance-disease-association-ingest: aggregator WITHOUT per-MOD nesting —
+ *   exercises the bundle-level fallback.
+ * - hgnc-ingest: direct primary ingest (only monarch as aggregator).
+ * - kg-phenio: ontology terms reached via phenio.
+ */
+const receipt = (): SourcesVersionsResponse => ({
+  release: "2026-05-07",
+  generated_at: "2026-05-07T16:11:30Z",
+  by_producer: {
+    "alliance-ingest": {
+      "infores:agr": {
+        infores: "infores:agr",
+        name: "Alliance of Genome Resources",
+        version: "8.3.0",
+        version_method: "alliance_fms_api",
+        retrieved_at: "",
+        urls: [],
+        via: [],
+      },
+      "infores:zfin": {
+        infores: "infores:zfin",
+        name: "ZFIN",
+        version: "2026-04-15",
+        version_method: "alliance_fms_submission",
+        retrieved_at: "",
+        urls: [],
+        via: ["infores:agr"],
+      },
+    },
+    "alliance-disease-association-ingest": {
+      "infores:agr": {
+        infores: "infores:agr",
+        name: "Alliance of Genome Resources",
+        version: "8.3.0",
+        version_method: "alliance_fms_api",
+        retrieved_at: "",
+        urls: [],
+        via: [],
+      },
+    },
+    "hgnc-ingest": {
+      "infores:hgnc": {
+        infores: "infores:hgnc",
+        name: "HUGO Gene Nomenclature Committee",
+        version: "2026-05-01",
+        version_method: "http_last_modified",
+        retrieved_at: "",
+        urls: [],
+        via: [],
+      },
+    },
+    "kg-phenio": {
+      "infores:mondo": {
+        infores: "infores:mondo",
+        name: "MONDO",
+        version: "2026-04-01",
+        version_method: "owl_version_iri",
+        retrieved_at: "",
+        urls: [],
+        via: ["phenio"],
+      },
+    },
+  },
+  canonical_producer: {
+    "infores:agr": "alliance-ingest",
+    "infores:zfin": "alliance-ingest",
+    "infores:hgnc": "hgnc-ingest",
+    "infores:mondo": "kg-phenio",
+  },
+});
+
+vi.mock("@/api/source-versions", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/api/source-versions")>();
+  return {
+    ...actual,
+    getSourcesVersions: vi.fn(),
+  };
+});
+
+/** Reimport composable + api with a fresh module-level cache per test. */
+async function loadFresh() {
+  vi.resetModules();
+  const api = await import("@/api/source-versions");
+  (
+    api.getSourcesVersions as unknown as ReturnType<typeof vi.fn>
+  ).mockResolvedValue(receipt());
+  const { useSourceVersions } =
+    await import("@/composables/use-source-versions");
+  const composable = useSourceVersions();
+  // Let `ensureLoaded()` resolve and populate the cache.
+  await flushPromises();
+  return composable;
+}
+
+describe("useSourceVersions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("resolves a nested per-MOD edge through the aggregator", async () => {
+    const { versionForEdge } = await loadFresh();
+    const result = versionForEdge({
+      primary_knowledge_source: "infores:zfin",
+      aggregator_knowledge_source: ["infores:agr", MONARCH_AGGREGATOR_INFORES],
+    });
+    expect(result?.primary.infores).toBe("infores:zfin");
+    expect(result?.primary.version).toBe("2026-04-15");
+    expect(result?.aggregator?.infores).toBe("infores:agr");
+    expect(result?.aggregator?.version).toBe("8.3.0");
+  });
+
+  it("falls back to bundle-level aggregator when primary isn't nested", async () => {
+    const { versionForEdge } = await loadFresh();
+    // Edge claims AGR aggregation but the producing ingest doesn't expose
+    // a per-MOD nesting for `infores:zfin` — should fall through to AGR
+    // itself rather than reaching into alliance-ingest.
+    const result = versionForEdge({
+      primary_knowledge_source: "infores:mgi",
+      aggregator_knowledge_source: ["infores:agr"],
+    });
+    // alliance-ingest is listed first in by_producer and has infores:agr,
+    // so it wins as the producer. `infores:mgi` isn't there → bundle fallback.
+    expect(result?.primary.infores).toBe("infores:agr");
+    expect(result?.primary.version).toBe("8.3.0");
+  });
+
+  it("resolves a direct ingest edge with no real aggregator", async () => {
+    const { versionForEdge } = await loadFresh();
+    const result = versionForEdge({
+      primary_knowledge_source: "infores:hgnc",
+      aggregator_knowledge_source: [MONARCH_AGGREGATOR_INFORES],
+    });
+    expect(result?.primary.infores).toBe("infores:hgnc");
+    expect(result?.primary.version).toBe("2026-05-01");
+    expect(result?.aggregator).toBeUndefined();
+  });
+
+  it("accepts aggregator_knowledge_source as a single string", async () => {
+    const { versionForEdge } = await loadFresh();
+    const result = versionForEdge({
+      primary_knowledge_source: "infores:zfin",
+      aggregator_knowledge_source: "infores:agr",
+    });
+    expect(result?.primary.infores).toBe("infores:zfin");
+    expect(result?.aggregator?.infores).toBe("infores:agr");
+  });
+
+  it("returns null when primary is unknown and an aggregator is named", async () => {
+    const { versionForEdge } = await loadFresh();
+    // Unknown aggregator → no producer match → null.
+    const result = versionForEdge({
+      primary_knowledge_source: "infores:zfin",
+      aggregator_knowledge_source: ["infores:nope"],
+    });
+    expect(result).toBeNull();
+  });
+
+  it("resolves an ontology infores via the phenio canonical producer", async () => {
+    const { versionForInfores } = await loadFresh();
+    const result = versionForInfores("infores:mondo");
+    expect(result?.version).toBe("2026-04-01");
+    expect(result?.via).toEqual(["phenio"]);
+  });
+
+  it("resolves a data-source infores via its self-named ingest", async () => {
+    const { versionForInfores } = await loadFresh();
+    expect(versionForInfores("infores:hgnc")?.version).toBe("2026-05-01");
+  });
+
+  it("returns null for unknown infores", async () => {
+    const { versionForInfores } = await loadFresh();
+    expect(versionForInfores("infores:never-heard-of")).toBeNull();
+    expect(versionForInfores(null)).toBeNull();
+    expect(versionForInfores(undefined)).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #1303.

## Summary

Adds build-receipt-driven source-version display across the UI, sourced from `data.monarchinitiative.org/monarch-kg/<release>/metadata.yaml`.

- **Backend** — `GET /v3/api/sources/versions` resolves the recursive `Release` tree into a `(producer, infores)` composite-key index plus a canonical-producer map for node-level lookups. 5-min cache, dev flag plumbed through. 11 new unit tests cover aggregator-with-nesting, aggregator-without-nesting, and direct-ingest resolution paths plus canonical-producer heuristics (self-named ingest, phenio fallback, both legacy `hgnc-ingest` and post-collapse `infores:hgnc` ids).
- **Association details** — new "Source Version" row, e.g. `ZFIN v2026-04-15 (via AGR v8.3.0)`. Falls back to bundle-level aggregator version where per-component nesting isn't available yet (alliance-ingest#10, go-ingest#9).
- **Sources list page** — Version column on Primary / Aggregator tabs, with a "Versions as of monarch-kg release X" subtitle.
- **Per-source dashboard** — header shows version, version_method, retrieved_at, and a collapsible Source URLs panel.
- **Node overview pages** — "{Source} Version" detail row mapped from the curie prefix (e.g. `MONDO:0007947` → "Mondo Version"). Lossy for sources whose infores name doesn't equal `prefix.toLowerCase()` — those just don't render.
- **Dev/prod handling** — `?dev=true` and `MONARCH_KG_USE_DEV` env var to read `monarch-kg-dev/` while prod's `metadata.yaml` is still on the legacy shape. Vite dev server opts in automatically; production builds keep reading `monarch-kg/`. Once prod ships the new shape this is a no-op.

## Test plan

- [ ] Backend: `cd backend && poetry run pytest tests/unit/test_source_versions.py` — 11/11 passing
- [ ] Frontend: `cd frontend && bun run test` — existing suite still green; `bun run type-check` clean
- [ ] Spot-check association detail on a ZFIN-via-AGR edge and a direct-ingest edge (e.g. HGNC) — `Source Version` row should render with/without the `(via …)` qualifier respectively
- [ ] Sources list `/kg/sources`: Version column populated on both Primary and Aggregator tabs
- [ ] Per-source dashboard (e.g. `/kg/sources/infores:mondo`): header shows version + URL chips
- [ ] Node page for `MONDO:0007947` shows "Mondo Version"
- [ ] With prod's legacy `metadata.yaml`, hitting the prod endpoint without `dev=true` returns a clear 502; `bun run dev` frontend transparently uses dev
