### PR TITLE
Fix pathograph term chips: anchor on real CURIE, stop hardcoding HP:

### DIFF
--- a/backend/src/monarch_py/api/pathograph.py
+++ b/backend/src/monarch_py/api/pathograph.py
@@ -88,20 +88,39 @@ async def _load_index(client: httpx.AsyncClient, name: str) -> dict:
     return data
 
 
+def _normalize_curie(curie: str) -> str:
+    """Return a CURIE with an uppercased *prefix*, local id untouched.
+
+    e.g. ``hgnc:1956`` -> ``HGNC:1956``; ``MONDO:0100471`` -> ``MONDO:0100471``.
+    Only the prefix is uppercased, so a local id containing letters (e.g.
+    ``ensembl:ENSG00000...``) is not corrupted. A string without a ``:`` is
+    returned unchanged.
+    """
+    prefix, sep, local = curie.partition(":")
+    if not sep:
+        return curie
+    return f"{prefix.upper()}:{local}"
+
+
 def _anchor_id(node: dict[str, Any]) -> str | None:
     """Stable cross-disorder id for nodes that should be boxed when merging.
 
-    Phenotypes box on their HP term id; single-gene genetic nodes box on the
-    HGNC id. Everything else (free-text mechanism nodes) stays disorder-local.
+    Phenotypes box on their term id (any ontology - HP, MONDO, CHEBI, ...);
+    single-gene genetic nodes box on the HGNC id. Everything else (free-text
+    mechanism nodes) stays disorder-local. The anchor is the node's *real*
+    CURIE - never a prefix-forced one - so it (a) resolves to the right Monarch
+    entity and (b) does not collide across ontologies that share a local id
+    (e.g. HP:0001250 vs MONDO:0001250).
     """
     meta = node.get("meta") or {}
-    if node.get("node_type") == "phenotype" and meta.get("term_id"):
-        return f"HP:{str(meta['term_id']).split(':')[-1]}"
+    term_id = meta.get("term_id")
+    if node.get("node_type") == "phenotype" and term_id and ":" in str(term_id):
+        return _normalize_curie(str(term_id))
     gene_ids = [gt["id"] for gt in (meta.get("gene_terms") or []) if gt.get("id")]
     # Anchor single-gene nodes on the real HGNC curie (e.g. "hgnc:1956" ->
     # "HGNC:1956") so the id is a resolvable Monarch entity, not a pseudo-curie.
     if node.get("node_type") == "genetic" and len(gene_ids) == 1 and gene_ids[0].lower().startswith("hgnc:"):
-        return gene_ids[0].upper()
+        return _normalize_curie(gene_ids[0])
     return None
 
 

--- a/backend/tests/unit/test_pathograph_api.py
+++ b/backend/tests/unit/test_pathograph_api.py
@@ -137,3 +137,43 @@ def test_malformed_artifact_json_returns_502(client, artifact_dir):
     (artifact_dir / "index.json").write_text("{not valid json")
     r = client.get("/v3/api/pathograph/MONDO:0000001")
     assert r.status_code == 502
+
+
+def test_normalize_curie_uppercases_only_prefix():
+    assert route._normalize_curie("hgnc:111") == "HGNC:111"
+    assert route._normalize_curie("MONDO:0100471") == "MONDO:0100471"
+    # local id containing letters must not be corrupted
+    assert route._normalize_curie("ensembl:ENSG001") == "ENSEMBL:ENSG001"
+    assert route._normalize_curie("nocolon") == "nocolon"
+
+
+def test_anchor_id_preserves_non_hp_phenotype_curie():
+    # A phenotype carrying a MONDO term_id must anchor on that real curie, not a
+    # prefix-forced "HP:0100471".
+    node = {"node_type": "phenotype", "meta": {"term_id": "MONDO:0100471"}}
+    assert route._anchor_id(node) == "MONDO:0100471"
+
+
+def test_anchor_id_no_cross_ontology_collision():
+    # HP:0001250 and MONDO:0001250 share a local id but must not collide.
+    hp = {"node_type": "phenotype", "meta": {"term_id": "HP:0001250"}}
+    mondo = {"node_type": "phenotype", "meta": {"term_id": "MONDO:0001250"}}
+    assert route._anchor_id(hp) == "HP:0001250"
+    assert route._anchor_id(mondo) == "MONDO:0001250"
+    assert route._anchor_id(hp) != route._anchor_id(mondo)
+
+
+def test_non_hp_phenotypes_with_shared_local_id_do_not_merge(client, artifact_dir, monkeypatch):
+    # Disorder A has an HP phenotype, B has a MONDO phenotype with the SAME local
+    # id; anchor-merged via a shared gene they must remain two separate nodes.
+    disorder_a = json.loads(json.dumps(DISORDER_A))
+    disorder_b = json.loads(json.dumps(DISORDER_B))
+    disorder_b["nodes"][2]["meta"]["term_id"] = "MONDO:0001250"
+    (artifact_dir / "MONDO_0000001.json").write_text(json.dumps(disorder_a))
+    (artifact_dir / "MONDO_0000002.json").write_text(json.dumps(disorder_b))
+    route._index_cache.clear()
+
+    body = client.get("/v3/api/pathograph/HGNC:111").json()
+    ids = {n["id"] for n in body["nodes"]}
+    assert "HP:0001250" in ids
+    assert "MONDO:0001250" in ids  # distinct anchor, not folded into HP:0001250

--- a/frontend/src/pages/node/SectionPathograph.vue
+++ b/frontend/src/pages/node/SectionPathograph.vue
@@ -319,22 +319,32 @@ type LaidOutNode = PathographNode & {
 
 type Point = { x: number; y: number };
 
+/** A well-formed single CURIE (one colon, no whitespace) - excludes the
+ * `<mondo>::<name>` disorder-local pseudo-ids and bare free-text node ids. */
+const isCurie = (value: unknown): value is string =>
+  typeof value === "string" && /^[^:\s]+:[^:\s]+$/.test(value);
+
+/** Uppercase only the prefix so Monarch routes resolve (e.g. `hgnc:1956` ->
+ * `HGNC:1956`) without corrupting a local id that contains letters. */
+const normalizeCurie = (curie: string): string => {
+  const [prefix, local] = curie.split(":");
+  return `${prefix.toUpperCase()}:${local}`;
+};
+
 /**
- * The ontology id + Monarch route for nodes that are themselves a term: HP
- * phenotypes and HGNC genes (from the merged anchor id), or any node carrying a
- * meta.term_id (e.g. biochemical CHEBI terms).
+ * The ontology id + Monarch route for nodes that are themselves a term: any
+ * node carrying a real term CURIE (HP phenotype, MONDO disease-like phenotype,
+ * CHEBI biomarker, HGNC gene, …). Prefer the authoritative `meta.term_id`, then
+ * fall back to the merged anchor `node.id` when it is itself a CURIE.
  */
 const nodeEntity = (
   node: PathographNode,
 ): { entityId?: string; link?: string } => {
-  // Phenotype and single-gene nodes are anchored on their real curie (HP:…,
-  // HGNC:…), so they resolve directly to a Monarch node route.
-  if (node.id.startsWith("HP:") || node.id.startsWith("HGNC:"))
-    return { entityId: node.id, link: `/${node.id}` };
   const termId = (node.meta as Record<string, unknown> | undefined)?.term_id;
-  if (typeof termId === "string" && termId.includes(":"))
-    return { entityId: termId, link: `/${termId}` };
-  return {};
+  const raw = isCurie(termId) ? termId : isCurie(node.id) ? node.id : undefined;
+  if (!raw) return {};
+  const curie = normalizeCurie(raw);
+  return { entityId: curie, link: `/${curie}` };
 };
 
 /** smooth an edge polyline through its bend points with quadratic curves */

--- a/frontend/src/pages/node/SectionPathograph.vue
+++ b/frontend/src/pages/node/SectionPathograph.vue
@@ -319,13 +319,17 @@ type LaidOutNode = PathographNode & {
 
 type Point = { x: number; y: number };
 
-/** A well-formed single CURIE (one colon, no whitespace) - excludes the
- * `<mondo>::<name>` disorder-local pseudo-ids and bare free-text node ids. */
+/**
+ * A well-formed single CURIE (one colon, no whitespace) - excludes the
+ * `<mondo>::<name>` disorder-local pseudo-ids and bare free-text node ids.
+ */
 const isCurie = (value: unknown): value is string =>
   typeof value === "string" && /^[^:\s]+:[^:\s]+$/.test(value);
 
-/** Uppercase only the prefix so Monarch routes resolve (e.g. `hgnc:1956` ->
- * `HGNC:1956`) without corrupting a local id that contains letters. */
+/**
+ * Uppercase only the prefix so Monarch routes resolve (e.g. `hgnc:1956` ->
+ * `HGNC:1956`) without corrupting a local id that contains letters.
+ */
 const normalizeCurie = (curie: string): string => {
   const [prefix, local] = curie.split(":");
   return `${prefix.toUpperCase()}:${local}`;


### PR DESCRIPTION
### Related issues

- Closes #1388

### Summary

The pathograph anchored every phenotype node on a **prefix-forced** HP curie (`backend/src/monarch_py/api/pathograph.py::_anchor_id`):
```python
return f"HP:{str(meta['term_id']).split(':')[-1]}"
```
Now that dismech emits non-HP `term_id`s on phenotype nodes (e.g. `MONDO:0100471` for a disease-like phenotype — see companion [dismech#8453](https://github.com/monarch-initiative/dismech/pull/8453)), this broke two ways: it linked the **wrong entity** (`MONDO:0100471` → `HP:0100471`), and it **silently collided on merge** (a phenotype `HP:0001250` in one disorder and `MONDO:0001250` in another share anchor `HP:0001250` and fold into one node).

- **fixes** backend `_anchor_id` to anchor on the node's **real CURIE** via a new `_normalize_curie` helper that uppercases only the *prefix* (`hgnc:1956` → `HGNC:1956`) and leaves the local id untouched (so `ensembl:ENSG…` isn't corrupted) — resolving both the wrong-curie and the cross-ontology merge-collision cases.
- **changes** frontend `nodeEntity` (`SectionPathograph.vue`) to prefer the authoritative `meta.term_id` over the merged `node.id`, fall back to `node.id` only when it is itself a well-formed CURIE (excludes the `<mondo>::<name>` pseudo-ids), and normalize prefix casing before building the route (fixes lowercase `hgnc:` routes).
- **adds** unit coverage for a non-HP phenotype `term_id`, the cross-ontology same-local-id collision, and prefix-case normalization.

Findings 4/5 in #1388 (non-HGNC gene anchoring; merging shared biochemical/treatment entities) are left as documented follow-ups.

### Checks

- [ ] All tests have passed (or issues created for failing tests) — new/changed backend functions verified against the real module locally; full backend suite (`uvicorn`/`httpx` API deps) and frontend build to be validated by CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_017Q7prymcaohpnB6EXWa2wr)_