### PR TITLE
Show dismech pathographs on disease and gene pages (#1318)

### DIFF
--- a/backend/src/monarch_py/api/additional_models.py
+++ b/backend/src/monarch_py/api/additional_models.py
@@ -98,6 +98,7 @@ class PathographEdge(BaseModel):
 class PathographSource(BaseModel):
     id: str = Field(..., title="Mondo id of a contributing disorder")
     name: str = Field(..., title="Disorder name")
+    url: Optional[str] = Field(None, title="Direct link to this disorder's dismech page")
 
 
 class Pathograph(BaseModel):

--- a/backend/src/monarch_py/api/additional_models.py
+++ b/backend/src/monarch_py/api/additional_models.py
@@ -74,3 +74,35 @@ class SemsimSearchRequest(BaseModel):
 
 class TextAnnotationRequest(BaseModel):
     content: str = Field(..., title="The text content to annotate")
+
+
+class PathographNode(BaseModel):
+    id: str = Field(..., title="Stable merged node id (anchor curie, or <mondo>::<name> when disorder-local)")
+    label: str = Field(..., title="Human-readable node label")
+    node_type: str = Field(..., title="dismech node type (pathophysiology, phenotype, genetic, …)")
+    color: Optional[str] = Field(None, title="dismech node fill color")
+    is_orphan: bool = Field(False, title="Whether this node is an unmatched edge target")
+    description: Optional[str] = Field(None, title="Node description")
+    meta: Optional[dict] = Field(None, title="dismech node metadata (term_id, gene_terms, …)")
+    sources: List[str] = Field(..., title="Mondo ids of the disorders contributing this node")
+
+
+class PathographEdge(BaseModel):
+    source: str = Field(..., title="Source node id")
+    target: str = Field(..., title="Target node id")
+    predicate: Optional[str] = Field(None, title="Causal predicate")
+    description: Optional[str] = Field(None, title="Edge description")
+    sources: List[str] = Field(..., title="Mondo ids of the disorders contributing this edge")
+
+
+class PathographSource(BaseModel):
+    id: str = Field(..., title="Mondo id of a contributing disorder")
+    name: str = Field(..., title="Disorder name")
+
+
+class Pathograph(BaseModel):
+    node_id: str = Field(..., title="The queried node id (disease Mondo or gene HGNC)")
+    category: str = Field(..., title="'disease' or 'gene'")
+    nodes: List[PathographNode] = Field(default_factory=list)
+    edges: List[PathographEdge] = Field(default_factory=list)
+    sources: List[PathographSource] = Field(default_factory=list, title="Disorders merged into this pathograph")

--- a/backend/src/monarch_py/api/config.py
+++ b/backend/src/monarch_py/api/config.py
@@ -39,6 +39,10 @@ class Settings(BaseModel):
         "DISMECH_PATHOGRAPHS_URL", "https://dismech.monarchinitiative.org/pathographs"
     )
 
+    # Base for dismech's human-facing disorder pages, used to deep-link each
+    # contributing disorder back to its dismech page (pages/disorders/<slug>.html).
+    dismech_site_url: str = os.getenv("DISMECH_SITE_URL", "https://dismech.monarchinitiative.org")
+
 
 settings = Settings()
 

--- a/backend/src/monarch_py/api/config.py
+++ b/backend/src/monarch_py/api/config.py
@@ -31,6 +31,14 @@ class Settings(BaseModel):
         "yes",
     )
 
+    # Base for the dismech pathograph artifact (index.json, by_gene.json,
+    # MONDO_<id>.json). Defaults to the published GitHub Pages location; point
+    # at a local directory while developing against an un-pushed dismech export:
+    #   DISMECH_PATHOGRAPHS_URL=/path/to/dismech/pathographs make dev-api
+    dismech_pathographs_url: str = os.getenv(
+        "DISMECH_PATHOGRAPHS_URL", "https://dismech.monarchinitiative.org/pathographs"
+    )
+
 
 settings = Settings()
 

--- a/backend/src/monarch_py/api/main.py
+++ b/backend/src/monarch_py/api/main.py
@@ -11,6 +11,7 @@ from monarch_py.api import (
     entity_grid,
     histopheno,
     meta,
+    pathograph,
     search,
     semsim,
     sources_versions,
@@ -42,6 +43,7 @@ app.include_router(entity.router, prefix=f"{PREFIX}/entity")
 app.include_router(entity_grid.router, prefix=f"{PREFIX}/entity")
 app.include_router(histopheno.router, prefix=f"{PREFIX}/histopheno")
 app.include_router(meta.router, prefix=PREFIX)
+app.include_router(pathograph.router, prefix=f"{PREFIX}/pathograph")
 app.include_router(search.router, prefix=PREFIX)
 app.include_router(semsim.router, prefix=f"{PREFIX}/semsim")
 app.include_router(sources_versions.router, prefix=PREFIX)

--- a/backend/src/monarch_py/api/pathograph.py
+++ b/backend/src/monarch_py/api/pathograph.py
@@ -52,8 +52,21 @@ def _read_artifact(name: str) -> str | None:
             return None
         resp.raise_for_status()
         return resp.text
-    path = Path(base) / name
+    # Local-dir mode: ``name`` can come from the artifact's own index.json
+    # (entry["file"]), so confine the resolved path to the base directory.
+    base_dir = Path(base).resolve()
+    path = (base_dir / name).resolve()
+    if not path.is_relative_to(base_dir):
+        raise HTTPException(status_code=400, detail="Invalid artifact path")
     return path.read_text() if path.exists() else None
+
+
+def _parse_json(text: str, name: str) -> Any:
+    """Parse an artifact body, surfacing a corrupt file as a 502 (not a 500)."""
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as e:
+        raise HTTPException(status_code=502, detail=f"Pathograph artifact {name} is not valid JSON: {e}") from e
 
 
 def _load_index(name: str) -> dict:
@@ -65,7 +78,7 @@ def _load_index(name: str) -> dict:
     text = _read_artifact(name)
     if text is None:
         raise HTTPException(status_code=502, detail=f"Pathograph artifact {name} is unavailable")
-    data = json.loads(text)
+    data = _parse_json(text, name)
     with _index_lock:
         _index_cache[name] = (time.time(), data)
     return data
@@ -162,7 +175,7 @@ def _collect_graphs(mondo_ids: list[str], index: dict) -> list[tuple[str, str, s
             text = _read_artifact(entry["file"])
             if text is None:
                 continue
-            collected.append((mondo, entry.get("name", mondo), entry.get("slug"), json.loads(text)))
+            collected.append((mondo, entry.get("name", mondo), entry.get("slug"), _parse_json(text, entry["file"])))
     return collected
 
 
@@ -217,7 +230,6 @@ def _get_pathograph(
         nodes=nodes,
         edges=edges,
         sources=[
-            PathographSource(id=mondo, name=name, url=_disorder_url(slug))
-            for mondo, (name, slug) in sources.items()
+            PathographSource(id=mondo, name=name, url=_disorder_url(slug)) for mondo, (name, slug) in sources.items()
         ],
     )

--- a/backend/src/monarch_py/api/pathograph.py
+++ b/backend/src/monarch_py/api/pathograph.py
@@ -1,0 +1,213 @@
+"""API endpoint serving dismech pathographs for disease and gene pages.
+
+Proxies the dismech pathograph artifact (``index.json``, ``by_gene.json`` and
+per-disorder ``MONDO_<id>.json`` files) so the frontend fetches same-origin —
+no CORS — and so the gene-page anchor-merge happens once, server-side, instead
+of N cross-origin fetches in the browser.
+
+The artifact base is ``settings.dismech_pathographs_url`` (a published URL in
+prod, a local directory while developing against an un-pushed dismech export).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+import requests
+from fastapi import APIRouter, HTTPException, Path as PathParam
+
+from monarch_py.api.additional_models import (
+    Pathograph,
+    PathographEdge,
+    PathographNode,
+    PathographSource,
+)
+from monarch_py.api.config import settings
+
+router = APIRouter(tags=["pathograph"], responses={404: {"description": "Not Found"}})
+
+# CURIE shape — node ids feed artifact lookups, so keep them strict.
+_CURIE_PATTERN = re.compile(r"^[A-Za-z]+:[A-Za-z0-9]+$")
+
+# index.json / by_gene.json are hit on every request; cache them briefly.
+_INDEX_TTL_SECONDS = 300
+_index_cache: dict[str, tuple[float, dict]] = {}
+_index_lock = threading.Lock()
+
+
+def _read_artifact(name: str) -> str | None:
+    """Read one artifact file by name from the configured base (URL or dir)."""
+    base = settings.dismech_pathographs_url
+    if base.startswith(("http://", "https://")):
+        try:
+            resp = requests.get(f"{base.rstrip('/')}/{name}", timeout=15)
+        except requests.RequestException as e:
+            raise HTTPException(status_code=502, detail=f"Failed to fetch {name}: {e}") from e
+        if resp.status_code == 404:
+            return None
+        resp.raise_for_status()
+        return resp.text
+    path = Path(base) / name
+    return path.read_text() if path.exists() else None
+
+
+def _load_index(name: str) -> dict:
+    """Load and cache a top-level index artifact (index.json or by_gene.json)."""
+    with _index_lock:
+        cached = _index_cache.get(name)
+        if cached and (time.time() - cached[0]) < _INDEX_TTL_SECONDS:
+            return cached[1]
+    text = _read_artifact(name)
+    if text is None:
+        raise HTTPException(status_code=502, detail=f"Pathograph artifact {name} is unavailable")
+    data = json.loads(text)
+    with _index_lock:
+        _index_cache[name] = (time.time(), data)
+    return data
+
+
+def _anchor_id(node: dict[str, Any]) -> str | None:
+    """Stable cross-disorder id for nodes that should be boxed when merging.
+
+    Phenotypes box on their HP term id; single-gene genetic nodes box on the
+    HGNC id. Everything else (free-text mechanism nodes) stays disorder-local.
+    """
+    meta = node.get("meta") or {}
+    if node.get("node_type") == "phenotype" and meta.get("term_id"):
+        return f"HP:{str(meta['term_id']).split(':')[-1]}"
+    gene_ids = [gt["id"] for gt in (meta.get("gene_terms") or []) if gt.get("id")]
+    if node.get("node_type") == "genetic" and len(gene_ids) == 1:
+        return f"GENE:{gene_ids[0].lower()}"
+    return None
+
+
+def _merge(graphs: list[tuple[str, str, dict]]) -> tuple[list[PathographNode], list[PathographEdge]]:
+    """Anchor-merge per-disorder graphs into one.
+
+    Shared phenotypes/genes collapse to a single boxed node (carrying every
+    contributing Mondo id in ``sources``); disorder-local mechanism nodes are
+    namespaced by Mondo id so they never collide. For a single graph this is a
+    faithful pass-through.
+    """
+    nodes: dict[str, PathographNode] = {}
+    edges: dict[tuple[str, str, str | None], PathographEdge] = {}
+
+    for mondo, _name, graph in graphs:
+        local_to_gid: dict[str, str] = {}
+        for node in graph.get("nodes", []):
+            gid = _anchor_id(node) or f"{mondo}::{node['id']}"
+            local_to_gid[node["id"]] = gid
+            existing = nodes.get(gid)
+            if existing is None:
+                nodes[gid] = PathographNode(
+                    id=gid,
+                    label=node["id"],
+                    node_type=node.get("node_type", "unknown"),
+                    color=node.get("color"),
+                    is_orphan=node.get("is_orphan", False),
+                    description=node.get("description"),
+                    meta=node.get("meta"),
+                    sources=[mondo],
+                )
+            else:
+                if mondo not in existing.sources:
+                    existing.sources.append(mondo)
+                # A node defined for real in any disorder beats an orphan stub.
+                if existing.is_orphan and not node.get("is_orphan", False):
+                    existing.is_orphan = False
+                    existing.node_type = node.get("node_type", existing.node_type)
+                    existing.color = node.get("color", existing.color)
+                    existing.label = node["id"]
+                existing.description = existing.description or node.get("description")
+                existing.meta = existing.meta or node.get("meta")
+
+        for edge in graph.get("edges", []):
+            source = local_to_gid.get(edge["source"])
+            target = local_to_gid.get(edge["target"])
+            if source is None or target is None:
+                continue
+            key = (source, target, edge.get("predicate"))
+            existing_edge = edges.get(key)
+            if existing_edge is None:
+                edges[key] = PathographEdge(
+                    source=source,
+                    target=target,
+                    predicate=edge.get("predicate"),
+                    description=edge.get("description"),
+                    sources=[mondo],
+                )
+            elif mondo not in existing_edge.sources:
+                existing_edge.sources.append(mondo)
+
+    return list(nodes.values()), list(edges.values())
+
+
+def _collect_graphs(mondo_ids: list[str], index: dict) -> list[tuple[str, str, dict]]:
+    """Load every disorder graph for the given Mondo ids."""
+    collected: list[tuple[str, str, dict]] = []
+    for mondo in mondo_ids:
+        for entry in index.get(mondo, []):
+            text = _read_artifact(entry["file"])
+            if text is None:
+                continue
+            collected.append((mondo, entry.get("name", mondo), json.loads(text)))
+    return collected
+
+
+@router.get("/{node_id}")
+def _get_pathograph(
+    node_id: str = PathParam(
+        title="Disease (MONDO) or gene (HGNC) id to fetch a pathograph for",
+        examples=["MONDO:0018923", "HGNC:870"],
+    ),
+) -> Pathograph:
+    """Return a dismech pathograph for a disease or gene node.
+
+    Disease (``MONDO:…``) returns that disorder's pathograph. Gene (``HGNC:…``)
+    returns every disorder pathograph the gene participates in, anchor-merged
+    into one graph. 404 when no pathograph exists for the node.
+    """
+    if not _CURIE_PATTERN.match(node_id):
+        raise HTTPException(status_code=400, detail="Invalid node id; expected a CURIE like MONDO:0018923")
+
+    upper = node_id.upper()
+    index = _load_index("index.json")
+
+    if upper.startswith("MONDO:"):
+        if upper not in index:
+            raise HTTPException(status_code=404, detail=f"No pathograph for {upper}")
+        mondo_ids = [upper]
+        category = "disease"
+    elif upper.startswith("HGNC:"):
+        by_gene = _load_index("by_gene.json")
+        mondo_ids = by_gene.get(node_id.lower())
+        if not mondo_ids:
+            raise HTTPException(status_code=404, detail=f"No pathographs reference {upper}")
+        category = "gene"
+    else:
+        raise HTTPException(
+            status_code=404, detail=f"Pathographs are only available for diseases and genes, not {upper}"
+        )
+
+    graphs = _collect_graphs(mondo_ids, index)
+    if not graphs:
+        raise HTTPException(status_code=404, detail=f"No pathograph data found for {upper}")
+
+    nodes, edges = _merge(graphs)
+    # De-dupe contributing disorders, preserving first-seen order.
+    sources: dict[str, str] = {}
+    for mondo, name, _graph in graphs:
+        sources.setdefault(mondo, name)
+
+    return Pathograph(
+        node_id=upper,
+        category=category,
+        nodes=nodes,
+        edges=edges,
+        sources=[PathographSource(id=mondo, name=name) for mondo, name in sources.items()],
+    )

--- a/backend/src/monarch_py/api/pathograph.py
+++ b/backend/src/monarch_py/api/pathograph.py
@@ -11,6 +11,7 @@ prod, a local directory while developing against an un-pushed dismech export).
 
 from __future__ import annotations
 
+import asyncio
 import json
 import re
 import threading
@@ -18,7 +19,7 @@ import time
 from pathlib import Path
 from typing import Any
 
-import requests
+import httpx
 from fastapi import APIRouter, HTTPException, Path as PathParam
 
 from monarch_py.api.additional_models import (
@@ -40,20 +41,23 @@ _index_cache: dict[str, tuple[float, dict]] = {}
 _index_lock = threading.Lock()
 
 
-def _read_artifact(name: str) -> str | None:
-    """Read one artifact file by name from the configured base (URL or dir)."""
+async def _read_artifact(client: httpx.AsyncClient, name: str) -> str | None:
+    """Read one artifact file by name from the configured base (URL or dir).
+
+    URL mode fetches over the shared async client (non-blocking); local-dir mode
+    reads from disk. ``name`` can come from the artifact's own index.json
+    (entry["file"]), so local reads are confined to the base directory.
+    """
     base = settings.dismech_pathographs_url
     if base.startswith(("http://", "https://")):
         try:
-            resp = requests.get(f"{base.rstrip('/')}/{name}", timeout=15)
-        except requests.RequestException as e:
+            resp = await client.get(f"{base.rstrip('/')}/{name}")
+        except httpx.HTTPError as e:
             raise HTTPException(status_code=502, detail=f"Failed to fetch {name}: {e}") from e
         if resp.status_code == 404:
             return None
         resp.raise_for_status()
         return resp.text
-    # Local-dir mode: ``name`` can come from the artifact's own index.json
-    # (entry["file"]), so confine the resolved path to the base directory.
     base_dir = Path(base).resolve()
     path = (base_dir / name).resolve()
     if not path.is_relative_to(base_dir):
@@ -69,13 +73,13 @@ def _parse_json(text: str, name: str) -> Any:
         raise HTTPException(status_code=502, detail=f"Pathograph artifact {name} is not valid JSON: {e}") from e
 
 
-def _load_index(name: str) -> dict:
+async def _load_index(client: httpx.AsyncClient, name: str) -> dict:
     """Load and cache a top-level index artifact (index.json or by_gene.json)."""
     with _index_lock:
         cached = _index_cache.get(name)
         if cached and (time.time() - cached[0]) < _INDEX_TTL_SECONDS:
             return cached[1]
-    text = _read_artifact(name)
+    text = await _read_artifact(client, name)
     if text is None:
         raise HTTPException(status_code=502, detail=f"Pathograph artifact {name} is unavailable")
     data = _parse_json(text, name)
@@ -94,8 +98,10 @@ def _anchor_id(node: dict[str, Any]) -> str | None:
     if node.get("node_type") == "phenotype" and meta.get("term_id"):
         return f"HP:{str(meta['term_id']).split(':')[-1]}"
     gene_ids = [gt["id"] for gt in (meta.get("gene_terms") or []) if gt.get("id")]
-    if node.get("node_type") == "genetic" and len(gene_ids) == 1:
-        return f"GENE:{gene_ids[0].lower()}"
+    # Anchor single-gene nodes on the real HGNC curie (e.g. "hgnc:1956" ->
+    # "HGNC:1956") so the id is a resolvable Monarch entity, not a pseudo-curie.
+    if node.get("node_type") == "genetic" and len(gene_ids) == 1 and gene_ids[0].lower().startswith("hgnc:"):
+        return gene_ids[0].upper()
     return None
 
 
@@ -167,20 +173,26 @@ def _merge(graphs: list[tuple[str, str, str | None, dict]]) -> tuple[list[Pathog
     return list(nodes.values()), list(edges.values())
 
 
-def _collect_graphs(mondo_ids: list[str], index: dict) -> list[tuple[str, str, str | None, dict]]:
-    """Load every disorder graph for the given Mondo ids (with name + dismech slug)."""
+async def _collect_graphs(
+    client: httpx.AsyncClient, mondo_ids: list[str], index: dict
+) -> list[tuple[str, str, str | None, dict]]:
+    """Load every disorder graph for the given Mondo ids (with name + dismech slug).
+
+    Disorder files are fetched concurrently — a gene linked to many disorders
+    would otherwise stack one blocking fetch per disorder.
+    """
+    entries = [(mondo, entry) for mondo in mondo_ids for entry in index.get(mondo, [])]
+    texts = await asyncio.gather(*(_read_artifact(client, entry["file"]) for _mondo, entry in entries))
     collected: list[tuple[str, str, str | None, dict]] = []
-    for mondo in mondo_ids:
-        for entry in index.get(mondo, []):
-            text = _read_artifact(entry["file"])
-            if text is None:
-                continue
-            collected.append((mondo, entry.get("name", mondo), entry.get("slug"), _parse_json(text, entry["file"])))
+    for (mondo, entry), text in zip(entries, texts):
+        if text is None:
+            continue
+        collected.append((mondo, entry.get("name", mondo), entry.get("slug"), _parse_json(text, entry["file"])))
     return collected
 
 
 @router.get("/{node_id}")
-def _get_pathograph(
+async def _get_pathograph(
     node_id: str = PathParam(
         title="Disease (MONDO) or gene (HGNC) id to fetch a pathograph for",
         examples=["MONDO:0018923", "HGNC:870"],
@@ -196,25 +208,26 @@ def _get_pathograph(
         raise HTTPException(status_code=400, detail="Invalid node id; expected a CURIE like MONDO:0018923")
 
     upper = node_id.upper()
-    index = _load_index("index.json")
+    async with httpx.AsyncClient(timeout=15) as client:
+        index = await _load_index(client, "index.json")
 
-    if upper.startswith("MONDO:"):
-        if upper not in index:
-            raise HTTPException(status_code=404, detail=f"No pathograph for {upper}")
-        mondo_ids = [upper]
-        category = "disease"
-    elif upper.startswith("HGNC:"):
-        by_gene = _load_index("by_gene.json")
-        mondo_ids = by_gene.get(node_id.lower())
-        if not mondo_ids:
-            raise HTTPException(status_code=404, detail=f"No pathographs reference {upper}")
-        category = "gene"
-    else:
-        raise HTTPException(
-            status_code=404, detail=f"Pathographs are only available for diseases and genes, not {upper}"
-        )
+        if upper.startswith("MONDO:"):
+            if upper not in index:
+                raise HTTPException(status_code=404, detail=f"No pathograph for {upper}")
+            mondo_ids = [upper]
+            category = "disease"
+        elif upper.startswith("HGNC:"):
+            by_gene = await _load_index(client, "by_gene.json")
+            mondo_ids = by_gene.get(node_id.lower())
+            if not mondo_ids:
+                raise HTTPException(status_code=404, detail=f"No pathographs reference {upper}")
+            category = "gene"
+        else:
+            raise HTTPException(
+                status_code=404, detail=f"Pathographs are only available for diseases and genes, not {upper}"
+            )
 
-    graphs = _collect_graphs(mondo_ids, index)
+        graphs = await _collect_graphs(client, mondo_ids, index)
     if not graphs:
         raise HTTPException(status_code=404, detail=f"No pathograph data found for {upper}")
 

--- a/backend/src/monarch_py/api/pathograph.py
+++ b/backend/src/monarch_py/api/pathograph.py
@@ -86,7 +86,14 @@ def _anchor_id(node: dict[str, Any]) -> str | None:
     return None
 
 
-def _merge(graphs: list[tuple[str, str, dict]]) -> tuple[list[PathographNode], list[PathographEdge]]:
+def _disorder_url(slug: str | None) -> str | None:
+    """Deep link to a disorder's dismech page, from the slug carried in index.json."""
+    if not slug:
+        return None
+    return f"{settings.dismech_site_url.rstrip('/')}/pages/disorders/{slug}.html"
+
+
+def _merge(graphs: list[tuple[str, str, str | None, dict]]) -> tuple[list[PathographNode], list[PathographEdge]]:
     """Anchor-merge per-disorder graphs into one.
 
     Shared phenotypes/genes collapse to a single boxed node (carrying every
@@ -97,7 +104,7 @@ def _merge(graphs: list[tuple[str, str, dict]]) -> tuple[list[PathographNode], l
     nodes: dict[str, PathographNode] = {}
     edges: dict[tuple[str, str, str | None], PathographEdge] = {}
 
-    for mondo, _name, graph in graphs:
+    for mondo, _name, _slug, graph in graphs:
         local_to_gid: dict[str, str] = {}
         for node in graph.get("nodes", []):
             gid = _anchor_id(node) or f"{mondo}::{node['id']}"
@@ -147,15 +154,15 @@ def _merge(graphs: list[tuple[str, str, dict]]) -> tuple[list[PathographNode], l
     return list(nodes.values()), list(edges.values())
 
 
-def _collect_graphs(mondo_ids: list[str], index: dict) -> list[tuple[str, str, dict]]:
-    """Load every disorder graph for the given Mondo ids."""
-    collected: list[tuple[str, str, dict]] = []
+def _collect_graphs(mondo_ids: list[str], index: dict) -> list[tuple[str, str, str | None, dict]]:
+    """Load every disorder graph for the given Mondo ids (with name + dismech slug)."""
+    collected: list[tuple[str, str, str | None, dict]] = []
     for mondo in mondo_ids:
         for entry in index.get(mondo, []):
             text = _read_artifact(entry["file"])
             if text is None:
                 continue
-            collected.append((mondo, entry.get("name", mondo), json.loads(text)))
+            collected.append((mondo, entry.get("name", mondo), entry.get("slug"), json.loads(text)))
     return collected
 
 
@@ -200,14 +207,17 @@ def _get_pathograph(
 
     nodes, edges = _merge(graphs)
     # De-dupe contributing disorders, preserving first-seen order.
-    sources: dict[str, str] = {}
-    for mondo, name, _graph in graphs:
-        sources.setdefault(mondo, name)
+    sources: dict[str, tuple[str, str | None]] = {}
+    for mondo, name, slug, _graph in graphs:
+        sources.setdefault(mondo, (name, slug))
 
     return Pathograph(
         node_id=upper,
         category=category,
         nodes=nodes,
         edges=edges,
-        sources=[PathographSource(id=mondo, name=name) for mondo, name in sources.items()],
+        sources=[
+            PathographSource(id=mondo, name=name, url=_disorder_url(slug))
+            for mondo, (name, slug) in sources.items()
+        ],
     )

--- a/backend/tests/unit/test_pathograph_api.py
+++ b/backend/tests/unit/test_pathograph_api.py
@@ -76,6 +76,8 @@ def test_disease_returns_passthrough_graph(client, artifact_dir):
     assert body["category"] == "disease"
     assert body["node_id"] == "MONDO:0000001"
     assert [s["id"] for s in body["sources"]] == ["MONDO:0000001"]
+    # Source deep-links to the disorder's dismech page, built from its slug.
+    assert body["sources"][0]["url"].endswith("/pages/disorders/Disease_A.html")
     assert len(body["nodes"]) == 3
     assert len(body["edges"]) == 2
     # The free-text mechanism node is namespaced by its Mondo id.

--- a/backend/tests/unit/test_pathograph_api.py
+++ b/backend/tests/unit/test_pathograph_api.py
@@ -84,7 +84,7 @@ def test_disease_returns_passthrough_graph(client, artifact_dir):
     ids = {n["id"] for n in body["nodes"]}
     assert "MONDO:0000001::Mechanism" in ids
     assert "HP:0001250" in ids  # phenotype anchored on its HP id
-    assert "GENE:hgnc:111" in ids  # gene anchored on its HGNC id
+    assert "HGNC:111" in ids  # gene anchored on its (real) HGNC curie
 
 
 def test_gene_merges_and_boxes_shared_nodes(client, artifact_dir):
@@ -96,7 +96,7 @@ def test_gene_merges_and_boxes_shared_nodes(client, artifact_dir):
 
     nodes = {n["id"]: n for n in body["nodes"]}
     # Shared gene and phenotype collapse to one node carrying both disorders.
-    assert sorted(nodes["GENE:hgnc:111"]["sources"]) == ["MONDO:0000001", "MONDO:0000002"]
+    assert sorted(nodes["HGNC:111"]["sources"]) == ["MONDO:0000001", "MONDO:0000002"]
     assert sorted(nodes["HP:0001250"]["sources"]) == ["MONDO:0000001", "MONDO:0000002"]
     # Same-named free-text mechanisms stay separate (one lane per disorder).
     assert "MONDO:0000001::Mechanism" in nodes
@@ -125,7 +125,7 @@ def test_hgnc_uppercase_resolves(client, artifact_dir):
 
 
 def test_upstream_error_returns_502(client, artifact_dir, monkeypatch):
-    def boom(name):
+    async def boom(_client, name):
         raise route.HTTPException(status_code=502, detail="upstream down")
 
     monkeypatch.setattr(route, "_read_artifact", boom)

--- a/backend/tests/unit/test_pathograph_api.py
+++ b/backend/tests/unit/test_pathograph_api.py
@@ -117,3 +117,23 @@ def test_unknown_ids_return_404(client, artifact_dir):
 def test_malformed_curie_returns_400(client, artifact_dir):
     r = client.get("/v3/api/pathograph/FOO:bar-baz")
     assert r.status_code == 400
+
+
+def test_hgnc_uppercase_resolves(client, artifact_dir):
+    # by_gene.json keys are lowercase (hgnc:111); the endpoint accepts HGNC:111.
+    assert client.get("/v3/api/pathograph/HGNC:111").status_code == 200
+
+
+def test_upstream_error_returns_502(client, artifact_dir, monkeypatch):
+    def boom(name):
+        raise route.HTTPException(status_code=502, detail="upstream down")
+
+    monkeypatch.setattr(route, "_read_artifact", boom)
+    assert client.get("/v3/api/pathograph/MONDO:0000001").status_code == 502
+
+
+def test_malformed_artifact_json_returns_502(client, artifact_dir):
+    # Corrupt the index so json parsing fails — should be a clean 502, not a 500.
+    (artifact_dir / "index.json").write_text("{not valid json")
+    r = client.get("/v3/api/pathograph/MONDO:0000001")
+    assert r.status_code == 502

--- a/backend/tests/unit/test_pathograph_api.py
+++ b/backend/tests/unit/test_pathograph_api.py
@@ -1,0 +1,117 @@
+"""Unit tests for the /pathograph FastAPI route.
+
+Exercises the artifact loader, the disease pass-through, and the gene
+anchor-merge against a crafted local artifact directory (no network).
+"""
+
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+
+from monarch_py.api import pathograph as route
+from monarch_py.api.main import app
+
+# Two disorders that share a gene (hgnc:111) and a phenotype (HP:0001250), and
+# each have a free-text mechanism node with the SAME label (must NOT merge).
+DISORDER_A = {
+    "nodes": [
+        {"id": "GeneX", "node_type": "genetic", "meta": {"gene_terms": [{"label": "GeneX", "id": "hgnc:111"}]}},
+        {"id": "Mechanism", "node_type": "pathophysiology", "description": "A's mechanism"},
+        {"id": "Seizure", "node_type": "phenotype", "meta": {"term_id": "HP:0001250"}},
+    ],
+    "edges": [
+        {"source": "GeneX", "target": "Mechanism", "predicate": "causes"},
+        {"source": "Mechanism", "target": "Seizure", "predicate": "causes"},
+    ],
+    "orphan_targets": [],
+}
+DISORDER_B = {
+    "nodes": [
+        {"id": "GeneX", "node_type": "genetic", "meta": {"gene_terms": [{"label": "GeneX", "id": "hgnc:111"}]}},
+        {"id": "Mechanism", "node_type": "pathophysiology", "description": "B's mechanism"},
+        {"id": "Seizure", "node_type": "phenotype", "meta": {"term_id": "HP:0001250"}},
+    ],
+    "edges": [
+        {"source": "GeneX", "target": "Mechanism", "predicate": "causes"},
+        {"source": "Mechanism", "target": "Seizure", "predicate": "causes"},
+    ],
+    "orphan_targets": [],
+}
+
+
+@pytest.fixture
+def artifact_dir(tmp_path, monkeypatch):
+    (tmp_path / "MONDO_0000001.json").write_text(json.dumps(DISORDER_A))
+    (tmp_path / "MONDO_0000002.json").write_text(json.dumps(DISORDER_B))
+    (tmp_path / "index.json").write_text(
+        json.dumps(
+            {
+                "MONDO:0000001": [{"file": "MONDO_0000001.json", "name": "Disease A", "slug": "Disease_A"}],
+                "MONDO:0000002": [{"file": "MONDO_0000002.json", "name": "Disease B", "slug": "Disease_B"}],
+            }
+        )
+    )
+    (tmp_path / "by_gene.json").write_text(json.dumps({"hgnc:111": ["MONDO:0000001", "MONDO:0000002"]}))
+    monkeypatch.setattr(route.settings, "dismech_pathographs_url", str(tmp_path))
+    return tmp_path
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    route._index_cache.clear()
+    yield
+    route._index_cache.clear()
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+def test_disease_returns_passthrough_graph(client, artifact_dir):
+    r = client.get("/v3/api/pathograph/MONDO:0000001")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["category"] == "disease"
+    assert body["node_id"] == "MONDO:0000001"
+    assert [s["id"] for s in body["sources"]] == ["MONDO:0000001"]
+    assert len(body["nodes"]) == 3
+    assert len(body["edges"]) == 2
+    # The free-text mechanism node is namespaced by its Mondo id.
+    ids = {n["id"] for n in body["nodes"]}
+    assert "MONDO:0000001::Mechanism" in ids
+    assert "HP:0001250" in ids  # phenotype anchored on its HP id
+    assert "GENE:hgnc:111" in ids  # gene anchored on its HGNC id
+
+
+def test_gene_merges_and_boxes_shared_nodes(client, artifact_dir):
+    r = client.get("/v3/api/pathograph/HGNC:111")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["category"] == "gene"
+    assert {s["id"] for s in body["sources"]} == {"MONDO:0000001", "MONDO:0000002"}
+
+    nodes = {n["id"]: n for n in body["nodes"]}
+    # Shared gene and phenotype collapse to one node carrying both disorders.
+    assert sorted(nodes["GENE:hgnc:111"]["sources"]) == ["MONDO:0000001", "MONDO:0000002"]
+    assert sorted(nodes["HP:0001250"]["sources"]) == ["MONDO:0000001", "MONDO:0000002"]
+    # Same-named free-text mechanisms stay separate (one lane per disorder).
+    assert "MONDO:0000001::Mechanism" in nodes
+    assert "MONDO:0000002::Mechanism" in nodes
+    # gene + phenotype (1 each) + 2 local mechanisms = 4 nodes
+    assert len(body["nodes"]) == 4
+    # GeneX->MechA, GeneX->MechB, MechA->HP, MechB->HP = 4 edges
+    assert len(body["edges"]) == 4
+
+
+def test_unknown_ids_return_404(client, artifact_dir):
+    assert client.get("/v3/api/pathograph/MONDO:0009999").status_code == 404
+    assert client.get("/v3/api/pathograph/HGNC:9999999").status_code == 404
+    # Not a disease or gene.
+    assert client.get("/v3/api/pathograph/CHEBI:12345").status_code == 404
+
+
+def test_malformed_curie_returns_400(client, artifact_dir):
+    r = client.get("/v3/api/pathograph/FOO:bar-baz")
+    assert r.status_code == 400

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "test:e2e": "playwright test"
   },
   "dependencies": {
+    "@dagrejs/dagre": "^3.0.0",
     "@duckdb/duckdb-wasm": "^1.28.0",
     "@floating-ui/dom": "^1.6.3",
     "@fortawesome/fontawesome-svg-core": "^6.5.1",

--- a/frontend/src/api/pathograph.ts
+++ b/frontend/src/api/pathograph.ts
@@ -25,6 +25,8 @@ export type PathographSource = {
   /** mondo id */
   id: string;
   name: string;
+  /** direct link to this disorder's dismech page, when available */
+  url?: string | null;
 };
 
 export type Pathograph = {

--- a/frontend/src/api/pathograph.ts
+++ b/frontend/src/api/pathograph.ts
@@ -1,0 +1,45 @@
+import { apiUrl, request } from "./index";
+
+export type PathographNode = {
+  /** stable merged id (anchor curie, or <mondo>::<name> when disorder-local) */
+  id: string;
+  label: string;
+  node_type: string;
+  color?: string | null;
+  is_orphan: boolean;
+  description?: string | null;
+  meta?: Record<string, unknown> | null;
+  /** mondo ids of the disorders contributing this node */
+  sources: string[];
+};
+
+export type PathographEdge = {
+  source: string;
+  target: string;
+  predicate?: string | null;
+  description?: string | null;
+  sources: string[];
+};
+
+export type PathographSource = {
+  /** mondo id */
+  id: string;
+  name: string;
+};
+
+export type Pathograph = {
+  node_id: string;
+  category: "disease" | "gene";
+  nodes: PathographNode[];
+  edges: PathographEdge[];
+  sources: PathographSource[];
+};
+
+/**
+ * Get the dismech pathograph for a disease (MONDO) or gene (HGNC) node. The
+ * backend returns 404 (→ thrown error) when no pathograph exists for the node.
+ */
+export const getPathograph = async (id: string): Promise<Pathograph> => {
+  const url = `${apiUrl}/pathograph/${id}`;
+  return await request<Pathograph>(url);
+};

--- a/frontend/src/pages/node/PageNode.vue
+++ b/frontend/src/pages/node/PageNode.vue
@@ -25,7 +25,6 @@
     <SectionTitle :node="node" />
     <SectionOverview :node="node" />
     <SectionVisualization :node="node" />
-    <SectionPathograph :node="node" />
     <SectionCrossSpecies :node="node" />
     <SectionAssociations :node="node" />
     <SectionBreadcrumbs :node="node" />
@@ -48,7 +47,6 @@ import SectionBreadcrumbs from "@/pages/node/SectionBreadcrumbs.vue";
 import SectionAssociations from "./SectionAssociations.vue";
 import SectionCrossSpecies from "./SectionCrossSpecies.vue";
 import SectionOverview from "./SectionOverview.vue";
-import SectionPathograph from "./SectionPathograph.vue";
 import SectionTitle from "./SectionTitle.vue";
 import SectionVisualization from "./SectionVisualization.vue";
 

--- a/frontend/src/pages/node/PageNode.vue
+++ b/frontend/src/pages/node/PageNode.vue
@@ -25,6 +25,7 @@
     <SectionTitle :node="node" />
     <SectionOverview :node="node" />
     <SectionVisualization :node="node" />
+    <SectionPathograph :node="node" />
     <SectionCrossSpecies :node="node" />
     <SectionAssociations :node="node" />
     <SectionBreadcrumbs :node="node" />
@@ -47,6 +48,7 @@ import SectionBreadcrumbs from "@/pages/node/SectionBreadcrumbs.vue";
 import SectionAssociations from "./SectionAssociations.vue";
 import SectionCrossSpecies from "./SectionCrossSpecies.vue";
 import SectionOverview from "./SectionOverview.vue";
+import SectionPathograph from "./SectionPathograph.vue";
 import SectionTitle from "./SectionTitle.vue";
 import SectionVisualization from "./SectionVisualization.vue";
 

--- a/frontend/src/pages/node/SectionAssociations.vue
+++ b/frontend/src/pages/node/SectionAssociations.vue
@@ -97,6 +97,15 @@
       </template>
     </AppSection>
 
+    <!-- dismech pathograph shown directly under the phenotype table -->
+    <SectionPathograph
+      v-if="
+        category.id === 'biolink:DiseaseToPhenotypicFeatureAssociation' ||
+        category.id === 'biolink:GeneToPhenotypicFeatureAssociation'
+      "
+      :node="node"
+    />
+
     <!-- Case-Phenotype Grid shown after Cases section -->
     <SectionCasePhenotypeGrid
       v-if="category.id === 'biolink:CaseToDiseaseAssociation'"
@@ -117,6 +126,7 @@ import AppTextbox from "@/components/AppTextbox.vue";
 import { useAssociationCategories } from "@/composables/use-association-categories";
 import AssociationsTable from "@/pages/node/AssociationsTable.vue";
 import SectionCasePhenotypeGrid from "@/pages/node/SectionCasePhenotypeGrid.vue";
+import SectionPathograph from "@/pages/node/SectionPathograph.vue";
 import { sectionTitle } from "@/util/sectionTitles";
 import { tabLabel } from "@/util/tabText";
 import { isTaxonFilterable } from "@/util/taxonFilterConfig";

--- a/frontend/src/pages/node/SectionPathograph.vue
+++ b/frontend/src/pages/node/SectionPathograph.vue
@@ -24,9 +24,7 @@
         }}.
       </template>
       <template v-else> Causal mechanism for {{ node.name }}. </template>
-      Sourced from Dismech, a pre-alpha resource that is actively curated, may
-      be incomplete or change, and is not yet part of the Monarch knowledge
-      graph.
+      From Dismech &mdash; curated using AI, may have mistakes.
       <AppLink :to="sourceLink">{{
         pathograph.category === "disease"
           ? "View this disorder on Dismech"

--- a/frontend/src/pages/node/SectionPathograph.vue
+++ b/frontend/src/pages/node/SectionPathograph.vue
@@ -44,7 +44,7 @@
       >
         <defs>
           <marker
-            id="pathograph-arrow"
+            :id="arrowId"
             viewBox="0 0 10 10"
             refX="9"
             refY="5"
@@ -62,7 +62,7 @@
           :key="`e${i}`"
           :d="edge.path"
           class="edge"
-          marker-end="url(#pathograph-arrow)"
+          :marker-end="`url(#${arrowId})`"
         >
           <title>
             {{ edge.predicate
@@ -116,7 +116,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, watch } from "vue";
+import { computed, getCurrentInstance, watch } from "vue";
 import { useRoute } from "vue-router";
 import dagre from "@dagrejs/dagre";
 import type { Node } from "@/api/model";
@@ -133,6 +133,9 @@ const props = defineProps<Props>();
 const route = useRoute();
 
 const DISMECH_HOME = "https://dismech.monarchinitiative.org";
+
+/** unique per-instance SVG marker id (a global id breaks if rendered twice) */
+const arrowId = `pathograph-arrow-${getCurrentInstance()?.uid ?? 0}`;
 
 /**
  * "Source" link target: when a single disorder backs this pathograph (every
@@ -192,12 +195,10 @@ type Point = { x: number; y: number };
 const nodeEntity = (
   node: PathographNode,
 ): { entityId?: string; link?: string } => {
-  if (node.id.startsWith("HP:"))
+  // Phenotype and single-gene nodes are anchored on their real curie (HP:…,
+  // HGNC:…), so they resolve directly to a Monarch node route.
+  if (node.id.startsWith("HP:") || node.id.startsWith("HGNC:"))
     return { entityId: node.id, link: `/${node.id}` };
-  if (node.id.startsWith("GENE:hgnc:")) {
-    const num = node.id.slice("GENE:hgnc:".length);
-    return { entityId: `HGNC:${num}`, link: `/HGNC:${num}` };
-  }
   const termId = (node.meta as Record<string, unknown> | undefined)?.term_id;
   if (typeof termId === "string" && termId.includes(":"))
     return { entityId: termId, link: `/${termId}` };

--- a/frontend/src/pages/node/SectionPathograph.vue
+++ b/frontend/src/pages/node/SectionPathograph.vue
@@ -74,12 +74,21 @@
           :height="NODE_H"
         >
           <div
+            v-tooltip="{
+              content: nodeTooltip(lnode),
+              allowHTML: true,
+              maxWidth: 360,
+              interactive: true,
+              appendTo: appendToBody,
+            }"
             class="node"
             :class="{ shared: lnode.shared, orphan: lnode.is_orphan }"
             :style="{ background: lnode.color || '#f3f4f6' }"
-            :title="lnode.tooltip"
           >
             <span class="node-label">{{ lnode.label }}</span>
+            <span v-if="lnode.entityId" class="node-id">{{
+              lnode.entityId
+            }}</span>
           </div>
         </foreignObject>
       </svg>
@@ -108,6 +117,7 @@ import {
   type PathographNode,
 } from "@/api/pathograph";
 import { useQuery } from "@/composables/use-query";
+import { appendToBody } from "@/global/tooltip";
 
 type Props = { node: Node };
 const props = defineProps<Props>();
@@ -115,7 +125,7 @@ const route = useRoute();
 
 /** node box geometry + layout spacing */
 const NODE_W = 184;
-const NODE_H = 58;
+const NODE_H = 66;
 const H_GAP = 28;
 const V_GAP = 52;
 const MARGIN = 20;
@@ -143,10 +153,33 @@ type LaidOutNode = PathographNode & {
   x: number;
   y: number;
   shared: boolean;
-  tooltip: string;
+  /** ontology id displayed on the node, when it is itself an entity */
+  entityId?: string;
+  /** Monarch node route for that entity, when resolvable */
+  link?: string;
 };
 
 type Point = { x: number; y: number };
+
+/**
+ * The ontology id + Monarch route for nodes that are themselves a term: HP
+ * phenotypes and HGNC genes (from the merged anchor id), or any node carrying a
+ * meta.term_id (e.g. biochemical CHEBI terms).
+ */
+const nodeEntity = (
+  node: PathographNode,
+): { entityId?: string; link?: string } => {
+  if (node.id.startsWith("HP:"))
+    return { entityId: node.id, link: `/${node.id}` };
+  if (node.id.startsWith("GENE:hgnc:")) {
+    const num = node.id.slice("GENE:hgnc:".length);
+    return { entityId: `HGNC:${num}`, link: `/HGNC:${num}` };
+  }
+  const termId = (node.meta as Record<string, unknown> | undefined)?.term_id;
+  if (typeof termId === "string" && termId.includes(":"))
+    return { entityId: termId, link: `/${termId}` };
+  return {};
+};
 
 /** smooth an edge polyline through its bend points with quadratic curves */
 const smoothPath = (points: Point[]): string => {
@@ -209,7 +242,7 @@ const layout = computed(() => {
       x: (p?.x ?? 0) - NODE_W / 2,
       y: (p?.y ?? 0) - NODE_H / 2,
       shared: sharedNodes.has(n.id),
-      tooltip: [n.label, n.description].filter(Boolean).join(" — "),
+      ...nodeEntity(n),
     };
   });
 
@@ -229,6 +262,144 @@ const layout = computed(() => {
   const graph = g.graph();
   return { nodes, edges, width: graph.width || 0, height: graph.height || 0 };
 });
+
+/** html-escape dynamic text going into the tooltip markup */
+const ESC: Record<string, string> = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+};
+const esc = (s: unknown): string => String(s).replace(/[&<>"]/g, (c) => ESC[c]);
+
+/** title-case a dismech node_type ("biological_process" → "Biological process") */
+const prettyType = (t: string): string =>
+  t.replace(/_/g, " ").replace(/^\w/, (c) => c.toUpperCase());
+
+/** meta list fields that hold the "thingy" terms composing a stringy node */
+const TERM_GROUPS = [
+  { key: "gene_terms", label: "Genes" },
+  { key: "cell_types", label: "Cell types" },
+  { key: "biological_processes", label: "Biological processes" },
+  { key: "molecular_functions", label: "Molecular functions" },
+  { key: "locations", label: "Locations" },
+  { key: "therapeutic_agents", label: "Therapeutic agents" },
+  { key: "readouts", label: "Readouts" },
+];
+
+/** scalar meta worth a compact footer line */
+const META_FIELDS = [
+  { key: "frequency", label: "Frequency" },
+  { key: "relationship_type", label: "Relationship" },
+  { key: "variant_origin", label: "Variant origin" },
+  { key: "clinical_significance", label: "Significance" },
+];
+
+const chip = (text: string): string =>
+  `<span style="display:inline-block;background:rgba(0,0,0,0.06);border-radius:4px;padding:1px 6px;margin:2px 3px 0 0">${esc(text)}</span>`;
+
+const termLabel = (item: unknown): string =>
+  typeof item === "string"
+    ? item
+    : ((item as { label?: string })?.label ?? String(item));
+
+type Evidence = {
+  reference: string;
+  reference_title?: string;
+  snippet?: string;
+  supports?: string;
+};
+
+/** PubMed link for a PMID reference, else no link (plain text) */
+const refUrl = (reference: string): string | undefined =>
+  reference.startsWith("PMID:")
+    ? `https://pubmed.ncbi.nlm.nih.gov/${reference.slice("PMID:".length)}`
+    : undefined;
+
+const truncate = (s: string, n = 160): string =>
+  s.length > n ? s.slice(0, n - 1).trimEnd() + "…" : s;
+
+/** render the evidence references (linked PMIDs + title + snippet) */
+const evidenceHtml = (evidence: Evidence[]): string => {
+  const items = evidence
+    .slice(0, 4)
+    .map((e) => {
+      const url = refUrl(e.reference);
+      const ref = url
+        ? `<a href="${url}" target="_blank" rel="noopener noreferrer" style="font-weight:500">${esc(e.reference)}</a>`
+        : `<span style="font-weight:500">${esc(e.reference)}</span>`;
+      const refutes =
+        e.supports && e.supports !== "SUPPORT"
+          ? ` <span style="opacity:0.7">(${esc(e.supports.toLowerCase())})</span>`
+          : "";
+      const title = e.reference_title
+        ? ` — ${esc(truncate(e.reference_title, 90))}`
+        : "";
+      const snippet = e.snippet
+        ? `<div style="opacity:0.75;font-style:italic;margin-top:1px">“${esc(truncate(e.snippet))}”</div>`
+        : "";
+      return `<div style="margin:3px 0;padding-left:6px;border-left:2px solid rgba(0,0,0,0.15)">${ref}${refutes}${title}${snippet}</div>`;
+    })
+    .join("");
+  const more =
+    evidence.length > 4
+      ? `<div style="opacity:0.6;margin-top:2px">+${evidence.length - 4} more</div>`
+      : "";
+  return `<div style="margin-top:6px;font-size:0.75rem"><div style="opacity:0.6;margin-bottom:1px">Evidence (${evidence.length})</div>${items}${more}</div>`;
+};
+
+/**
+ * Hover tooltip: the node label + type + description, then the constituent
+ * ontology terms (genes, cell types, processes, locations, …) pulled from meta
+ * — making the "thingy" composition of a free-text node explicit.
+ */
+const nodeTooltip = (node: LaidOutNode): string => {
+  const meta = (node.meta || {}) as Record<string, unknown>;
+  const parts: string[] = [
+    `<div style="font-size:0.7rem;text-transform:uppercase;letter-spacing:0.04em;opacity:0.65">${esc(prettyType(node.node_type))}</div>`,
+    `<div style="font-weight:600;margin:1px 0 2px">${esc(node.label)}</div>`,
+  ];
+  if (node.entityId)
+    parts.push(
+      node.link
+        ? `<div style="font-size:0.74rem;margin-bottom:4px"><a href="${esc(node.link)}" target="_blank" rel="noopener noreferrer">${esc(node.entityId)} — open in Monarch ↗</a></div>`
+        : `<div style="font-size:0.74rem;opacity:0.7;margin-bottom:4px;font-family:monospace">${esc(node.entityId)}</div>`,
+    );
+  if (node.description)
+    parts.push(
+      `<div style="font-size:0.82rem;opacity:0.9;margin-bottom:5px">${esc(node.description)}</div>`,
+    );
+
+  for (const { key, label } of TERM_GROUPS) {
+    const list = meta[key];
+    if (!Array.isArray(list) || !list.length) continue;
+    const shown = list.slice(0, 10).map((i) => chip(termLabel(i)));
+    if (list.length > 10) shown.push(chip(`+${list.length - 10} more`));
+    parts.push(
+      `<div style="margin:3px 0;font-size:0.78rem"><span style="opacity:0.6">${esc(label)}:</span> ${shown.join("")}</div>`,
+    );
+  }
+
+  const footer = META_FIELDS.filter(
+    (f) => meta[f.key] != null && meta[f.key] !== "",
+  )
+    .map((f) => `${esc(f.label)}: ${esc(meta[f.key])}`)
+    .join(" · ");
+  if (footer)
+    parts.push(
+      `<div style="font-size:0.74rem;opacity:0.65;margin-top:5px">${footer}</div>`,
+    );
+
+  const evidence = meta.evidence;
+  if (Array.isArray(evidence) && evidence.length)
+    parts.push(evidenceHtml(evidence as Evidence[]));
+  else if (meta.evidence_count)
+    parts.push(
+      `<div style="font-size:0.74rem;opacity:0.65;margin-top:5px">Evidence: ${esc(meta.evidence_count)}</div>`,
+    );
+
+  return `<div style="text-align:left;line-height:1.3">${parts.join("")}</div>`;
+};
 </script>
 
 <style lang="scss" scoped>
@@ -257,6 +428,7 @@ const layout = computed(() => {
 .node {
   box-sizing: border-box;
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
   width: 100%;
@@ -285,6 +457,17 @@ const layout = computed(() => {
   overflow: hidden;
   font-size: 0.78rem;
   line-height: 1.15;
+}
+
+.node-id {
+  max-width: 100%;
+  margin-top: 2px;
+  overflow: hidden;
+  font-size: 0.6rem;
+  font-family: monospace;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  opacity: 0.55;
 }
 
 .legend {

--- a/frontend/src/pages/node/SectionPathograph.vue
+++ b/frontend/src/pages/node/SectionPathograph.vue
@@ -29,7 +29,8 @@
         pathograph.category === "disease"
           ? "View this disorder on Dismech"
           : "Explore these disorders on Dismech"
-      }}</AppLink>.
+      }}</AppLink
+      >.
       <AppLink to="https://dismech.monarchinitiative.org/details/"
         >Learn more about Dismech</AppLink
       >.
@@ -332,6 +333,13 @@ type Evidence = {
   supports?: string;
 };
 
+/**
+ * Only allow relative or http(s) hrefs in the hand-built tooltip HTML — never a
+ * javascript:/data: URI, even if the upstream artifact format ever changes.
+ */
+const safeHref = (href: string): string =>
+  /^(\/|https?:\/\/)/i.test(href) ? href : "#";
+
 /** PubMed link for a PMID reference, else no link (plain text) */
 const refUrl = (reference: string): string | undefined =>
   reference.startsWith("PMID:")
@@ -384,7 +392,7 @@ const nodeTooltip = (node: LaidOutNode): string => {
   if (node.entityId)
     parts.push(
       node.link
-        ? `<div style="font-size:0.74rem;margin-bottom:4px"><a href="${esc(node.link)}" target="_blank" rel="noopener noreferrer">${esc(node.entityId)} — open in Monarch ↗</a></div>`
+        ? `<div style="font-size:0.74rem;margin-bottom:4px"><a href="${esc(safeHref(node.link))}" target="_blank" rel="noopener noreferrer">${esc(node.entityId)} — open in Monarch ↗</a></div>`
         : `<div style="font-size:0.74rem;opacity:0.7;margin-bottom:4px;font-family:monospace">${esc(node.entityId)}</div>`,
     );
   if (node.description)
@@ -429,16 +437,6 @@ const nodeTooltip = (node: LaidOutNode): string => {
   margin: 0 0 10px;
   color: $gray;
   font-size: 0.9rem;
-}
-
-.disclaimer {
-  margin: 0 0 12px;
-  padding: 6px 10px;
-  border-left: 3px solid $gray;
-  background: rgba(0, 0, 0, 0.03);
-  color: $gray;
-  font-size: 0.8rem;
-  line-height: 1.35;
 }
 
 .graph-scroll {

--- a/frontend/src/pages/node/SectionPathograph.vue
+++ b/frontend/src/pages/node/SectionPathograph.vue
@@ -1,0 +1,299 @@
+<!--
+  dismech disease-mechanism pathograph for a disease or gene node.
+
+  Fetches the merged pathograph from the backend (which proxies the dismech
+  artifact and, for genes, anchor-merges every disorder the gene participates
+  in) and lays it out as a left→right causal DAG. Renders nothing when the node
+  has no pathograph (the common case), so it self-hides.
+-->
+
+<template>
+  <AppSection
+    v-if="pathograph && layout.nodes.length"
+    width="full"
+    class="inset"
+    alignment="left"
+  >
+    <AppHeading icon="diagram-project">Disease Mechanism Pathograph</AppHeading>
+
+    <p class="caption">
+      <template v-if="pathograph.category === 'gene'">
+        Mechanisms involving {{ node.name }} across
+        {{ pathograph.sources.length }} disorder{{
+          pathograph.sources.length === 1 ? "" : "s"
+        }}.
+      </template>
+      <template v-else>
+        Curated causal mechanism for {{ node.name }}.
+      </template>
+      Source:
+      <AppLink to="https://dismech.monarchinitiative.org">dismech</AppLink>.
+    </p>
+
+    <div class="graph-scroll">
+      <svg
+        :viewBox="`0 0 ${layout.width} ${layout.height}`"
+        :style="{ width: layout.width + 'px', maxWidth: '100%' }"
+        class="graph"
+      >
+        <defs>
+          <marker
+            id="pathograph-arrow"
+            viewBox="0 0 10 10"
+            refX="9"
+            refY="5"
+            markerWidth="7"
+            markerHeight="7"
+            orient="auto-start-reverse"
+          >
+            <path d="M 0 0 L 10 5 L 0 10 z" fill="#9ca3af" />
+          </marker>
+        </defs>
+
+        <!-- edges -->
+        <path
+          v-for="(edge, i) in layout.edges"
+          :key="`e${i}`"
+          :d="edge.path"
+          class="edge"
+          marker-end="url(#pathograph-arrow)"
+        >
+          <title>
+            {{ edge.predicate
+            }}{{ edge.description ? `: ${edge.description}` : "" }}
+          </title>
+        </path>
+
+        <!-- nodes -->
+        <foreignObject
+          v-for="lnode in layout.nodes"
+          :key="lnode.id"
+          :x="lnode.x"
+          :y="lnode.y"
+          :width="NODE_W"
+          :height="NODE_H"
+        >
+          <div
+            class="node"
+            :class="{ shared: lnode.shared, orphan: lnode.is_orphan }"
+            :style="{ background: lnode.color || '#f3f4f6' }"
+            :title="lnode.tooltip"
+          >
+            <span class="node-label">{{ lnode.label }}</span>
+          </div>
+        </foreignObject>
+      </svg>
+    </div>
+
+    <!-- per-disorder legend for the merged gene view -->
+    <ul
+      v-if="pathograph.category === 'gene' && pathograph.sources.length > 1"
+      class="legend"
+    >
+      <li v-for="source in pathograph.sources" :key="source.id">
+        <AppLink :to="`/${source.id}`">{{ source.name }}</AppLink>
+      </li>
+    </ul>
+  </AppSection>
+</template>
+
+<script setup lang="ts">
+import { computed, watch } from "vue";
+import { useRoute } from "vue-router";
+import dagre from "@dagrejs/dagre";
+import type { Node } from "@/api/model";
+import {
+  getPathograph,
+  type Pathograph,
+  type PathographNode,
+} from "@/api/pathograph";
+import { useQuery } from "@/composables/use-query";
+
+type Props = { node: Node };
+const props = defineProps<Props>();
+const route = useRoute();
+
+/** node box geometry + layout spacing */
+const NODE_W = 184;
+const NODE_H = 58;
+const H_GAP = 28;
+const V_GAP = 52;
+const MARGIN = 20;
+
+const { query: runGetPathograph, data: pathograph } = useQuery<
+  Pathograph | null,
+  []
+>(async () => {
+  /** pathographs only exist for diseases and genes; skip the fetch otherwise */
+  const category = props.node.category;
+  if (category !== "biolink:Disease" && category !== "biolink:Gene")
+    return null;
+  return getPathograph(props.node.id || "");
+}, null);
+
+/**
+ * refetch on node change; 404 (no pathograph) leaves data null and hides
+ * section
+ */
+watch([() => route.path, () => props.node.id], runGetPathograph, {
+  immediate: true,
+});
+
+type LaidOutNode = PathographNode & {
+  x: number;
+  y: number;
+  shared: boolean;
+  tooltip: string;
+};
+
+type Point = { x: number; y: number };
+
+/** smooth an edge polyline through its bend points with quadratic curves */
+const smoothPath = (points: Point[]): string => {
+  if (points.length < 2) return "";
+  let d = `M ${points[0].x} ${points[0].y}`;
+  for (let i = 1; i < points.length - 1; i++) {
+    const mid = {
+      x: (points[i].x + points[i + 1].x) / 2,
+      y: (points[i].y + points[i + 1].y) / 2,
+    };
+    d += ` Q ${points[i].x} ${points[i].y} ${mid.x} ${mid.y}`;
+  }
+  const last = points[points.length - 1];
+  d += ` L ${last.x} ${last.y}`;
+  return d;
+};
+
+/** dagre layered DAG layout (rankdir left→right, crossing-minimized) */
+const layout = computed(() => {
+  const data = pathograph.value;
+  const empty = {
+    nodes: [] as LaidOutNode[],
+    edges: [] as {
+      path: string;
+      predicate?: string | null;
+      description?: string | null;
+    }[],
+    width: 0,
+    height: 0,
+  };
+  if (!data || !data.nodes.length) return empty;
+
+  const g = new dagre.graphlib.Graph();
+  g.setGraph({
+    // left→right: the (often many) terminal phenotypes stack vertically, so a
+    // big graph grows in height (page-scrollable) instead of overflowing width.
+    rankdir: "LR",
+    nodesep: H_GAP,
+    ranksep: V_GAP,
+    marginx: MARGIN,
+    marginy: MARGIN,
+  });
+  g.setDefaultEdgeLabel(() => ({}));
+  for (const n of data.nodes)
+    g.setNode(n.id, { width: NODE_W, height: NODE_H });
+  for (const e of data.edges)
+    if (g.hasNode(e.source) && g.hasNode(e.target))
+      g.setEdge(e.source, e.target);
+  dagre.layout(g);
+
+  const sharedNodes = new Set(
+    data.nodes.filter((n) => (n.sources?.length || 0) > 1).map((n) => n.id),
+  );
+
+  /** dagre node coords are centers; convert to top-left for foreignObject */
+  const nodes: LaidOutNode[] = data.nodes.map((n) => {
+    const p = g.node(n.id) as Point;
+    return {
+      ...n,
+      x: (p?.x ?? 0) - NODE_W / 2,
+      y: (p?.y ?? 0) - NODE_H / 2,
+      shared: sharedNodes.has(n.id),
+      tooltip: [n.label, n.description].filter(Boolean).join(" — "),
+    };
+  });
+
+  const edges = data.edges
+    .map((e) => {
+      if (!g.hasNode(e.source) || !g.hasNode(e.target)) return null;
+      const points = (g.edge(e.source, e.target)?.points || []) as Point[];
+      if (points.length < 2) return null;
+      return {
+        path: smoothPath(points),
+        predicate: e.predicate,
+        description: e.description,
+      };
+    })
+    .filter((e): e is NonNullable<typeof e> => e !== null);
+
+  const graph = g.graph();
+  return { nodes, edges, width: graph.width || 0, height: graph.height || 0 };
+});
+</script>
+
+<style lang="scss" scoped>
+.caption {
+  margin: 0 0 10px;
+  color: $gray;
+  font-size: 0.9rem;
+}
+
+.graph-scroll {
+  width: 100%;
+  overflow-x: auto;
+}
+
+.graph {
+  display: block;
+  height: auto;
+}
+
+.edge {
+  fill: none;
+  stroke: #9ca3af;
+  stroke-width: 1.5;
+}
+
+.node {
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  padding: 4px 8px;
+  border: 1px solid rgba(0, 0, 0, 0.25);
+  border-radius: 6px;
+  text-align: center;
+  cursor: default;
+
+  &.shared {
+    border-width: 2px;
+    border-color: rgba(0, 0, 0, 0.7);
+    box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.08);
+  }
+
+  &.orphan {
+    border-style: dashed;
+  }
+}
+
+.node-label {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  font-size: 0.78rem;
+  line-height: 1.15;
+}
+
+.legend {
+  display: flex;
+  flex-wrap: wrap;
+  margin: 10px 0 0;
+  padding: 0;
+  gap: 6px 16px;
+  font-size: 0.85rem;
+  list-style: none;
+}
+</style>

--- a/frontend/src/pages/node/SectionPathograph.vue
+++ b/frontend/src/pages/node/SectionPathograph.vue
@@ -30,6 +30,12 @@
       <AppLink to="https://dismech.monarchinitiative.org">dismech</AppLink>.
     </p>
 
+    <p class="disclaimer">
+      dismech is in pre-alpha development &mdash; its mechanism content is
+      actively being curated and may be incomplete or change. These mechanisms
+      come from dismech and are not part of the Monarch knowledge graph.
+    </p>
+
     <div class="graph-scroll">
       <svg
         :viewBox="`0 0 ${layout.width} ${layout.height}`"
@@ -407,6 +413,16 @@ const nodeTooltip = (node: LaidOutNode): string => {
   margin: 0 0 10px;
   color: $gray;
   font-size: 0.9rem;
+}
+
+.disclaimer {
+  margin: 0 0 12px;
+  padding: 6px 10px;
+  border-left: 3px solid $gray;
+  background: rgba(0, 0, 0, 0.03);
+  color: $gray;
+  font-size: 0.8rem;
+  line-height: 1.35;
 }
 
 .graph-scroll {

--- a/frontend/src/pages/node/SectionPathograph.vue
+++ b/frontend/src/pages/node/SectionPathograph.vue
@@ -23,17 +23,18 @@
           pathograph.sources.length === 1 ? "" : "s"
         }}.
       </template>
-      <template v-else>
-        Curated causal mechanism for {{ node.name }}.
-      </template>
-      Source:
-      <AppLink to="https://dismech.monarchinitiative.org">dismech</AppLink>.
-    </p>
-
-    <p class="disclaimer">
-      dismech is in pre-alpha development &mdash; its mechanism content is
-      actively being curated and may be incomplete or change. These mechanisms
-      come from dismech and are not part of the Monarch knowledge graph.
+      <template v-else> Causal mechanism for {{ node.name }}. </template>
+      Sourced from Dismech, a pre-alpha resource that is actively curated, may
+      be incomplete or change, and is not yet part of the Monarch knowledge
+      graph.
+      <AppLink :to="sourceLink">{{
+        pathograph.category === "disease"
+          ? "View this disorder on Dismech"
+          : "Explore these disorders on Dismech"
+      }}</AppLink>.
+      <AppLink to="https://dismech.monarchinitiative.org/details/"
+        >Learn more about Dismech</AppLink
+      >.
     </p>
 
     <div class="graph-scroll">
@@ -107,6 +108,9 @@
     >
       <li v-for="source in pathograph.sources" :key="source.id">
         <AppLink :to="`/${source.id}`">{{ source.name }}</AppLink>
+        <AppLink v-if="source.url" :to="source.url" class="legend-dismech"
+          >Dismech</AppLink
+        >
       </li>
     </ul>
   </AppSection>
@@ -128,6 +132,20 @@ import { appendToBody } from "@/global/tooltip";
 type Props = { node: Node };
 const props = defineProps<Props>();
 const route = useRoute();
+
+const DISMECH_HOME = "https://dismech.monarchinitiative.org";
+
+/**
+ * "Source" link target: when a single disorder backs this pathograph (every
+ * disease, and genes tied to just one disorder), deep-link straight to that
+ * disorder's dismech page; for multi-disorder gene merges the per-disorder
+ * legend below carries the individual links, so fall back to the dismech home.
+ */
+const sourceLink = computed(() => {
+  const sources = pathograph.value?.sources ?? [];
+  if (sources.length === 1 && sources[0]?.url) return sources[0].url;
+  return DISMECH_HOME;
+});
 
 /** node box geometry + layout spacing */
 const NODE_W = 184;
@@ -494,5 +512,11 @@ const nodeTooltip = (node: LaidOutNode): string => {
   gap: 6px 16px;
   font-size: 0.85rem;
   list-style: none;
+}
+
+.legend-dismech {
+  margin-left: 4px;
+  font-size: 0.75rem;
+  opacity: 0.7;
 }
 </style>


### PR DESCRIPTION
Addresses #1318.

## Summary
Embeds dismech disease-mechanism pathographs on disease and gene node pages — a **runtime embed, decoupled from the KG ingest (#1282)**.

- **Backend** — `GET /v3/api/pathograph/{node_id}` proxies the dismech artifact same-origin (no CORS, TTL-cached). Disease (`MONDO:…`) returns that disorder's pathograph; gene (`HGNC:…`) anchor-merges every disorder the gene participates in, boxing shared HP phenotypes + HGNC genes. Artifact base via `DISMECH_PATHOGRAPHS_URL`.
- **Frontend** — `SectionPathograph.vue` renders a dagre left→right causal DAG (self-hides when a node has no pathograph). Interactivity: hover tooltip exposing each node's constituent ontology terms (genes / cell types / processes / …), **evidence shown as PubMed-linked references with snippets** (not just a count), ontology IDs on entity nodes, and an "open in Monarch" link in the popup.

Consumes the artifact produced by **monarch-initiative/dismech#4215**. The evidence display falls back to a count if the published artifact predates that PR, so this is safe to merge independently.

## Screenshots
_(attached in a comment below)_

## Tests
Backend `tests/unit/test_pathograph_api.py` (4 passing): disease passthrough, gene merge + boxing, local-node namespacing, 404/400. Frontend typecheck + lint clean.

## Follow-ups (not in this PR)
Click→detail drawer; hover-highlight neighbors; gene-view disorder filtering; dismech entity-resolution (BP→GO / cell→CL / location→UBERON) so the tooltip term chips become links too.
