### PR TITLE
feat(associations): subject/object namespace facets in the association browser (#1385)

### DIFF
--- a/frontend/src/components/dashboard/SourceAssociationBrowser.vue
+++ b/frontend/src/components/dashboard/SourceAssociationBrowser.vue
@@ -393,7 +393,9 @@ let searchDebounce: ReturnType<typeof setTimeout> | null = null;
 const facetFields = [
   "category",
   "subject_category",
+  "subject_namespace",
   "object_category",
+  "object_namespace",
   "predicate",
   "subject_taxon_label",
   "object_taxon_label",
@@ -413,7 +415,13 @@ const categoryFacets = computed(() => getFacetValues("category"));
 const subjectCategoryFacets = computed(() =>
   getFacetValues("subject_category"),
 );
+const subjectNamespaceFacets = computed(() =>
+  getFacetValues("subject_namespace"),
+);
 const objectCategoryFacets = computed(() => getFacetValues("object_category"));
+const objectNamespaceFacets = computed(() =>
+  getFacetValues("object_namespace"),
+);
 const predicateFacets = computed(() => getFacetValues("predicate"));
 const subjectTaxonFacets = computed(() =>
   getFacetValues("subject_taxon_label"),
@@ -470,6 +478,12 @@ const facetConfigs = computed<FacetConfig[]>(() => {
       formatter: formatCategory,
     },
     {
+      filterKey: "subjectNamespace",
+      label: "Subject Namespace",
+      values: subjectNamespaceFacets,
+      formatter: identity,
+    },
+    {
       filterKey: "predicate",
       label: "Predicate",
       values: predicateFacets,
@@ -480,6 +494,12 @@ const facetConfigs = computed<FacetConfig[]>(() => {
       label: "Object Category",
       values: objectCategoryFacets,
       formatter: formatCategory,
+    },
+    {
+      filterKey: "objectNamespace",
+      label: "Object Namespace",
+      values: objectNamespaceFacets,
+      formatter: identity,
     },
     {
       filterKey: "subjectTaxonLabel",

--- a/frontend/src/composables/use-source-dashboard.ts
+++ b/frontend/src/composables/use-source-dashboard.ts
@@ -13,7 +13,9 @@ const defaultNumberParam = (defaultValue: number): Param<number> => ({
 export interface SourceFilters {
   category: string;
   subjectCategory: string;
+  subjectNamespace: string;
   objectCategory: string;
+  objectNamespace: string;
   predicate: string;
   subjectTaxonLabel: string;
   objectTaxonLabel: string;
@@ -28,7 +30,9 @@ export interface SourceFilters {
 const filterKeys: (keyof SourceFilters)[] = [
   "category",
   "subjectCategory",
+  "subjectNamespace",
   "objectCategory",
+  "objectNamespace",
   "predicate",
   "subjectTaxonLabel",
   "objectTaxonLabel",
@@ -43,7 +47,9 @@ const filterKeys: (keyof SourceFilters)[] = [
 export const emptyFilters = (): SourceFilters => ({
   category: "",
   subjectCategory: "",
+  subjectNamespace: "",
   objectCategory: "",
+  objectNamespace: "",
   predicate: "",
   subjectTaxonLabel: "",
   objectTaxonLabel: "",
@@ -61,8 +67,12 @@ const buildFilterQueries = (filters: SourceFilters): string[] => {
   if (filters.category) fqs.push(`category:"${filters.category}"`);
   if (filters.subjectCategory)
     fqs.push(`subject_category:"${filters.subjectCategory}"`);
+  if (filters.subjectNamespace)
+    fqs.push(`subject_namespace:"${filters.subjectNamespace}"`);
   if (filters.objectCategory)
     fqs.push(`object_category:"${filters.objectCategory}"`);
+  if (filters.objectNamespace)
+    fqs.push(`object_namespace:"${filters.objectNamespace}"`);
   if (filters.predicate) fqs.push(`predicate:"${filters.predicate}"`);
   if (filters.subjectTaxonLabel)
     fqs.push(`subject_taxon_label:"${filters.subjectTaxonLabel}"`);

--- a/frontend/unit/useSourceDashboard.test.ts
+++ b/frontend/unit/useSourceDashboard.test.ts
@@ -31,7 +31,9 @@ describe("emptyFilters", () => {
     const expectedKeys: (keyof SourceFilters)[] = [
       "category",
       "subjectCategory",
+      "subjectNamespace",
       "objectCategory",
+      "objectNamespace",
       "predicate",
       "subjectTaxonLabel",
       "objectTaxonLabel",
@@ -108,6 +110,16 @@ describe("useAssociationFilters", () => {
     const { filterQueries, setFilter } = useAssociationFilters();
     setFilter("predicate", "biolink:has_phenotype");
     expect(filterQueries.value).toHaveLength(1);
+  });
+
+  it("namespace filters build quoted Solr fq entries", () => {
+    const { filterQueries, setFilter } = useAssociationFilters();
+
+    setFilter("subjectNamespace", "HGNC");
+    setFilter("objectNamespace", "HP");
+
+    expect(filterQueries.value).toContain('subject_namespace:"HGNC"');
+    expect(filterQueries.value).toContain('object_namespace:"HP"');
   });
 
   it("negated filter omits quotes around value", () => {


### PR DESCRIPTION
Closes #1385.

## What

Adds `subject_namespace` and `object_namespace` as facets in both the top-level association browser (`/kg/associations`) and the source-scoped one (`/kg/sources/:infores`), positioned directly after Subject Category and Object Category as the issue asked.

Frontend-only. `GET /association` already accepts free-form `facet_fields` and `filter_queries`, and both fields are indexed on the association core, so nothing on the backend changed.

- `SourceAssociationBrowser.vue` — two entries in `facetFields`, two facet-value computeds, two `facetConfigs` entries. The sidebar, the "Show N more" collapse, and the active-filter pills are all data-driven off `facetConfigs`, so they pick the new facets up for free.
- `use-source-dashboard.ts` — `subjectNamespace`/`objectNamespace` added to the four lists that have to stay in sync (`SourceFilters`, `filterKeys`, `emptyFilters`, `buildFilterQueries`). Being filter keys means they get URL syncing via `useParam` like every other facet, so namespace-filtered views are shareable and survive back/forward.

Values are rendered unformatted (`identity`), since they're already display-ready prefixes like `MGI`, `HGNC`, `HP`.

## Verification

Ran against a local Solr loaded from `monarch-kg-dev/latest` (15.8M associations) with the local API and dev server.

- Facet order on both pages: Association Type, Subject Category, **Subject Namespace**, Predicate, Object Category, **Object Namespace**, Subject Taxon, …
- Clicking Subject Namespace → MGI (facet count 3,497,827) filters the table to exactly 3,497,827 associations, sets `?subjectNamespace=MGI`, and adds a removable "Subject Namespace: MGI" pill.
- `bun run test:unit` 303 passed, `test:types` clean, `test:lint` 0 errors.

Added a `useSourceDashboard` case asserting the two new filters build quoted Solr fq entries, and updated the `emptyFilters` key-list assertion.