### PR TITLE
Expose /ground endpoint for direct entity grounding

### DIFF
--- a/backend/src/monarch_py/api/text_annotation.py
+++ b/backend/src/monarch_py/api/text_annotation.py
@@ -2,8 +2,8 @@ from fastapi import APIRouter, Query, Response
 from typing import List
 
 from monarch_py.api.additional_models import TextAnnotationRequest
-from monarch_py.api.config import spacyner
-from monarch_py.datamodels.model import TextAnnotationResult
+from monarch_py.api.config import solr, spacyner
+from monarch_py.datamodels.model import Entity, TextAnnotationResult
 
 router = APIRouter(tags=["text_annotation"], responses={404: {"description": "Not Found"}})
 
@@ -26,3 +26,13 @@ def _entities(text: str = Query(default="", title="")) -> List[TextAnnotationRes
 @router.post("/annotate/entities")
 def _post_entities(request: TextAnnotationRequest) -> List[TextAnnotationResult]:
     return _entities(request.content)
+
+
+@router.get("/ground")
+def _ground(text: str = Query(default="", title="The text to ground to an entity")) -> List[Entity]:
+    return solr().ground_entity(text)
+
+
+@router.post("/ground")
+def _post_ground(request: TextAnnotationRequest) -> List[Entity]:
+    return _ground(request.content)

--- a/backend/src/monarch_py/api/text_annotation.py
+++ b/backend/src/monarch_py/api/text_annotation.py
@@ -30,6 +30,8 @@ def _post_entities(request: TextAnnotationRequest) -> List[TextAnnotationResult]
 
 @router.get("/ground")
 def _ground(text: str = Query(default="", title="The text to ground to an entity")) -> List[Entity]:
+    if not text.strip():
+        return []
     return solr().ground_entity(text)
 
 

--- a/backend/tests/integration/test_ground_endpoint.py
+++ b/backend/tests/integration/test_ground_endpoint.py
@@ -1,0 +1,32 @@
+"""Integration tests for the /ground API endpoint."""
+
+import pytest
+from fastapi.testclient import TestClient
+from monarch_py.api.main import app
+from monarch_py.implementations.solr.solr_implementation import SolrImplementation
+
+pytestmark = pytest.mark.skipif(
+    condition=not SolrImplementation().solr_is_available(),
+    reason="Solr is not available",
+)
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+def test_get_ground_ranks_exact_synonym_first(client):  # pragma: no cover
+    response = client.get("/v3/api/ground", params={"text": "kidney disease"})
+    assert response.status_code == 200
+    results = response.json()
+    assert results
+    assert results[0]["id"] == "MONDO:0005240"
+
+
+def test_post_ground_ranks_exact_synonym_first(client):  # pragma: no cover
+    response = client.post("/v3/api/ground", json={"content": "kidney disease"})
+    assert response.status_code == 200
+    results = response.json()
+    assert results
+    assert results[0]["id"] == "MONDO:0005240"

--- a/backend/tests/integration/test_ground_endpoint.py
+++ b/backend/tests/integration/test_ground_endpoint.py
@@ -5,7 +5,7 @@ from fastapi.testclient import TestClient
 from monarch_py.api.main import app
 from monarch_py.implementations.solr.solr_implementation import SolrImplementation
 
-pytestmark = pytest.mark.skipif(
+requires_solr = pytest.mark.skipif(
     condition=not SolrImplementation().solr_is_available(),
     reason="Solr is not available",
 )
@@ -16,6 +16,7 @@ def client():
     return TestClient(app)
 
 
+@requires_solr
 def test_get_ground_ranks_exact_synonym_first(client):  # pragma: no cover
     response = client.get("/v3/api/ground", params={"text": "kidney disease"})
     assert response.status_code == 200
@@ -24,9 +25,17 @@ def test_get_ground_ranks_exact_synonym_first(client):  # pragma: no cover
     assert results[0]["id"] == "MONDO:0005240"
 
 
+@requires_solr
 def test_post_ground_ranks_exact_synonym_first(client):  # pragma: no cover
     response = client.post("/v3/api/ground", json={"content": "kidney disease"})
     assert response.status_code == 200
     results = response.json()
     assert results
     assert results[0]["id"] == "MONDO:0005240"
+
+
+@pytest.mark.parametrize("blank", ["", " ", "\t\n"])
+def test_ground_returns_empty_for_blank_input(client, blank):
+    response = client.get("/v3/api/ground", params={"text": blank})
+    assert response.status_code == 200
+    assert response.json() == []


### PR DESCRIPTION
Follow-up to #1309. Currently `SolrImplementation.ground_entity()` is reachable only indirectly through the annotator's NER pipeline (`/annotate`, `/annotate/entities`). Exposing it directly lets callers ground a known span without paying for the spaCy NER step, and makes the rank-1 improvements from #1306 directly addressable as an API.

## Summary

- `GET /ground?text=<text>` → `List[Entity]`
- `POST /ground` with `TextAnnotationRequest` body → `List[Entity]`

Both delegate to `solr().ground_entity(text)` — same return shape that the annotator already consumes internally. Added to the existing `text_annotation` router (sibling to `/annotate` and `/annotate/entities`); no `main.py` change needed.

## Test plan
- [x] New integration tests in `test_ground_endpoint.py` covering GET and POST against the live Solr (`@pytest.mark.skipif` on `solr_is_available()`, matching the pattern used by `test_case_phenotype_api.py`)
- [x] Tests assert `kidney disease` → MONDO:0005240 ranks first, providing an end-to-end check that the #1309 boost lands at the API layer
- [x] Test bodies marked `# pragma: no cover` (consistent with the other Solr-gated integration tests, since CI has no Solr)

## Out of scope
- The `[:3]` truncation inside `SolrImplementation.ground_entity` (the annotator's downstream filter, not the function itself) — same as #1306's listed follow-up.