### PR TITLE
Add gunicorn --max-requests worker recycling (#1379)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -41,6 +41,9 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 FROM builder-base AS production
 ENV SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL=True
 # ENV UVICORN_WORKERS=8
+# ENV WORKER_TIMEOUT=300
+# ENV MAX_REQUESTS=2000
+# ENV MAX_REQUESTS_JITTER=200
 WORKDIR /opt/monarch-app/backend
 
 RUN ls -l . && \

--- a/backend/start_api.sh
+++ b/backend/start_api.sh
@@ -8,4 +8,6 @@ uv run gunicorn src.monarch_py.api.main:app \
     --bind 0.0.0.0:8000 \
     --timeout ${WORKER_TIMEOUT:-300} \
     --worker-class uvicorn.workers.UvicornWorker \
-    --workers ${UVICORN_WORKERS}
+    --workers ${UVICORN_WORKERS} \
+    --max-requests ${MAX_REQUESTS:-2000} \
+    --max-requests-jitter ${MAX_REQUESTS_JITTER:-200}


### PR DESCRIPTION
Closes #1379.

## Summary
API worker processes accumulate private anonymous heap over their lifetime and never give it back. Because `start_api.sh` ran gunicorn without `--max-requests`, workers lived for the container's lifetime, making that growth permanent until redeploy. This adds request-bounded worker recycling to bound the growth by construction.

## Change
`backend/start_api.sh` now passes, parameterized via env vars so they're tunable without an image rebuild:

```bash
--max-requests ${MAX_REQUESTS:-2000} \
--max-requests-jitter ${MAX_REQUESTS_JITTER:-200}
```

Jitter prevents every worker hitting the limit simultaneously and recycling together.

## Verification
Confirmed the flag is wired through `UvicornWorker` in the versions installed in this repo (not a no-op):
- `gunicorn/workers/base.py` computes `self.max_requests = cfg.max_requests + jitter` per worker.
- `uvicorn/workers.py:50` forwards it as uvicorn's `limit_max_requests`.

So uvicorn shuts the worker down after N requests and the gunicorn arbiter starts a replacement. Recycling is graceful — in-flight requests finish before the worker exits — so with 8 workers, one recycling at a time is invisible to clients.

## Scope
This bounds the symptom. The underlying native heap growth in the API request path (Solr querying, association hydration, entity/TSV serialization) still wants a native heap profiler and is left as separate follow-up work, as described in the issue.

https://claude.ai/code/session_01PtdSMoF7DCKT1eEaktNYy9