### PR TITLE
Deduplicate Causal Genes / causes_disease in node header (#1328)

### DIFF
--- a/backend/src/monarch_py/implementations/solr/solr_implementation.py
+++ b/backend/src/monarch_py/implementations/solr/solr_implementation.py
@@ -153,8 +153,10 @@ class SolrImplementation(EntityInterface, AssociationInterface, SearchInterface,
             )
             if mode_of_inheritance_associations is not None and len(mode_of_inheritance_associations.items) == 1:
                 entity.inheritance = self._get_counterpart_entity(mode_of_inheritance_associations.items[0], entity)
-            # Get causal gene
-            entity.causal_gene = [
+            # Get causal gene. The same gene->disease causal edge can be asserted by
+            # multiple sources (e.g. OMIM + ClinGen), yielding multiple associations
+            # for the same gene; dedupe by entity id so it isn't shown twice.
+            entity.causal_gene = self._deduplicate_entities(
                 self._get_counterpart_entity(association, entity)
                 for association in self.get_associations(
                     object=id,
@@ -162,9 +164,9 @@ class SolrImplementation(EntityInterface, AssociationInterface, SearchInterface,
                     predicate=[AssociationPredicate.CAUSES],
                     category=[AssociationCategory.CAUSAL_GENE_TO_DISEASE_ASSOCIATION],
                 ).items
-            ]
+            )
         if "biolink:Gene" == entity.category:
-            entity.causes_disease = [
+            entity.causes_disease = self._deduplicate_entities(
                 self._get_counterpart_entity(association, entity)
                 for association in self.get_associations(
                     subject=id,
@@ -172,7 +174,7 @@ class SolrImplementation(EntityInterface, AssociationInterface, SearchInterface,
                     predicate=[AssociationPredicate.CAUSES],
                     category=[AssociationCategory.CAUSAL_GENE_TO_DISEASE_ASSOCIATION],
                 ).items
-            ]
+            )
         node: Node = Node(
             **entity.model_dump(),
             cross_species_term_clique=self._get_cross_species_term_clique(entity),
@@ -218,6 +220,18 @@ class SolrImplementation(EntityInterface, AssociationInterface, SearchInterface,
             raise ValueError(f"Association does not contain this_entity: {this_entity.id}")
 
         return entity
+
+    @staticmethod
+    def _deduplicate_entities(entities) -> List[Entity]:
+        """Deduplicate an iterable of entities by id, preserving first-seen order."""
+        seen = set()
+        deduplicated = []
+        for entity in entities:
+            if entity.id in seen:
+                continue
+            seen.add(entity.id)
+            deduplicated.append(entity)
+        return deduplicated
 
     def get_counterpart_entities(
         self,

--- a/backend/tests/unit/test_solr_implementation.py
+++ b/backend/tests/unit/test_solr_implementation.py
@@ -21,6 +21,65 @@ def test_get_counterpart_entities_limit():
         assert mock_get_associations.call_args_list[0].kwargs["limit"] == 1000
 
 
+def test_deduplicate_entities_by_id():
+    """_deduplicate_entities keeps one entry per id, preserving first-seen order."""
+    entities = [
+        Entity(id="HGNC:3603", name="FBN1", category="biolink:Gene"),
+        Entity(id="HGNC:3603", name="FBN1", category="biolink:Gene"),
+        Entity(id="HGNC:1234", name="OTHER", category="biolink:Gene"),
+    ]
+    result = SolrImplementation._deduplicate_entities(entities)
+    assert [e.id for e in result] == ["HGNC:3603", "HGNC:1234"]
+
+
+def test_get_entity_deduplicates_causal_genes():
+    """The same causal gene asserted by multiple sources should appear once in causal_gene."""
+    solr_doc = {
+        "id": "MONDO:0007947",
+        "category": "biolink:Disease",
+        "name": "Marfan syndrome",
+        "provided_by": "phenio_nodes",
+    }
+
+    def causes_association(source):
+        return ExpandedAssociation(
+            id=f"uuid-{source}",
+            agent_type="not_provided",
+            knowledge_level="knowledge_assertion",
+            subject="HGNC:3603",
+            subject_label="FBN1",
+            subject_category="biolink:Gene",
+            predicate="biolink:causes",
+            object="MONDO:0007947",
+            object_label="Marfan syndrome",
+            object_category="biolink:Disease",
+            primary_knowledge_source=source,
+        )
+
+    # FBN1 asserted by both ClinGen and OMIM -> two associations, one gene.
+    associations = AssociationResults(
+        items=[causes_association("infores:clingen"), causes_association("infores:omim")],
+        limit=20,
+        offset=0,
+        total=2,
+    )
+
+    with (
+        patch("monarch_py.implementations.solr.solr_implementation.SolrService") as mock_solr_cls,
+        patch.object(SolrImplementation, "get_associations", return_value=associations),
+        patch.object(SolrImplementation, "_get_cross_species_term_clique", return_value=None),
+        patch.object(SolrImplementation, "_get_node_hierarchy", return_value=None),
+        patch.object(SolrImplementation, "get_association_counts") as mock_counts,
+        patch.object(SolrImplementation, "_get_mapped_entities", return_value=[]),
+    ):
+        mock_solr_cls.return_value.get.return_value = solr_doc
+        mock_counts.return_value.items = []
+
+        node = SolrImplementation().get_entity("MONDO:0007947", extra=True)
+
+    assert [g.id for g in node.causal_gene] == ["HGNC:3603"]
+
+
 def test_get_generic_entity_grid_accepts_multiple_row_categories():
     """get_generic_entity_grid should accept row_assoc_categories as a list."""
     mock_entity = MagicMock()


### PR DESCRIPTION
## What & why

The **Causal Genes** list in the disease header (and the symmetric `causes_disease` list on gene pages) could show the same gene/disease twice. Example: **Marfan syndrome (MONDO:0007947)** showed **FBN1** twice.

**Root cause:** the same causal gene→disease edge is asserted independently by multiple sources (e.g. `infores:clingen` *and* `infores:omim`), producing multiple `CausalGeneToDiseaseAssociation` records for the same (gene, disease) pair. `get_entity()` mapped each association to a counterpart entity without deduplicating by id.

Closes #1328. Follow-on from #1326 / #1327.

## Fix

Dedupe the counterpart entities by `id` (preserving first-seen order) when building `causal_gene` and `causes_disease`, via a small shared `_deduplicate_entities` helper.

## Testing

- New unit tests: `_deduplicate_entities` by id, and `get_entity()` collapsing a multi-source FBN1 duplicate to a single entry.
- Verified against the local Solr KG: Marfan syndrome → FBN1 once (was twice); Noonan syndrome → 7 distinct genes unaffected.
- `ruff check` clean on changed files.

https://claude.ai/code/session_01GMyr8EWJq7TZq23AeBR8G3