### PR TITLE
Give each DuckDB worker its own spill directory

### DIFF
--- a/backend/src/monarch_py/service/ducksim.py
+++ b/backend/src/monarch_py/service/ducksim.py
@@ -17,13 +17,71 @@ shared ancestors; Phenodigm = sqrt(Resnik·Jaccard); termset score = bidirection
 
 from __future__ import annotations
 
+import atexit
+import errno
 import math
+import os
+import re
+import shutil
+import tempfile
+from pathlib import Path
 from statistics import mean
 from typing import NamedTuple
 
 import duckdb
 
 DEFAULT_PREDICATES = ("rdfs:subClassOf",)
+
+# DuckDB spills to `temp_directory` when a query exceeds `memory_limit`, which is expected
+# under load. Its default is the *relative* path ".tmp", and its spill filenames are keyed by
+# allocation-size class rather than by process — duckdb_temp_storage_S64K-0.tmp and friends.
+# Every gunicorn worker shares a working directory, so without an explicit setting all of them
+# write to the same handful of files and corrupt each other's spills the moment two spill at
+# once. Give each process its own absolute directory instead.
+_TEMP_ROOT_ENV = "DUCKSIM_TEMP_ROOT"
+_WORKER_DIR_PREFIX = "worker-"
+_WORKER_DIR_RE = re.compile(rf"^{_WORKER_DIR_PREFIX}(\d+)-")
+
+
+def _process_alive(pid: int) -> bool:
+    """Whether `pid` is still running. A live process we don't own raises EPERM, not ESRCH."""
+    try:
+        os.kill(pid, 0)
+    except OSError as exc:
+        return exc.errno == errno.EPERM
+    return True
+
+
+def _sweep_abandoned(root: Path) -> None:
+    """Remove spill directories whose owning worker is gone.
+
+    Workers are recycled frequently (gunicorn --max-requests), and atexit does not run on
+    SIGKILL or OOM-kill, so cleanup cannot rely on the owner tidying up after itself. Sweeping
+    on the way in keeps the root from accumulating a directory per recycled worker, and clears
+    the orphaned spill files a previous crash left behind.
+    """
+    for child in root.iterdir():
+        match = _WORKER_DIR_RE.match(child.name)
+        if not match or not child.is_dir():
+            continue
+        if not _process_alive(int(match.group(1))):
+            shutil.rmtree(child, ignore_errors=True)
+
+
+def worker_temp_directory() -> str:
+    """An absolute, per-process directory for DuckDB to spill into."""
+    root = Path(os.getenv(_TEMP_ROOT_ENV) or Path(tempfile.gettempdir()) / "monarch-ducksim")
+    root.mkdir(parents=True, exist_ok=True)
+    try:
+        _sweep_abandoned(root)
+    except OSError:
+        # Cleanup is best-effort: a sweep failure must not stop this worker from starting.
+        pass
+    # mkdtemp rather than a bare pid path, so a recycled worker that reuses a pid cannot land
+    # on a directory the sweep has not reached yet. The pid stays in the name for the sweep.
+    path = tempfile.mkdtemp(prefix=f"{_WORKER_DIR_PREFIX}{os.getpid()}-", dir=root)
+    atexit.register(shutil.rmtree, path, True)
+    return path
 
 
 class _Metric(NamedTuple):
@@ -106,6 +164,9 @@ class Ducksim:
         safe_path = str(path).replace("'", "''")
         con.execute(f"SET memory_limit = '{safe_mem}'")
         con.execute(f"SET threads = {int(threads)}")
+        # Spills go to a directory owned by this process alone; see worker_temp_directory.
+        safe_tmp = worker_temp_directory().replace("'", "''")
+        con.execute(f"SET temp_directory = '{safe_tmp}'")
         con.execute(f"ATTACH '{safe_path}' AS src (READ_ONLY)")
         self = cls(con)
         self._define_closure(

--- a/backend/tests/unit/test_ducksim_temp_directory.py
+++ b/backend/tests/unit/test_ducksim_temp_directory.py
@@ -1,0 +1,86 @@
+"""Each worker gets its own DuckDB spill directory (#1421).
+
+DuckDB spills to `temp_directory` when a query exceeds `memory_limit`, which is correct
+behaviour under load. The bug was *where* it spilled: the default is the relative path
+".tmp", and spill filenames are keyed by allocation-size class rather than by process, so
+every gunicorn worker resolved the same handful of paths from a shared working directory
+and corrupted each other's spills.
+"""
+
+import os
+from pathlib import Path
+
+import duckdb
+import pytest
+
+from monarch_py.service.ducksim import Ducksim, worker_temp_directory
+
+
+@pytest.fixture()
+def temp_root(tmp_path, monkeypatch):
+    monkeypatch.setenv("DUCKSIM_TEMP_ROOT", str(tmp_path / "root"))
+    return tmp_path / "root"
+
+
+def test_directory_is_absolute(temp_root):
+    """A relative path resolves against the working directory, which every worker shares."""
+    assert Path(worker_temp_directory()).is_absolute()
+
+
+def test_each_call_gets_its_own_directory(temp_root):
+    assert worker_temp_directory() != worker_temp_directory()
+
+
+def test_directory_is_named_for_the_owning_process(temp_root):
+    """The pid in the name is what lets the sweep identify directories to reclaim."""
+    assert Path(worker_temp_directory()).name.startswith(f"worker-{os.getpid()}-")
+
+
+def test_sweep_reclaims_directories_whose_worker_is_gone(temp_root):
+    """Workers are recycled by gunicorn --max-requests, and atexit does not run on SIGKILL,
+    so without a sweep the root accumulates a directory per recycled worker."""
+    temp_root.mkdir(parents=True, exist_ok=True)
+    dead = temp_root / "worker-999999-abandoned"
+    dead.mkdir()
+    (dead / "duckdb_temp_storage_S64K-0.tmp").write_bytes(b"orphaned spill")
+
+    worker_temp_directory()
+
+    assert not dead.exists()
+
+
+def test_sweep_leaves_live_workers_alone(temp_root):
+    """Sweeping a running worker's directory would cause exactly the corruption this fixes."""
+    live = worker_temp_directory()
+    (Path(live) / "duckdb_temp_storage_S64K-0.tmp").write_bytes(b"in use")
+
+    worker_temp_directory()
+
+    assert Path(live, "duckdb_temp_storage_S64K-0.tmp").exists()
+
+
+def test_sweep_ignores_unrelated_directories(temp_root):
+    temp_root.mkdir(parents=True, exist_ok=True)
+    bystander = temp_root / "not-a-worker-dir"
+    bystander.mkdir()
+
+    worker_temp_directory()
+
+    assert bystander.exists()
+
+
+def test_from_duckdb_points_duckdb_at_the_per_worker_directory(temp_root, tmp_path):
+    """The setting has to reach the connection; a spill that lands in '.tmp' is the bug."""
+    source = tmp_path / "src.duckdb"
+    con = duckdb.connect(str(source))
+    con.execute("CREATE TABLE closure AS SELECT 'a' AS subject_id, 'rdfs:subClassOf' AS predicate_id, 'b' AS object_id")
+    con.execute("CREATE TABLE information_content AS SELECT 'a' AS term, 1.0 AS ic")
+    con.execute("CREATE TABLE closure_size AS SELECT 'a' AS entity, 1 AS size")
+    con.close()
+
+    sim = Ducksim.from_duckdb(source, associations=None)
+    configured = sim.con.execute("SELECT current_setting('temp_directory')").fetchone()[0]
+
+    assert Path(configured).is_absolute()
+    assert Path(configured).parent == temp_root
+    assert configured != ".tmp"


### PR DESCRIPTION
Closes #1421.

`temp_directory` was never set, so DuckDB used its default of the **relative** path `.tmp`. Spill filenames are keyed by allocation-size class rather than by process, and every gunicorn worker resolves `.tmp` against the same working directory — so eight workers wrote to the same handful of files and corrupted each other's spills whenever two spilled at once.

To be clear about what the bug is: spilling is correct behaviour. Queries exceeded the per-worker `DUCKSIM_MEMORY_LIMIT` under concurrency and DuckDB did what it should. The bug is *where* it spilled.

## Reproduced, then fixed

Six concurrent spilling processes against the same workload:

| | result |
|---|---|
| shared temp directory (production's effective behaviour) | `IOException: Could not read enough bytes from file …` — the same error as the incident — plus a nonsensical `4.0 GiB/190.7 MiB used` OOM, from workers reading each other's spill headers |
| per-worker temp directory | **6/6 succeeded** |

I also confirmed the spill files that appear are exactly the ones from the incident report — `duckdb_temp_storage_DEFAULT-0.tmp`, `S64K`, `S128K` — and that they now land in the per-worker directory with no stray `.tmp` in the working directory.

## The fix

`worker_temp_directory()` gives each process an absolute directory of its own, and `from_duckdb` points the connection at it. Absolute rather than relative, so behaviour no longer depends on the working directory. `lru_cache(maxsize=1)` on `ducksim()` means one directory per worker, not one per request.

**Cleanup has to survive workers that never run `atexit`.** Gunicorn recycles them via `--max-requests` (#1379), and SIGKILL/OOM-kill skips it entirely — which is how the 358 MB of orphaned spill files ended up on the container's writable layer. So each worker also sweeps directories whose owning pid is gone on the way in. That handles both the recycling accumulation the issue flagged and the orphaned-files problem, without needing an external cleanup job.

`mkdtemp` rather than a bare pid path, so a recycled worker that reuses a pid cannot land on a directory the sweep hasn't reached yet; the pid stays in the directory name for the sweep to read. Root is overridable with `DUCKSIM_TEMP_ROOT`.

## Tests

Seven unit tests covering: the path is absolute, each call gets its own directory, the name carries the owning pid, the sweep reclaims dead workers' directories, **the sweep leaves live workers alone** (sweeping a running worker's directory would cause exactly the corruption this fixes), unrelated directories are ignored, and `from_duckdb` actually points the connection at the per-worker path rather than `.tmp`.

599 passed / 16 skipped backend.

## Note

This is independent of the 2026-09-02 KG release — it's a concurrency fix, not a KG-compatibility one — so it can go in on its own schedule. Given the failure mode only appears under load, though, shipping it before the next traffic burst seems worthwhile.

https://claude.ai/code/session_01N6fjfGqaFpyjepw23qCyLv
