### PR TITLE
Add Phenogrid documentation to the docs site

### DIFF
--- a/docs/Phenogrid/index.md
+++ b/docs/Phenogrid/index.md
@@ -1,0 +1,1 @@
+--8<-- "frontend/PHENOGRID.md"

--- a/frontend/PHENOGRID.md
+++ b/frontend/PHENOGRID.md
@@ -26,8 +26,8 @@ See the [Events](#events) section for more details.
 
 Phenogrid can operate in multiple modes, which you can specify via the `src` URL.
 
-- [`/phenogrid-search`](#search-mode) - Compares a list of enumerated phenotypes (set A) against all the phenotypes from a gene or disease of interest (group B).
-- [`/phenogrid-multi-compare`](#multi-compare-mode) - Compares a list of enumerated phenotypes to _multiple_ enumerated other lists of phenotypes.
+- [`/phenogrid-search`](#search-mode-parameters) - Compares a list of enumerated phenotypes (set A) against all the phenotypes from a gene or disease of interest (group B).
+- [`/phenogrid-multi-compare`](#multi-compare-mode-parameters) - Compares a list of enumerated phenotypes to _multiple_ enumerated other lists of phenotypes.
 
 For more details on the parameters for each mode, see the respective sections below.
 

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -40,6 +40,7 @@ nav:
     - Creating an Ingest: 'Creating-an-Ingest.md'
   - Neo4J: 'Neo4J/index.md'
   - Monarch R: 'MonarchR/index.md'
+  - Phenogrid: 'Phenogrid/index.md'
   - FastAPI:
     - Overview: 'FastAPI/index.md'
     - Endpoints:
@@ -134,6 +135,8 @@ markdown_extensions:
       smart_enable: all
   - pymdownx.snippets:
       check_paths: true
+      base_path:
+        - '.'
   - pymdownx.tabbed:
       alternate_style: true
 

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -135,8 +135,11 @@ markdown_extensions:
       smart_enable: all
   - pymdownx.snippets:
       check_paths: true
+      # 'make docs' runs mkdocs from backend/ (-f ../mkdocs.yaml), so '..'
+      # resolves to the repo root; '.' covers running from the repo root directly.
       base_path:
         - '.'
+        - '..'
   - pymdownx.tabbed:
       alternate_style: true
 


### PR DESCRIPTION
## Summary

Surfaces the Phenogrid documentation on the Monarch KG docs site, as requested in #921. The docs previously lived only at `frontend/PHENOGRID.md`.

## Changes

- **`docs/Phenogrid/index.md`** (new) — includes the canonical `frontend/PHENOGRID.md` via a `pymdownx.snippets` include, so there's a single source of truth (no divergent copy to keep in sync).
- **`mkdocs.yaml`** — adds `Phenogrid` to the nav and sets the snippets `base_path` to the repo root so the include resolves at build time.
- **`frontend/PHENOGRID.md`** — fixes two broken in-page anchor links (`#search-mode` → `#search-mode-parameters`, `#multi-compare-mode` → `#multi-compare-mode-parameters`); these were also broken when viewing the file on GitHub.

## Testing

`mkdocs build` succeeds; the Phenogrid page renders the full content with no warnings.

Closes #921