### PR TITLE
fix: re-raise caught ValidationError in parse_associations

### DIFF
--- a/backend/src/monarch_py/implementations/solr/solr_parsers.py
+++ b/backend/src/monarch_py/implementations/solr/solr_parsers.py
@@ -146,7 +146,7 @@ def parse_associations(
                 association = ExpandedAssociation(**doc)
             except ValidationError:
                 logger.error(f"Validation error for {doc}")
-                raise ValidationError
+                raise
             association.provided_by_link = (
                 get_provided_by_link(association.provided_by) if association.provided_by else []
             )

--- a/backend/tests/unit/test_solr_parsers.py
+++ b/backend/tests/unit/test_solr_parsers.py
@@ -1,7 +1,7 @@
 from typing import Optional, List, Union
 
 import pytest
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from monarch_py.datamodels.model import AssociationDirectionEnum, Node
 from monarch_py.datamodels.solr import SolrQueryResult
@@ -37,6 +37,21 @@ def test_parse_associations_compact(association_response, associations_compact):
     assert parsed == associations_compact, (
         f"Parsed result is not as expected. Difference: {dict_diff(parsed, associations_compact)}"
     )
+
+
+def test_parse_associations_reraises_validation_error(association_response):
+    """Regression: a malformed association doc must surface the real pydantic
+    ValidationError, not a TypeError. The handler previously did
+    `raise ValidationError` (the bare class), which under pydantic v2 raises
+    `TypeError: ValidationError.__new__() missing 2 required positional arguments`
+    and 500s the entity endpoint (wired to the LB healthcheck).
+    See docs/incidents/2026-06-10 in monarch-stack-v3."""
+    association_response["response"]["numFound"] = association_response["response"].pop("num_found")
+    solr_response = SolrQueryResult(**association_response)
+    # Drop a required field so ExpandedAssociation(**doc) fails validation.
+    solr_response.response.docs[0].pop("id", None)
+    with pytest.raises(ValidationError):
+        parse_associations(solr_response)
 
 
 def test_parse_association_counts(association_counts_response, association_counts, node):


### PR DESCRIPTION
## Problem

`parse_associations` (solr_parsers.py:149) did `raise ValidationError` — re-raising the bare pydantic **class** rather than the caught instance. Under pydantic v2 this throws:

```
TypeError: ValidationError.__new__() missing 2 required positional arguments: 'title' and 'line_errors'
```

instead of surfacing the real validation error. The entity endpoint (`get_entity` → `get_associations` → `parse_associations`) then 500s with a confusing TypeError.

This matters operationally: `/v3/api/entity/MONDO:0007038` is the **GCP load-balancer healthcheck path** for the api backend, so a single malformed association doc 500s the healthcheck and pulls the whole backend out of rotation — site down at the edge. Surfaced while investigating the 2026-06-10 stack outage (see `docs/incidents/2026-06-10/` in monarch-stack-v3).

## Fix

Use a bare `raise` to re-raise the caught exception, matching the five sibling `except ValidationError` handlers in this same file (lines 253, 281, …).

## Test

Adds `test_parse_associations_reraises_validation_error`: corrupts an association doc (drops a required field) and asserts `parse_associations` raises `ValidationError` — which fails with the old bare-class `raise` (TypeError) and passes now. `39/39` parser tests green.