### PR TITLE
[bot] Use the semanticsql CDN for the HP semsql download (off raw bbop-sqlite S3)

### DIFF
--- a/backend/src/monarch_py/api/utils/similarity_utils.py
+++ b/backend/src/monarch_py/api/utils/similarity_utils.py
@@ -8,7 +8,7 @@ from fastapi import HTTPException
 from monarch_py.api.additional_models import SemsimSearchGroup
 
 IS_A = omd.slots.subClassOf.curie
-HP_DB_URL = "https://s3.amazonaws.com/bbop-sqlite/hp.db.gz"
+HP_DB_URL = "https://semanticsql.berkeleybop.io/hp.db.gz"
 
 
 def compare_termsets(
@@ -18,7 +18,7 @@ def compare_termsets(
     offset: int = 0,
     limit: int = 20,
 ):
-    hp_db = OAKLIB_MODULE.ensure_gunzip(url=HP_DB_URL, autoclean=False)
+    hp_db = OAKLIB_MODULE.ensure_gunzip(url=HP_DB_URL, autoclean=False, download_kwargs={"backend": "requests", "headers": {"User-Agent": "monarch-app"}})
     oi = SqlImplementation(OntologyResource(slug=hp_db))
     results = oi.termset_pairwise_similarity(subjects, objects, predicates)
     return results


### PR DESCRIPTION
[bot] Opened by a Claude Code agent on behalf of @kltm.

Repoints `HP_DB_URL` from the raw S3 bucket to the edge-cached CDN `https://semanticsql.berkeleybop.io`, and adds a `requests` backend + custom User-Agent to the download.

The UA change is required, not optional: the CDN returns **403** to the default `Python-urllib` User-Agent (Cloudflare Browser Integrity Check), and pystow's default `ensure_gunzip` backend is `urllib`, so the URL swap alone would break the download. Passing `download_kwargs={"backend": "requests", "headers": {"User-Agent": "monarch-app"}}` mirrors what OAK 0.7.2 does. CI should confirm the installed pystow accepts `download_kwargs`.

Part of migrating consumers off raw `bbop-sqlite` access (INCATools/semantic-sql#112, #115).

_— Posted by Claude Code agent on behalf of @kltm._
