### PR TITLE
feat(grounding): add optional CURIE prefix and biolink category filters

### DIFF
--- a/backend/src/monarch_py/api/additional_models.py
+++ b/backend/src/monarch_py/api/additional_models.py
@@ -4,6 +4,8 @@ from typing import List, Optional
 from fastapi import Query, Request
 from pydantic import BaseModel, Field
 
+from monarch_py.datamodels.category_enums import EntityCategory
+
 
 class PaginationParams(BaseModel):
     request: Request
@@ -78,7 +80,7 @@ class TextAnnotationRequest(BaseModel):
         default=None,
         title="Restrict grounding results to entities using one of these CURIE prefixes (e.g. MONDO, HP)",
     )
-    category: Optional[List[str]] = Field(
+    category: Optional[List[EntityCategory]] = Field(
         default=None,
         title="Restrict grounding results to entities of one of these biolink categories (e.g. biolink:Disease)",
     )

--- a/backend/src/monarch_py/api/additional_models.py
+++ b/backend/src/monarch_py/api/additional_models.py
@@ -74,6 +74,14 @@ class SemsimSearchRequest(BaseModel):
 
 class TextAnnotationRequest(BaseModel):
     content: str = Field(..., title="The text content to annotate")
+    prefix: Optional[List[str]] = Field(
+        default=None,
+        title="Restrict grounding results to entities using one of these CURIE prefixes (e.g. MONDO, HP)",
+    )
+    category: Optional[List[str]] = Field(
+        default=None,
+        title="Restrict grounding results to entities of one of these biolink categories (e.g. biolink:Disease)",
+    )
 
 
 class PathographNode(BaseModel):

--- a/backend/src/monarch_py/api/text_annotation.py
+++ b/backend/src/monarch_py/api/text_annotation.py
@@ -1,8 +1,9 @@
 from fastapi import APIRouter, Query, Response
-from typing import List
+from typing import List, Optional, Union
 
 from monarch_py.api.additional_models import TextAnnotationRequest
 from monarch_py.api.config import solr, spacyner
+from monarch_py.datamodels.category_enums import EntityCategory
 from monarch_py.datamodels.model import Entity, TextAnnotationResult
 
 router = APIRouter(tags=["text_annotation"], responses={404: {"description": "Not Found"}})
@@ -28,13 +29,36 @@ def _post_entities(request: TextAnnotationRequest) -> List[TextAnnotationResult]
     return _entities(request.content)
 
 
-@router.get("/ground")
-def _ground(text: str = Query(default="", title="The text to ground to an entity")) -> List[Entity]:
+def _ground_entity(
+    text: str,
+    prefix: Optional[List[str]] = None,
+    category: Optional[List[str]] = None,
+) -> List[Entity]:
+    """Shared grounding logic for the GET and POST endpoints."""
     if not text.strip():
         return []
-    return solr().ground_entity(text)
+    return solr().ground_entity(text, prefix=prefix, category=category)
+
+
+@router.get("/ground")
+def _ground(
+    text: str = Query(default="", title="The text to ground to an entity"),
+    prefix: Union[List[str], None] = Query(
+        default=None,
+        title="Restrict results to entities using one of these CURIE prefixes (e.g. MONDO, HP)",
+    ),
+    category: Union[List[EntityCategory], None] = Query(
+        default=None,
+        title="Restrict results to entities of one of these biolink categories (e.g. biolink:Disease)",
+    ),
+) -> List[Entity]:
+    return _ground_entity(
+        text,
+        prefix=prefix,
+        category=[c.value for c in category] if category else None,
+    )
 
 
 @router.post("/ground")
 def _post_ground(request: TextAnnotationRequest) -> List[Entity]:
-    return _ground(request.content)
+    return _ground_entity(request.content, prefix=request.prefix, category=request.category)

--- a/backend/src/monarch_py/api/text_annotation.py
+++ b/backend/src/monarch_py/api/text_annotation.py
@@ -61,4 +61,8 @@ def _ground(
 
 @router.post("/ground")
 def _post_ground(request: TextAnnotationRequest) -> List[Entity]:
-    return _ground_entity(request.content, prefix=request.prefix, category=request.category)
+    return _ground_entity(
+        request.content,
+        prefix=request.prefix,
+        category=[c.value for c in request.category] if request.category else None,
+    )

--- a/backend/src/monarch_py/implementations/solr/solr_implementation.py
+++ b/backend/src/monarch_py/implementations/solr/solr_implementation.py
@@ -842,17 +842,26 @@ class SolrImplementation(EntityInterface, AssociationInterface, SearchInterface,
     # Implements: GroundingInterface #
     ##################################
 
-    def ground_entity(self, text: str) -> List[Entity]:
+    def ground_entity(
+        self,
+        text: str,
+        prefix: Optional[List[str]] = None,
+        category: Optional[List[str]] = None,
+    ) -> List[Entity]:
         """Grounds a single entity
 
         Args:
             text (str): Text to ground
+            prefix (List[str], optional): Restrict results to entities whose identifier
+                uses one of these CURIE prefixes (e.g. ["MONDO", "HP"]). Defaults to None.
+            category (List[str], optional): Restrict results to entities of one of these
+                biolink categories (e.g. ["biolink:Disease"]). Defaults to None.
 
         Returns:
             Entity: Dataclass representing a single entity
         """
         solr = SolrService(base_url=self.base_url, core=core.ENTITY)
-        query = build_grounding_query(text)
+        query = build_grounding_query(text, prefix=prefix, category=category)
         query_result = solr.query(query)
         search_result = parse_search(query_result)
         entities = [entity for entity in search_result.items[:3]]

--- a/backend/src/monarch_py/implementations/solr/solr_query_utils.py
+++ b/backend/src/monarch_py/implementations/solr/solr_query_utils.py
@@ -304,7 +304,20 @@ def build_mapping_query(
     return query
 
 
-def build_grounding_query(text: str) -> SolrQuery:
+def build_grounding_query(
+    text: str,
+    prefix: Optional[List[str]] = None,
+    category: Optional[List[str]] = None,
+) -> SolrQuery:
+    """Build the Solr query used to ground free text to an entity.
+
+    Args:
+        text: The text to ground.
+        prefix: Optional list of CURIE prefixes (e.g. ["MONDO", "HP"]) to restrict
+            results to, matched against the entity `namespace` field.
+        category: Optional list of biolink categories (e.g. ["biolink:Disease"]) to
+            restrict results to, matched against the entity `category` field.
+    """
     query = SolrQuery(q=text, rows=10, start=0)
     query.q = f'"{text}"'  # quoting so that the complete text is matched as a unit
     # Prefer keyword/string fields over tokenized fields, and prefer exact_synonym
@@ -316,6 +329,8 @@ def build_grounding_query(text: str) -> SolrQuery:
     )
     query.def_type = "edismax"
     query.boost = obsolete_unboost(multiplier=0.001)
+    query.add_field_filter_query("namespace", prefix)
+    query.add_field_filter_query("category", category)
     return query
 
 

--- a/backend/src/monarch_py/interfaces/grounding_interface.py
+++ b/backend/src/monarch_py/interfaces/grounding_interface.py
@@ -1,5 +1,5 @@
 from abc import ABC
-from typing import List
+from typing import List, Optional
 
 from monarch_py.datamodels.model import Entity
 
@@ -7,12 +7,21 @@ from monarch_py.datamodels.model import Entity
 class GroundingInterface(ABC):
     """Abstract interface for grounding text to entities"""
 
-    def ground_entity(self, text: str) -> List[Entity]:
+    def ground_entity(
+        self,
+        text: str,
+        prefix: Optional[List[str]] = None,
+        category: Optional[List[str]] = None,
+    ) -> List[Entity]:
         """
         Grounds a single entity
 
         Args:
             text (str): Text to ground
+            prefix (List[str], optional): Restrict results to entities whose identifier
+                uses one of these CURIE prefixes (e.g. ["MONDO", "HP"]). Defaults to None.
+            category (List[str], optional): Restrict results to entities of one of these
+                biolink categories (e.g. ["biolink:Disease"]). Defaults to None.
         Returns:
             Entity: Dataclass representing a single entity
         """

--- a/backend/tests/integration/test_ground_endpoint.py
+++ b/backend/tests/integration/test_ground_endpoint.py
@@ -74,3 +74,11 @@ def test_post_ground_accepts_prefix_and_category_filters(client):  # pragma: no 
 def test_get_ground_rejects_invalid_category(client):
     response = client.get("/v3/api/ground", params={"text": "Marfan syndrome", "category": "not-a-category"})
     assert response.status_code == 422
+
+
+def test_post_ground_rejects_invalid_category(client):
+    response = client.post(
+        "/v3/api/ground",
+        json={"content": "Marfan syndrome", "category": ["not-a-category"]},
+    )
+    assert response.status_code == 422

--- a/backend/tests/integration/test_ground_endpoint.py
+++ b/backend/tests/integration/test_ground_endpoint.py
@@ -39,3 +39,38 @@ def test_ground_returns_empty_for_blank_input(client, blank):
     response = client.get("/v3/api/ground", params={"text": blank})
     assert response.status_code == 200
     assert response.json() == []
+
+
+@requires_solr
+def test_get_ground_prefix_filter_restricts_results(client):  # pragma: no cover
+    response = client.get("/v3/api/ground", params={"text": "Marfan syndrome", "prefix": "MONDO"})
+    assert response.status_code == 200
+    results = response.json()
+    assert results
+    assert all(r["id"].startswith("MONDO:") for r in results)
+
+
+@requires_solr
+def test_get_ground_category_filter_restricts_results(client):  # pragma: no cover
+    response = client.get("/v3/api/ground", params={"text": "Marfan syndrome", "category": "biolink:Disease"})
+    assert response.status_code == 200
+    results = response.json()
+    assert results
+    assert all(r["category"] == "biolink:Disease" for r in results)
+
+
+@requires_solr
+def test_post_ground_accepts_prefix_and_category_filters(client):  # pragma: no cover
+    response = client.post(
+        "/v3/api/ground",
+        json={"content": "Marfan syndrome", "prefix": ["MONDO"], "category": ["biolink:Disease"]},
+    )
+    assert response.status_code == 200
+    results = response.json()
+    assert results
+    assert all(r["id"].startswith("MONDO:") and r["category"] == "biolink:Disease" for r in results)
+
+
+def test_get_ground_rejects_invalid_category(client):
+    response = client.get("/v3/api/ground", params={"text": "Marfan syndrome", "category": "not-a-category"})
+    assert response.status_code == 422

--- a/backend/tests/unit/test_solr_queries.py
+++ b/backend/tests/unit/test_solr_queries.py
@@ -9,6 +9,7 @@ from monarch_py.implementations.solr.solr_query_utils import (
     build_association_counts_query,
     build_association_query,
     build_autocomplete_query,
+    build_grounding_query,
     build_histopheno_query,
     build_mapping_query,
     build_search_query,
@@ -79,9 +80,9 @@ def test_build_association_multiple_predicates():
     )
     assert len(query.filter_queries) > 0, "filter_queries is empty"
     predicate_filter = [fq for fq in query.filter_queries if fq.startswith("predicate:")][0]
-    assert predicate_filter == "predicate:biolink\\:has_phenotype OR predicate:biolink\\:expressed_in", (
-        "multiple predicate filter is not as expected"
-    )
+    assert (
+        predicate_filter == "predicate:biolink\\:has_phenotype OR predicate:biolink\\:expressed_in"
+    ), "multiple predicate filter is not as expected"
 
 
 def test_build_association_multiple_entites():
@@ -450,3 +451,35 @@ def test_build_multi_category_row_query_single_row_category_in_list():
     assert "biolink:DiseaseToPhenotypicFeatureAssociation" in fq
     # Single category should still be wrapped in parens (from OR join)
     assert fq == '(category:"biolink:DiseaseToPhenotypicFeatureAssociation")'
+
+
+def test_build_grounding_query_no_filters():
+    """Without prefix/category filters, grounding query carries no filter queries."""
+    query = build_grounding_query("Marfan syndrome")
+    assert query.q == '"Marfan syndrome"'
+    assert query.filter_queries == []
+
+
+def test_build_grounding_query_with_prefix():
+    """A single CURIE prefix is filtered against the entity `namespace` field."""
+    query = build_grounding_query("Marfan syndrome", prefix=["MONDO"])
+    assert "namespace:MONDO" in query.filter_queries
+
+
+def test_build_grounding_query_with_multiple_prefixes():
+    """Multiple prefixes are OR'd within a single namespace filter query."""
+    query = build_grounding_query("kidney disease", prefix=["MONDO", "HP"])
+    assert any("namespace:MONDO" in fq and "namespace:HP" in fq and " OR " in fq for fq in query.filter_queries)
+
+
+def test_build_grounding_query_with_category():
+    """A biolink category is filtered against the entity `category` field (colon escaped)."""
+    query = build_grounding_query("Marfan syndrome", category=["biolink:Disease"])
+    assert r"category:biolink\:Disease" in query.filter_queries
+
+
+def test_build_grounding_query_with_prefix_and_category():
+    """Prefix and category produce two independent filter queries."""
+    query = build_grounding_query("Marfan syndrome", prefix=["MONDO"], category=["biolink:Disease"])
+    assert "namespace:MONDO" in query.filter_queries
+    assert r"category:biolink\:Disease" in query.filter_queries


### PR DESCRIPTION
### Related issues

- Closes #1353

### Summary

- adds an optional, multi-valued `prefix` filter to the `/ground` endpoint (`GET` and `POST`) that restricts results to entities whose identifier uses one of the given CURIE prefixes (e.g. `MONDO`, `HP`), matched against the entity `namespace` field
- adds an optional, multi-valued `category` filter to the `/ground` endpoint that restricts results to one or more biolink categories (e.g. `biolink:Disease`), matched against the entity `category` field — validated on the `GET` path via the same `EntityCategory` enum the `/search` endpoint uses
- threads both filters through `build_grounding_query`, `SolrImplementation.ground_entity`, and the `GroundingInterface` abstract method, all defaulting to `None`
- adds unit tests for query construction (namespace/category filter queries, colon escaping) and endpoint tests for the new params (including a 422 on an invalid category)

Both parameters are optional with a `None` default, so existing callers are unaffected.

### Checks

- [x] All tests have passed (or issues created for failing tests)

<sub>Unit tests for query building and the non-Solr endpoint tests (blank input, invalid-category 422) pass locally; the Solr-dependent grounding assertions are `skipif`-guarded when Solr is unavailable, matching the existing tests in these files.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FaKuHbtndQ7e6TdBWiAGXa)_