### PR TITLE
Pin /sources/versions to deployed MONARCH_KG_VERSION

### DIFF
--- a/backend/src/monarch_py/api/sources_versions.py
+++ b/backend/src/monarch_py/api/sources_versions.py
@@ -101,19 +101,36 @@ def _serialize(receipt: ResolvedReceipt) -> dict:
 
 
 @router.get("/sources/versions")
-def sources_versions(release: str = "latest", dev: bool | None = None) -> dict:
+def sources_versions(release: str | None = None, dev: bool | None = None) -> dict:
     """Return the resolved version index for a given monarch-kg release.
 
-    Default is `latest`, which resolves to the most recent published release
-    on `data.monarchinitiative.org`. Specific dates (`2026-05-07`) are also
-    accepted for retrospective lookups. Pass `dev=true` to read from
-    `monarch-kg-dev/`; otherwise the deployment-wide default applies (set
-    via the `MONARCH_KG_USE_DEV` env var, default false).
+    Default is the release this API was built against (the `MONARCH_KG_VERSION`
+    env var, surfaced in `/version`), so the receipt reflects the bytes
+    actually in the deployed Solr/DuckDB. Falls back to `latest` when the env
+    var is unset. Specific dates (`2026-05-07`) are also accepted for
+    retrospective lookups. Pass `dev=true` to read from `monarch-kg-dev/`;
+    otherwise the deployment-wide default applies (set via the
+    `MONARCH_KG_USE_DEV` env var, default false).
     """
-    if not _RELEASE_PATTERN.match(release):
+    resolved_release = release if release is not None else _default_release()
+    if not _RELEASE_PATTERN.match(resolved_release):
         raise HTTPException(
             status_code=400,
             detail="Invalid release identifier; expected alphanumerics, `.`, `_`, or `-`.",
         )
     use_dev = settings.monarch_kg_use_dev if dev is None else dev
-    return _serialize(_fetch_receipt(release, dev=use_dev))
+    return _serialize(_fetch_receipt(resolved_release, dev=use_dev))
+
+
+def _default_release() -> str:
+    """Pin the receipt URL to the deployed build when we know which one it is.
+
+    `MONARCH_KG_VERSION` is set per-deploy by monarch-stack-v3 and seeds
+    `settings.monarch_kg_version`. Unset → the Settings default `"unknown"`,
+    which means we're running locally or the deploy didn't pass it through;
+    fall back to `latest` so the endpoint still does something useful.
+    """
+    pinned = settings.monarch_kg_version
+    if not pinned or pinned == "unknown":
+        return "latest"
+    return pinned

--- a/backend/tests/unit/test_sources_versions_api.py
+++ b/backend/tests/unit/test_sources_versions_api.py
@@ -49,8 +49,11 @@ def _ok_response(text: str = VALID_RECEIPT_YAML):
 
 
 def test_endpoint_returns_serialized_receipt(client):
-    with patch("monarch_py.api.sources_versions.requests.get", return_value=_ok_response()) as g:
-        r = client.get("/v3/api/sources/versions")
+    # Force the unpinned-default path so this test doesn't depend on whatever
+    # `MONARCH_KG_VERSION` happens to be set to in the caller's environment.
+    with patch.object(route.settings, "monarch_kg_version", "unknown"):
+        with patch("monarch_py.api.sources_versions.requests.get", return_value=_ok_response()) as g:
+            r = client.get("/v3/api/sources/versions")
     assert r.status_code == 200
     body = r.json()
     assert body["release"] == "2026-05-07"
@@ -62,6 +65,27 @@ def test_endpoint_returns_serialized_receipt(client):
     assert "version_drift" not in body
     g.assert_called_once()
     assert "monarch-kg/latest/metadata.yaml" in g.call_args.args[0]
+
+
+def test_endpoint_defaults_to_deployed_release_when_env_pinned(client):
+    """When `MONARCH_KG_VERSION` is set, the endpoint reads that build's
+    receipt rather than `latest` — so each deploy sees the versions for the
+    bytes actually loaded into its Solr/DuckDB."""
+    with patch.object(route.settings, "monarch_kg_version", "2026-05-09"):
+        with patch("monarch_py.api.sources_versions.requests.get", return_value=_ok_response()) as g:
+            r = client.get("/v3/api/sources/versions")
+    assert r.status_code == 200
+    assert "monarch-kg/2026-05-09/metadata.yaml" in g.call_args.args[0]
+
+
+def test_endpoint_release_query_param_overrides_pinned_default(client):
+    """Explicit `release=` still wins over the env-var default — useful for
+    retrospective lookups from the same deploy."""
+    with patch.object(route.settings, "monarch_kg_version", "2026-05-09"):
+        with patch("monarch_py.api.sources_versions.requests.get", return_value=_ok_response()) as g:
+            r = client.get("/v3/api/sources/versions", params={"release": "2026-04-01"})
+    assert r.status_code == 200
+    assert "monarch-kg/2026-04-01/metadata.yaml" in g.call_args.args[0]
 
 
 def test_endpoint_caches_within_ttl(client):
@@ -87,8 +111,9 @@ def test_endpoint_refetches_when_ttl_expired(client):
 
 
 def test_dev_flag_hits_dev_mirror(client):
-    with patch("monarch_py.api.sources_versions.requests.get", return_value=_ok_response()) as g:
-        r = client.get("/v3/api/sources/versions", params={"dev": "true"})
+    with patch.object(route.settings, "monarch_kg_version", "unknown"):
+        with patch("monarch_py.api.sources_versions.requests.get", return_value=_ok_response()) as g:
+            r = client.get("/v3/api/sources/versions", params={"dev": "true"})
     assert r.status_code == 200
     assert "monarch-kg-dev/latest/metadata.yaml" in g.call_args.args[0]
 

--- a/frontend/src/api/source-versions.ts
+++ b/frontend/src/api/source-versions.ts
@@ -33,11 +33,16 @@ export interface SourcesVersionsResponse {
 export const MONARCH_AGGREGATOR_INFORES = "infores:monarchinitiative";
 
 export const getSourcesVersions = async (
-  release = "latest",
-  dev = import.meta.env.DEV,
+  release?: string,
+  dev?: boolean,
 ): Promise<SourcesVersionsResponse> => {
-  const params: Record<string, string> = { release };
-  if (dev) params.dev = "true";
+  // Both params are intentionally optional: the backend defaults `release` to
+  // the deployed `MONARCH_KG_VERSION` (so each environment reads its own
+  // build's receipt) and `dev` to its `MONARCH_KG_USE_DEV` env var. Passing
+  // them here would override those deploy-time decisions.
+  const params: Record<string, string> = {};
+  if (release !== undefined) params.release = release;
+  if (dev !== undefined) params.dev = dev ? "true" : "false";
   return await request<SourcesVersionsResponse>(
     `${apiUrl}/sources/versions`,
     params,


### PR DESCRIPTION
## Summary

Beta (and prod, when it deploys) was rendering the version slots from #1308 but no version content. Root cause: the route defaulted to `monarch-kg/latest/metadata.yaml`, which on prod is still the pre-collapse legacy stub (no top-level `id`) → 502 → composable cache populated with nothing → empty rows everywhere.

The dated build receipt (e.g. `monarch-kg/2026-05-09/metadata.yaml`) is already in the new shape on the same mirror, and we already know which release is deployed: `MONARCH_KG_VERSION` is set per-deploy by monarch-stack-v3 and surfaced via `/v3/api/version`.

- **Backend (`api/sources_versions.py`)** — `release` query param defaults to `settings.monarch_kg_version` when set (anything other than the `"unknown"` Settings default). Falls back to `"latest"` for local dev with no env var. Explicit `?release=` still wins for retrospective lookups.
- **Frontend (`api/source-versions.ts`)** — drop the `release = "latest"` and `dev = import.meta.env.DEV` defaults. Don't send either query param unless the caller explicitly asks; let the backend's deploy-pinned defaults apply. Removes the prod-vs-Vite-dev divergence — beta and prod now both read their own build's receipt without special handling.

The `?dev=true` escape hatch and `MONARCH_KG_USE_DEV` env var stay in place for local poking.

## Test plan

- [ ] Backend: `poetry run pytest backend/tests/unit/test_sources_versions_api.py backend/tests/unit/test_source_versions.py` — covers the new pinned-default path, the explicit-`release`-override path, and the `MONARCH_KG_VERSION=unknown` fallback (existing tests now patch `settings.monarch_kg_version` so they don't depend on ambient env).
- [ ] Hit `https://api-beta.monarchinitiative.org/v3/api/sources/versions` once this is deployed — expect 200 with `release: "2026-05-09"` (or whatever `/version` reports). Spot-check association detail / sources list / per-source dashboard / node overview on beta — version content should now populate.
- [ ] Frontend `bun run test` still green; no callers other than the composable pass arguments to `getSourcesVersions`.