### PR TITLE
curie_service: switch to merged.monarch context

### DIFF
--- a/backend/src/monarch_py/service/curie_service.py
+++ b/backend/src/monarch_py/service/curie_service.py
@@ -6,9 +6,14 @@ __all__ = [
     "converter",
 ]
 
-# this is a magic keyword that represents the "merged" context from Chris M's algorithm
-# (https://github.com/linkml/prefixmaps/blob/main/src/prefixmaps/data/merged.csv)
-converter = load_converter("merged")
+# Use the Monarch-specific clone of the "merged" prefixmap context. Aligns
+# with kg-phenio's normalize step (also being moved to the same context to
+# fix the FBBT/WBBT prefix-casing issue that was dropping ~503k Alliance
+# gene-expression edges to dangling, see monarch-app#1319). Same canonical
+# behavior as "merged" today; standardizes the Monarch-facing label across
+# the stack.
+# (https://github.com/linkml/prefixmaps/blob/main/src/prefixmaps/data/merged.monarch.csv)
+converter = load_converter("merged.monarch")
 converter.add_prefix("GARD", "https://rarediseases.info.nih.gov/diseases/")
 converter.add_prefix("NORD", "https://rarediseases.org/?p=")
 converter.add_prefix("Orphanet", "https://www.orpha.net/en/disease/detail/", merge=True)

--- a/backend/src/monarch_py/service/curie_service.py
+++ b/backend/src/monarch_py/service/curie_service.py
@@ -7,11 +7,7 @@ __all__ = [
 ]
 
 # Use the Monarch-specific clone of the "merged" prefixmap context. Aligns
-# with kg-phenio's normalize step (also being moved to the same context to
-# fix the FBBT/WBBT prefix-casing issue that was dropping ~503k Alliance
-# gene-expression edges to dangling, see monarch-app#1319). Same canonical
-# behavior as "merged" today; standardizes the Monarch-facing label across
-# the stack.
+# with kg-phenio's normalize step 
 # (https://github.com/linkml/prefixmaps/blob/main/src/prefixmaps/data/merged.monarch.csv)
 converter = load_converter("merged.monarch")
 converter.add_prefix("GARD", "https://rarediseases.info.nih.gov/diseases/")


### PR DESCRIPTION
## Summary

Switch the CURIE↔IRI converter from the generic `merged` context to **`merged.monarch`** — the Monarch-specific clone of the same prefixmap context, also shipped in `linkml/prefixmaps`.

```python
# before
converter = load_converter(\"merged\")

# after
converter = load_converter(\"merged.monarch\")
```

## Why

Aligns monarch-app with kg-phenio (companion PR moving its `normalize.py` from `contexts=[\"obo\", \"bioregistry.upper\"]` to `contexts=[\"merged.monarch\"]`), so the whole stack uses a single Monarch-curated CURIE convention.

Same canonical behavior today. Verified against a representative sample of CURIEs:

```
FBbt:00000001              →  http://purl.obolibrary.org/obo/FBbt_00000001
WBbt:0000001               →  http://purl.obolibrary.org/obo/WBbt_0000001
MONDO:0007078              →  http://purl.obolibrary.org/obo/MONDO_0007078
GARD:7922                  →  https://rarediseases.info.nih.gov/diseases/7922
Orphanet:98473             →  https://www.orpha.net/en/disease/detail/98473
ICD10CM:G71.0              →  https://www.icd10data.com/search?s=G71.0
phenopacket.store:foo      →  https://github.com/monarch-initiative/phenopacket-store/blob/main/notebooks/foo
```

All four existing `add_prefix` overrides (GARD / NORD / Orphanet / phenopacket.store) and the patched `ICD10CM` map continue to work unchanged.

## Context

Tracing the 2026-06-03 monarch-kg release shortfall on `alliance_gene_to_expression_edges` (1.45M vs 1.9M expected) led to a CURIE-casing bug where kg-phenio's normalize step uppercases the OBO mixed-case anatomy prefixes (`FBbt:` → `FBBT:`, `WBbt:` → `WBBT:`), causing all Drosophila and C. elegans gene-expression edges to dangle.

That bug lives in kg-phenio's combination of `[\"obo\", \"bioregistry.upper\"]` interacting with `universalizer.make_id_maps`'s lowercased-reverse-IRI logic. Switching to a single `merged.monarch` context removes the multi-context ambiguity.

This monarch-app change is the alignment piece — same convention everywhere.

Tracking issue: #1319.