### PR TITLE
Fix NANDO linkouts

### DIFF
--- a/backend/src/monarch_py/service/curie_service.py
+++ b/backend/src/monarch_py/service/curie_service.py
@@ -15,6 +15,10 @@ converter.add_prefix("Orphanet", "https://www.orpha.net/en/disease/detail/", mer
 # icd.codes is dead/returning 403s, override to use icd10data.com search
 # (add_prefix merge only adds as synonym, so patch prefix_map directly)
 converter.prefix_map["ICD10CM"] = "https://www.icd10data.com/search?s="
+# bioregistry's canonical NANDO expansion uses a slash (.../NANDO/2200622),
+# which doesn't resolve; identifiers.org expects a colon (.../NANDO:2200622).
+# The colon form is only a prefix_alias upstream, so patch prefix_map directly.
+converter.prefix_map["NANDO"] = "http://identifiers.org/NANDO:"
 converter.add_prefix(
     "phenopacket.store",
     "https://github.com/monarch-initiative/phenopacket-store/blob/main/notebooks/",

--- a/backend/tests/unit/test_curie_service.py
+++ b/backend/tests/unit/test_curie_service.py
@@ -21,6 +21,7 @@ import pytest
         ("SGD:S000000001", "identifiers.org/sgd/S000000001"),
         ("RGD:1", "identifiers.org/rgd/1"),
         ("HGNC:5", "identifiers.org/hgnc/5"),
+        ("NANDO:2200622", "identifiers.org/NANDO:2200622"),  # colon, not slash (issue #1221)
         ### These prefixes are currently broken in the curie service
         ("ENSEMBL:ENSG00000157764", "identifiers.org/ensembl/ENSG00000157764"),
         ("OMIM:613647", "identifiers.org/mim/613647"),


### PR DESCRIPTION
## Summary

Fixes #1221. NANDO entity linkouts (e.g. on `/MONDO:0019350`) were broken because the CURIE expanded to a slash-separated identifiers.org URL that doesn't resolve:

- Before: `http://identifiers.org/NANDO/2200622`
- After: `http://identifiers.org/NANDO:2200622`

## Root cause

bioregistry's *canonical* NANDO expansion uses a slash (`.../NANDO/`); the colon form is only a `prefix_alias`. The `merged` prefixmap context we load inherits that canonical, so `converter.expand("NANDO:2200622")` produced the slash form.

No released `prefixmaps` version corrects this — 0.2.4/0.2.5/0.2.6 all keep the slash form as canonical. (prefixmaps `main` does change it, but to `nanbyodata.jp`, not the identifiers.org form requested in the issue.) So this overrides the prefix locally, matching the existing `ICD10CM` direct-`prefix_map` patch in `curie_service.py`.

## Testing

Added a regression case to `test_curie_service.py`; `tests/unit/test_curie_service.py` and `tests/unit/test_entity_utils.py` pass (29 tests).