### PR TITLE
Make Claude Code Review on-demand instead of auto-firing on every PR/commit

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,22 +1,15 @@
 name: Claude Code Review
 
 on:
+  # Run on-demand only: add the "claude-review" label to a PR to request a review.
+  # This avoids firing automatically on every PR open and every pushed commit.
   pull_request:
-    types: [opened, synchronize]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+    types: [labeled]
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Only run when the "claude-review" label is applied to the PR.
+    if: github.event.label.name == 'claude-review'
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Problem

The **Claude Code Review** workflow (`.github/workflows/claude-code-review.yml`) was triggering on `pull_request: [opened, synchronize]`, meaning it fired automatically on every PR open **and every pushed commit**. This was too noisy.

## Change

Switch the workflow to run **on-demand only**: it now triggers on the `labeled` event and runs only when the `claude-review` label is added to a PR.

```yaml
on:
  pull_request:
    types: [labeled]

jobs:
  claude-review:
    if: github.event.label.name == 'claude-review'
```

To request a review, add the `claude-review` label to the PR. The review no longer fires constantly on every commit.

Note: this leaves the separate `@claude` mention workflow (`claude.yml`) untouched — that one is already on-demand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0191nwLicjTKELDkGHXKX5nU)_