### PR TITLE
fix(pathograph): render for diseases/genes with no phenotype associations

### DIFF
--- a/frontend/src/pages/node/SectionAssociations.vue
+++ b/frontend/src/pages/node/SectionAssociations.vue
@@ -97,21 +97,20 @@
       </template>
     </AppSection>
 
-    <!-- dismech pathograph shown directly under the phenotype table -->
-    <SectionPathograph
-      v-if="
-        category.id === 'biolink:DiseaseToPhenotypicFeatureAssociation' ||
-        category.id === 'biolink:GeneToPhenotypicFeatureAssociation'
-      "
-      :node="node"
-    />
-
     <!-- Case-Phenotype Grid shown after Cases section -->
     <SectionCasePhenotypeGrid
       v-if="category.id === 'biolink:CaseToDiseaseAssociation'"
       :node="node"
     />
   </div>
+
+  <!--
+    dismech pathograph, below all association tables. Rendered once regardless of
+    which association categories exist (a disease/gene can have a pathograph but
+    no Monarch phenotype associations); self-gates to disease/gene and self-hides
+    when there is no pathograph.
+  -->
+  <SectionPathograph :node="node" />
 </template>
 
 <script setup lang="ts">


### PR DESCRIPTION
## Problem

The dismech pathograph did not appear on some disease/gene pages even though the pathograph API returned valid data. Example: **MONDO:0018484** (Semicircular Canal Dehiscence Syndrome) — `GET /v3/api/pathograph/MONDO:0018484` returns a 14-node graph, and the disorder renders on dismech's own site, but the section was missing on Monarch (beta and localhost).

## Root cause

`SectionPathograph` was rendered **inside** the association `v-for` loop in `SectionAssociations.vue`, gated on a `biolink:DiseaseToPhenotypicFeatureAssociation` (or `GeneToPhenotypicFeatureAssociation`) category being present. A disease/gene that has a pathograph but **no Monarch phenotype associations** never produces that category, so the component was never mounted — its own disease/gene gate and 404 self-hide never even ran. MONDO:0018484 has zero associations (`association_counts: []`), so it fell straight through.

## Fix

Move `<SectionPathograph :node="node" />` out of the loop so it renders **once, below all association tables**. It retains its own disease/gene category gate and self-hides on 404, so it now displays whenever pathograph data exists, regardless of association counts.

Trade-off: for a disease that *does* have phenotypes, the pathograph now sits at the bottom of the associations section rather than directly under the phenotype table — a consistent, predictable location for every disease/gene.

## Verification

Ran the frontend locally against the beta API:
- **MONDO:0018484** (no associations): pathograph now renders — caption + all 14 nodes. Previously showed nothing.
- **MONDO:0010200** (Wilson disease, has phenotypes): still renders, now at the bottom of the associations section. No regression.
- No console errors in either case.

https://claude.ai/code/session_01BpftbLFiPqgA1xbiNBNJSW

Closes #1367
