### PR TITLE
fix(ducksim): dedupe entity-phenotype associations (jaccard/phenodigm 500s)

### DIFF
--- a/backend/src/monarch_py/service/ducksim.py
+++ b/backend/src/monarch_py/service/ducksim.py
@@ -348,7 +348,12 @@ class Ducksim:
                        FROM qterms qt JOIN _clo c ON c.s = qt.q JOIN _ic ic ON ic.term = c.o),
              qsize AS (SELECT q, count(*) AS sz FROM q_anc GROUP BY q),
              nq AS (SELECT count(*) AS n FROM qterms),
-             ent_ph AS (SELECT entity AS e, phenotype AS p FROM _assoc {entity_filter}),
+             -- DISTINCT: an entity may be annotated to the same phenotype via multiple association
+             -- rows (different evidence/sources). Without dedup, p_anc repeats that phenotype's
+             -- ancestors, inflating the count(*) intersection below past the union size -> a zero or
+             -- negative jaccard denominator (inf score; sqrt-of-negative for phenodigm). psize already
+             -- uses count(DISTINCT), so the two must agree.
+             ent_ph AS (SELECT DISTINCT entity AS e, phenotype AS p FROM _assoc {entity_filter}),
              np AS (SELECT e, count(DISTINCT p) AS n FROM ent_ph GROUP BY e),
              p_anc AS (SELECT ep.e, ep.p, c.o AS a FROM ent_ph ep JOIN _clo c ON c.s = ep.p),
              psize AS (SELECT e, p, count(DISTINCT a) AS sz FROM p_anc GROUP BY e, p),

--- a/backend/tests/unit/test_ducksim.py
+++ b/backend/tests/unit/test_ducksim.py
@@ -119,6 +119,28 @@ def test_search_ranking(engine):
     assert [e for e, _ in ranked][:2] == ["E:1", "E:3"]
 
 
+def test_duplicate_associations_dont_inflate_jaccard(tmp_path):
+    """An entity annotated to the same phenotype via multiple association rows (different evidence)
+    must not double-count that phenotype's ancestors: the count(*) intersection would exceed the
+    union, giving a zero/negative jaccard denominator — an inf score (JSON-unserializable -> API 500)
+    and sqrt-of-negative for phenodigm. Regression for the MGI/ZFIN cross-species search 500s."""
+    path = _mini_kg(tmp_path)
+    con = duckdb.connect(path)
+    # E:1 already has has_phenotype A1; add a duplicate association row for the same (E:1, A1).
+    con.execute(
+        "INSERT INTO edges VALUES ('E:1', 'A1', "
+        "'biolink:DiseaseToPhenotypicFeatureAssociation', 'biolink:has_phenotype', NULL)"
+    )
+    con.close()
+    eng = Ducksim.from_duckdb(_bake(path))
+    for metric in ("jaccard_similarity", "phenodigm_score"):
+        scores = [s for _, s in eng.hybrid_search(["A1"], prefix="E", metric=metric)]
+        assert scores, metric
+        assert all(math.isfinite(s) for s in scores), (metric, scores)
+    # de-duped, E:1 (phenotype {A1}) vs query {A1} is still a perfect jaccard match
+    assert dict(eng.hybrid_search(["A1"], prefix="E", metric="jaccard_similarity"))["E:1"] == pytest.approx(1.0)
+
+
 def test_directionality(engine):
     # E:3 phenotypes {A1,B1}, query {A1}; the entity is the subject.
     #   subject_to_object (entity->query): (IC(A1) + 0) / 2 = IC(A1)/2


### PR DESCRIPTION
## Problem

`POST /v3/api/semsim/search` with `metric=jaccard_similarity` or `phenodigm_score` returned **500** for many searches (notably cross-species groups like Mouse/Zebrafish genes):

- jaccard: `ValueError: Out of range float values are not JSON compliant: inf`
- phenodigm: DuckDB `Out of Range Error: cannot take square root of a negative number`

(resnik / `ancestor_information_content` was unaffected.)

## Root cause

An entity can be annotated to the same phenotype via multiple association rows (different evidence/sources), so `_assoc` holds duplicate `(entity, phenotype)` pairs. In `_termset_search`, `p_anc` didn't dedupe them, so each duplicate repeated that phenotype's ancestors. The pairwise **intersection** uses `count(*)`, so it over-counted shared ancestors and exceeded the **union** — driving the jaccard denominator `psize + qsize - inter` to zero (→ `inf`) or negative (→ `sqrt` of a negative for phenodigm). `psize` already uses `count(DISTINCT)`, so the two disagreed.

Example (`MGI:98349`, phenotype `MP:0004210` annotated 3×, query `HP:0001250`): `psize=26`, `qsize=25`, but `inter=51` → denom `0`.

## Fix

`SELECT DISTINCT entity, phenotype` in `ent_ph` so the `count(*)` intersection agrees with the `count(DISTINCT)` sizes. Verified against `monarch-kg.duckdb`: the previously-500ing MGI/ZFIN jaccard/phenodigm searches now return finite scores, and the de-duped results are correct.

## Test

Adds `test_duplicate_associations_dont_inflate_jaccard`: a mini-KG with a duplicate association asserts jaccard/phenodigm search scores are finite. It fails on `main` (inf / sqrt error) and passes with the fix.

https://claude.ai/code/session_01SQpKZ3pcL7JUDeR3wNM3P1