### PR TITLE
Mondo node-header relationships: review follow-ups (#1326)

### DIFF
--- a/backend/src/monarch_py/implementations/solr/solr_implementation.py
+++ b/backend/src/monarch_py/implementations/solr/solr_implementation.py
@@ -129,7 +129,10 @@ class SolrImplementation(EntityInterface, AssociationInterface, SearchInterface,
     # Process-level cache of RO relation CURIE -> KG label. RO labels (loaded from
     # phenio) are stable for the lifetime of a server process, so resolving each
     # relation once avoids a per-page Solr round-trip. ClassVar keeps it off the
-    # dataclass field list.
+    # dataclass field list. The check-then-write below is intentionally lock-free:
+    # concurrent requests racing on the same uncached relation may each do one extra
+    # Solr lookup at startup, but the write is idempotent, so the cost is bounded and
+    # not worth a lock.
     _relation_label_cache: ClassVar[Dict[str, Optional[str]]] = {}
 
     def solr_is_available(self) -> bool:
@@ -289,12 +292,18 @@ class SolrImplementation(EntityInterface, AssociationInterface, SearchInterface,
         associations.sort(key=lambda a: relation_order[a.original_predicate or a.predicate])
 
         relationships: List[NodeRelationship] = []
-        seen: set = set()
+        seen: set[tuple[str, str]] = set()
         for association in associations:
             relation = association.original_predicate or association.predicate
             if relation not in self._relation_label_cache:
-                relation_entity = self.get_entity(relation, extra=False)
-                self._relation_label_cache[relation] = relation_entity.name if relation_entity is not None else None
+                # A failure resolving one RO term's label must not blank out the whole
+                # relationships block, so degrade to no label rather than propagating.
+                try:
+                    relation_entity = self.get_entity(relation, extra=False)
+                    self._relation_label_cache[relation] = relation_entity.name if relation_entity is not None else None
+                except Exception:
+                    logger.warning(f"Could not resolve label for relation {relation}", exc_info=True)
+                    self._relation_label_cache[relation] = None
             counterpart = self._get_counterpart_entity(association, this_entity)
             # Mondo may assert the same relation->counterpart from multiple rows; show it once.
             if (relation, counterpart.id) in seen:

--- a/backend/src/monarch_py/implementations/solr/solr_implementation.py
+++ b/backend/src/monarch_py/implementations/solr/solr_implementation.py
@@ -295,15 +295,21 @@ class SolrImplementation(EntityInterface, AssociationInterface, SearchInterface,
         seen: set[tuple[str, str]] = set()
         for association in associations:
             relation = association.original_predicate or association.predicate
-            if relation not in self._relation_label_cache:
+            if relation in self._relation_label_cache:
+                relation_label = self._relation_label_cache[relation]
+            else:
                 # A failure resolving one RO term's label must not blank out the whole
                 # relationships block, so degrade to no label rather than propagating.
+                # Only memoize definitive results (resolved name or confirmed-missing);
+                # on a transient error leave the cache empty so a later request retries
+                # instead of being permanently poisoned with None.
                 try:
                     relation_entity = self.get_entity(relation, extra=False)
-                    self._relation_label_cache[relation] = relation_entity.name if relation_entity is not None else None
+                    relation_label = relation_entity.name if relation_entity is not None else None
+                    self._relation_label_cache[relation] = relation_label
                 except Exception:
                     logger.warning(f"Could not resolve label for relation {relation}", exc_info=True)
-                    self._relation_label_cache[relation] = None
+                    relation_label = None
             counterpart = self._get_counterpart_entity(association, this_entity)
             # Mondo may assert the same relation->counterpart from multiple rows; show it once.
             if (relation, counterpart.id) in seen:
@@ -325,7 +331,7 @@ class SolrImplementation(EntityInterface, AssociationInterface, SearchInterface,
             relationships.append(
                 NodeRelationship(
                     relation=relation,
-                    relation_label=self._relation_label_cache[relation],
+                    relation_label=relation_label,
                     related_entity=counterpart,
                 )
             )

--- a/backend/tests/unit/test_solr_implementation.py
+++ b/backend/tests/unit/test_solr_implementation.py
@@ -157,6 +157,43 @@ def test_get_node_relationships_handles_missing_ro_label():
     assert relationships[0].related_entity.id == "NCBIGene:281783"
 
 
+def test_get_node_relationships_survives_label_lookup_error():
+    """If resolving an RO term raises, degrade to no label rather than blanking the block."""
+    disease = Entity(id="MONDO:1010417", name="d", category="biolink:Disease")
+    associations = AssociationResults(items=[_mondo_disease_gene_association()], limit=100, offset=0, total=1)
+
+    with (
+        patch.object(SolrImplementation, "get_associations", return_value=associations),
+        patch.object(SolrImplementation, "get_entity", side_effect=RuntimeError("solr down")),
+    ):
+        relationships = SolrImplementation()._get_node_relationships(disease)
+
+    assert len(relationships) == 1
+    assert relationships[0].relation == "RO:0004003"
+    assert relationships[0].relation_label is None
+    assert relationships[0].related_entity.id == "NCBIGene:281783"
+
+
+def test_get_node_relationships_does_not_cache_label_lookup_error():
+    """A transient lookup failure must not poison the cache; a later call retries and resolves."""
+    disease = Entity(id="MONDO:1010417", name="d", category="biolink:Disease")
+    associations = AssociationResults(items=[_mondo_disease_gene_association()], limit=100, offset=0, total=1)
+    ro_term = Entity(id="RO:0004003", name="has material basis in germline mutation in", category="biolink:NamedThing")
+
+    impl = SolrImplementation()
+    with patch.object(SolrImplementation, "get_associations", return_value=associations):
+        # First call: lookup raises -> no label, and nothing cached.
+        with patch.object(SolrImplementation, "get_entity", side_effect=RuntimeError("solr down")):
+            first = impl._get_node_relationships(disease)
+        assert first[0].relation_label is None
+        assert "RO:0004003" not in SolrImplementation._relation_label_cache
+
+        # Second call (Solr recovered): lookup retries and resolves the label.
+        with patch.object(SolrImplementation, "get_entity", return_value=ro_term):
+            second = impl._get_node_relationships(disease)
+        assert second[0].relation_label == "has material basis in germline mutation in"
+
+
 def test_get_node_relationships_filters_to_curated_relations():
     """Mondo related_to relations outside the curated allowlist are dropped from the header."""
     disease = Entity(id="MONDO:0018310", name="Langerhans cell histiocytosis", category="biolink:Disease")

--- a/frontend/src/pages/node/SectionNodeRelationships.vue
+++ b/frontend/src/pages/node/SectionNodeRelationships.vue
@@ -1,0 +1,60 @@
+<!--
+  Mondo disease<->X relationships. These enter the KG with a generic
+  biolink:related_to predicate but retain the real relation (an RO term) in
+  original_predicate; the backend resolves that term's label from the KG.
+  Grouped by relation label so the RO term's meaning is revealed. Shared by
+  the disease and non-disease node header layouts (only one renders at a time).
+-->
+<template>
+  <AppDetail
+    v-for="group in relationshipGroups"
+    :key="`rel-${group.key}`"
+    :title="group.label"
+    :full="true"
+  >
+    <AppFlex align-h="left">
+      <AppNodeBadge
+        v-for="entity in group.entities"
+        :key="entity.id"
+        :node="entity"
+      />
+    </AppFlex>
+  </AppDetail>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import type { Entity, Node } from "@/api/model";
+import AppDetail from "@/components/AppDetail.vue";
+import AppNodeBadge from "@/components/AppNodeBadge.vue";
+
+type Props = { node: Node };
+
+const { node } = defineProps<Props>();
+
+/**
+ * Group the node's Mondo disease<->X relationships by their relation label so
+ * each RO relation (e.g. "has material basis in germline mutation in") becomes
+ * a titled block. Prefer the KG-resolved label; fall back to the relation CURIE
+ * so distinct unlabeled relations stay distinguishable (same chain for key +
+ * title).
+ */
+const relationshipGroups = computed(() => {
+  const groups = new Map<
+    string,
+    { key: string; label: string; entities: Entity[] }
+  >();
+  for (const rel of node.node_relationships ?? []) {
+    if (!rel.related_entity) continue;
+    const key = rel.relation_label || rel.relation || "Related to";
+    const label = key.charAt(0).toUpperCase() + key.slice(1);
+    let group = groups.get(key);
+    if (!group) {
+      group = { key, label, entities: [] };
+      groups.set(key, group);
+    }
+    group.entities.push(rel.related_entity);
+  }
+  return [...groups.values()];
+});
+</script>

--- a/frontend/src/pages/node/SectionOverview.vue
+++ b/frontend/src/pages/node/SectionOverview.vue
@@ -52,26 +52,7 @@
           :frequency-label="frequencyLabel"
           :node="node"
         />
-        <!--
-          Mondo disease<->X relationships. These enter the KG with a generic
-          biolink:related_to predicate but retain the real relation (an RO term)
-          in original_predicate; the backend resolves that term's label from the
-          KG. Grouped by relation label so the RO term's meaning is revealed.
-        -->
-        <AppDetail
-          v-for="group in relationshipGroups"
-          :key="`rel-${group.label}`"
-          :title="group.label"
-          :full="true"
-        >
-          <AppFlex align-h="left">
-            <AppNodeBadge
-              v-for="entity in group.entities"
-              :key="entity.id"
-              :node="entity"
-            />
-          </AppFlex>
-        </AppDetail>
+        <SectionNodeRelationships :node="node" />
         <AppDetail
           :blank="!otherMappings.length"
           title="Equivalent disease concepts in other termiologies"
@@ -200,21 +181,7 @@
           <span>{{ nodeVersion.version || "unknown" }}</span>
         </AppDetail>
 
-        <!-- Mondo related_to relationships (RO original_predicate), grouped by relation label -->
-        <AppDetail
-          v-for="group in relationshipGroups"
-          :key="`rel-${group.label}`"
-          :title="group.label"
-          :full="true"
-        >
-          <AppFlex align-h="left">
-            <AppNodeBadge
-              v-for="entity in group.entities"
-              :key="entity.id"
-              :node="entity"
-            />
-          </AppFlex>
-        </AppDetail>
+        <SectionNodeRelationships :node="node" />
 
         <AppDetail
           :blank="!otherMappings.length"
@@ -254,7 +221,7 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import omit from "lodash/omit";
-import type { Entity, Node } from "@/api/model";
+import type { Node } from "@/api/model";
 import AppDetail from "@/components/AppDetail.vue";
 import AppDetails from "@/components/AppDetails.vue";
 import AppNodeBadge from "@/components/AppNodeBadge.vue";
@@ -263,35 +230,13 @@ import AppTagList from "@/components/AppTagList.vue";
 import { useClinicalResources } from "@/composables/use-clinical-resources";
 import { useSourceVersions } from "@/composables/use-source-versions";
 import SectionClinicalReources from "./SectionClinicalReources.vue";
+import SectionNodeRelationships from "./SectionNodeRelationships.vue";
 
 type Props = { node: Node };
 
 const { node } = defineProps<Props>();
 const isDiseaseNode = computed(() => node.category === "biolink:Disease");
 
-/**
- * Group the node's Mondo disease<->gene relationships by their relation label
- * so each RO relation (e.g. "has material basis in germline mutation in")
- * becomes a titled block. Falls back to the relation CURIE if the KG had no
- * label.
- */
-const relationshipGroups = computed(() => {
-  const groups = new Map<string, { label: string; entities: Entity[] }>();
-  for (const rel of node.node_relationships ?? []) {
-    if (!rel.related_entity) continue;
-    // Prefer the KG-resolved label; fall back to the relation CURIE so distinct
-    // unlabeled relations stay distinguishable (same chain for key and title).
-    const key = rel.relation_label || rel.relation || "Related to";
-    const label = key.charAt(0).toUpperCase() + key.slice(1);
-    let group = groups.get(key);
-    if (!group) {
-      group = { label, entities: [] };
-      groups.set(key, group);
-    }
-    group.entities.push(rel.related_entity);
-  }
-  return [...groups.values()];
-});
 /** separate out mappings into categories */
 const clinicalSynopsis = computed(
   () =>


### PR DESCRIPTION
Follow-up fixes from the third automated review pass on #1326. These landed in the working tree after #1327 merged, so they need their own PR.

## Changes

**Backend — `solr_implementation.py`**
- Wrap the RO relation-label lookup in `try/except`: an unresolvable term now degrades to no label (with a warning log) instead of aborting the entire node-relationships block.
- Precise annotation `seen: set[tuple[str, str]]`.
- Comment documenting the benign lock-free race on the process-level `_relation_label_cache` (idempotent, startup-only — not worth a lock).

**Frontend — `SectionNodeRelationships.vue` (new) + `SectionOverview.vue`**
- Extract the duplicated node-relationships template + `relationshipGroups` computed into a shared child component, rendered by both the disease and non-disease node-header branches (net −46 lines in the parent).

## Validation
- Backend: 41 unit tests pass, ruff clean.
- Frontend: `vue-tsc --noEmit` clean, eslint clean.