### PR TITLE
test(ducksim): invariant/metamorphic + API-contract tests (red until #1342)

### DIFF
--- a/backend/tests/api/test_semsim_ducksim_api.py
+++ b/backend/tests/api/test_semsim_ducksim_api.py
@@ -1,0 +1,88 @@
+"""API-contract tests for the ducksim search endpoint.
+
+Drives the real FastAPI semsim router with a ducksim backend over a tiny baked KG and asserts every
+metric x directionality returns 200 with a JSON-serializable body. This is the boundary where an
+inf/nan score turns into a 500 (starlette's json.dumps uses allow_nan=False), so it catches the class
+of failure the engine-only tests can miss.
+"""
+
+import duckdb
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+
+from monarch_py.api import semsim as semsim_module
+from monarch_py.api.semsim import router
+from monarch_py.service.ducksim import Ducksim
+from monarch_py.service.ducksim_service import DucksimService
+
+METRICS = ["ancestor_information_content", "jaccard_similarity", "phenodigm_score"]
+DIRECTIONS = ["bidirectional", "subject_to_object", "object_to_subject"]
+
+# MONDO:1 annotated to A1 twice — a duplicate association, to exercise the serialization boundary.
+ASSOC = [("MONDO:1", "A1"), ("MONDO:1", "A1"), ("MONDO:2", "B1"), ("MONDO:3", "A1")]
+
+
+def _baked_kg(path, assoc_rows):
+    con = duckdb.connect(str(path))
+    con.execute("CREATE TABLE closure(subject_id VARCHAR, predicate_id VARCHAR, object_id VARCHAR)")
+    con.executemany(
+        "INSERT INTO closure VALUES (?, 'rdfs:subClassOf', ?)",
+        [("R", "R"), ("A", "A"), ("A", "R"), ("B", "B"), ("B", "R"),
+         ("A1", "A1"), ("A1", "A"), ("A1", "R"), ("B1", "B1"), ("B1", "B"), ("B1", "R")],
+    )
+    con.execute(
+        "CREATE TABLE edges(subject VARCHAR, object VARCHAR, category VARCHAR, predicate VARCHAR, negated VARCHAR)"
+    )
+    con.executemany(
+        "INSERT INTO edges VALUES (?, ?, 'biolink:DiseaseToPhenotypicFeatureAssociation', 'biolink:has_phenotype', NULL)",
+        assoc_rows,
+    )
+    entities = sorted({e for e, _ in assoc_rows})
+    con.execute("CREATE TABLE nodes(id VARCHAR, name VARCHAR, category VARCHAR)")
+    con.executemany(
+        "INSERT INTO nodes VALUES (?, ?, 'biolink:Disease')",
+        [(e, e) for e in entities] + [("A1", "a1"), ("B1", "b1")],
+    )
+    con.execute("""CREATE TABLE information_content AS
+        WITH clo AS (SELECT subject_id AS s, object_id AS o FROM closure WHERE predicate_id='rdfs:subClassOf'),
+             n AS (SELECT count(DISTINCT o) AS nn FROM clo)
+        SELECT o AS term, -log2(count(DISTINCT s)::DOUBLE / (SELECT nn FROM n)) AS ic FROM clo GROUP BY o""")
+    con.execute("""CREATE TABLE closure_size AS
+        SELECT e.subject AS entity, count(DISTINCT c.object_id) AS size
+        FROM edges e JOIN closure c ON c.subject_id = e.object GROUP BY e.subject""")
+    con.close()
+    return Ducksim.from_duckdb(str(path))
+
+
+@pytest.fixture
+def ducksim_client(tmp_path, monkeypatch):
+    service = DucksimService(engine=_baked_kg(tmp_path / "kg.duckdb", ASSOC))
+    # route every semsim_service() call in the router to our in-memory ducksim service
+    monkeypatch.setattr(semsim_module, "semsim_service", lambda engine=None: service)
+    return TestClient(router)
+
+
+@pytest.mark.parametrize("metric", METRICS)
+@pytest.mark.parametrize("directionality", DIRECTIONS)
+def test_post_search_serializes_all_metrics_and_directions(ducksim_client, metric, directionality):
+    response = ducksim_client.post(
+        "/search/",
+        json={
+            "termset": ["A1"],
+            "group": "Human Diseases",
+            "metric": metric,
+            "directionality": directionality,
+            "limit": 5,
+        },
+    )
+    assert response.status_code == status.HTTP_200_OK, response.text
+    body = response.json()  # raises / errors if an inf/nan score reached the response
+    assert isinstance(body, list) and body
+
+
+@pytest.mark.parametrize("metric", METRICS)
+def test_get_search_serializes_all_metrics(ducksim_client, metric):
+    response = ducksim_client.get(f"/search/A1/Human Diseases?metric={metric}&limit=5")
+    assert response.status_code == status.HTTP_200_OK, response.text
+    assert isinstance(response.json(), list)

--- a/backend/tests/unit/test_ducksim_invariants.py
+++ b/backend/tests/unit/test_ducksim_invariants.py
@@ -1,0 +1,98 @@
+"""Invariant / metamorphic tests for the ducksim engine.
+
+Unlike test_ducksim.py (which pins exact scores on one fixed KG), these assert *properties* that
+must hold on any KG — the class of guarantees that catches data-shape bugs the happy-path tests miss
+(e.g. duplicate associations inflating the jaccard intersection into an inf/negative denominator).
+
+Ontology (reflexive subClassOf): A1 < A < R, B1 < B < R.  Entities are MONDO diseases so the same
+KG can drive the API-contract tests.
+"""
+
+import math
+
+import duckdb
+import pytest
+
+from monarch_py.service.ducksim import Ducksim
+
+METRICS = ["ancestor_information_content", "jaccard_similarity", "phenodigm_score"]
+
+# MONDO:1 is annotated to A1 twice — the multi-evidence duplicate that must not be double-counted.
+DUP_ASSOC = [("MONDO:1", "A1"), ("MONDO:1", "A1"), ("MONDO:2", "B1"), ("MONDO:3", "A1")]
+UNIQ_ASSOC = [("MONDO:1", "A1"), ("MONDO:2", "B1"), ("MONDO:3", "A1")]
+
+
+def baked_kg(path, assoc_rows):
+    """Build a tiny baked monarch-kg.duckdb and return a Ducksim over it. `assoc_rows` is a list of
+    (entity, phenotype) has_phenotype edges; duplicates are allowed. IC / closure_size are baked with
+    koza's count(DISTINCT) formulas."""
+    con = duckdb.connect(str(path))
+    con.execute("CREATE TABLE closure(subject_id VARCHAR, predicate_id VARCHAR, object_id VARCHAR)")
+    con.executemany(
+        "INSERT INTO closure VALUES (?, 'rdfs:subClassOf', ?)",
+        [("R", "R"), ("A", "A"), ("A", "R"), ("B", "B"), ("B", "R"),
+         ("A1", "A1"), ("A1", "A"), ("A1", "R"), ("B1", "B1"), ("B1", "B"), ("B1", "R")],
+    )
+    con.execute(
+        "CREATE TABLE edges(subject VARCHAR, object VARCHAR, category VARCHAR, predicate VARCHAR, negated VARCHAR)"
+    )
+    con.executemany(
+        "INSERT INTO edges VALUES (?, ?, 'biolink:DiseaseToPhenotypicFeatureAssociation', 'biolink:has_phenotype', NULL)",
+        assoc_rows,
+    )
+    entities = sorted({e for e, _ in assoc_rows})
+    con.execute("CREATE TABLE nodes(id VARCHAR, name VARCHAR)")
+    con.executemany(
+        "INSERT INTO nodes VALUES (?, ?)",
+        [("A1", "a1"), ("B1", "b1"), ("A", "a"), ("B", "b"), ("R", "root")] + [(e, e) for e in entities],
+    )
+    con.execute("""CREATE TABLE information_content AS
+        WITH clo AS (SELECT object_id AS o FROM closure WHERE predicate_id = 'rdfs:subClassOf'),
+             n AS (SELECT count(DISTINCT o) AS nn FROM clo)
+        SELECT o AS term, -log2(count(DISTINCT s)::DOUBLE / (SELECT nn FROM n)) AS ic
+        FROM (SELECT subject_id AS s, object_id AS o FROM closure WHERE predicate_id='rdfs:subClassOf') GROUP BY o""")
+    con.execute("""CREATE TABLE closure_size AS
+        SELECT e.subject AS entity, count(DISTINCT c.object_id) AS size
+        FROM edges e JOIN closure c ON c.subject_id = e.object GROUP BY e.subject""")
+    con.close()
+    return Ducksim.from_duckdb(str(path))
+
+
+@pytest.mark.parametrize("metric", METRICS)
+def test_search_scores_finite_with_duplicate_associations(tmp_path, metric):
+    """A duplicate (entity, phenotype) association must not produce inf/nan scores (or crash) — the
+    intersection can't exceed the union, so the jaccard denominator stays positive."""
+    eng = baked_kg(tmp_path / "dup.duckdb", DUP_ASSOC)
+    scores = [s for _, s in eng.hybrid_search(["A1"], prefix="MONDO", metric=metric)]
+    assert scores
+    assert all(math.isfinite(s) for s in scores), (metric, scores)
+
+
+def test_duplicate_association_is_idempotent(tmp_path):
+    """Annotating an entity to the same phenotype twice must not change any score vs. once — the
+    association set is a set, not a multiset (metamorphic guard for the count(*) intersection)."""
+    uniq = baked_kg(tmp_path / "uniq.duckdb", UNIQ_ASSOC)
+    dup = baked_kg(tmp_path / "dup.duckdb", DUP_ASSOC)
+    for metric in METRICS:
+        u = dict(uniq.hybrid_search(["A1"], prefix="MONDO", metric=metric))
+        d = dict(dup.hybrid_search(["A1"], prefix="MONDO", metric=metric))
+        assert u.keys() == d.keys(), metric
+        for k in u:
+            assert u[k] == pytest.approx(d[k]), (metric, k, u[k], d[k])
+
+
+@pytest.mark.parametrize("metric", METRICS)
+def test_search_score_bounds(tmp_path, metric):
+    """Every score is finite and non-negative; jaccard additionally lies in [0, 1]."""
+    eng = baked_kg(tmp_path / "kg.duckdb", DUP_ASSOC)
+    for e, s in eng.hybrid_search(["A1"], prefix="MONDO", metric=metric):
+        assert math.isfinite(s) and s >= 0.0, (metric, e, s)
+        if metric == "jaccard_similarity":
+            assert s <= 1.0 + 1e-9, (e, s)
+
+
+def test_self_similarity_is_perfect_jaccard(tmp_path):
+    """A term compared to itself is a perfect jaccard match (invariant independent of the dup bug)."""
+    eng = baked_kg(tmp_path / "kg.duckdb", UNIQ_ASSOC)
+    r = eng.termset_pairwise_similarity(["A1"], ["A1"], metric="jaccard_similarity")
+    assert r["average_score"] == pytest.approx(1.0)


### PR DESCRIPTION
Follow-on to **#1342**. Adds the two highest-ROI test layers we were missing for ducksim — both would have independently caught this week's jaccard/phenodigm 500s.

> ⚠️ **Intentionally red until #1342 merges.** These tests reproduce the duplicate-association bug, so on current `main` the jaccard/phenodigm cases fail (13 failed, 7 passed). Once #1342's `DISTINCT` fix is on `main` and this branch is updated, all 20 pass (verified locally). Merge #1342 first, then rebase/merge main here.

## 1. Engine invariants + metamorphic (`test_ducksim_invariants.py`)
Properties that must hold on *any* KG, not exact scores on one fixed KG:
- all scores finite (no `inf`/`nan`), jaccard ∈ [0,1], resnik ≥ 0
- self-similarity is a perfect jaccard match
- **metamorphic**: duplicating an `(entity, phenotype)` association doesn't change any score (associations are a set, not a multiset)

## 2. API contract / serialization (`test_semsim_ducksim_api.py`)
Drives the real FastAPI search router with a ducksim backend over a tiny baked KG; asserts every `metric × directionality` (GET + POST) returns `200` with a JSON-serializable body. This is the boundary where an `inf` score becomes a `500` (`starlette` uses `allow_nan=False`) — exactly the reported failure.

Both use a self-contained baked mini-KG (`MONDO` diseases, `A1<A<R` / `B1<B<R`) with a duplicate association.

## Follow-ups (from the testing-rigor discussion, not in this PR)
- Golden-file equivalence vs semsimian on a fixed small phenio subset (the actual spec).
- Koza baked-table contract test (guard koza↔ducksim IC drift).
- Property-based (Hypothesis) generation of random ontologies/associations.

https://claude.ai/code/session_01SQpKZ3pcL7JUDeR3wNM3P1